### PR TITLE
feat: add Cove dishwasher support + fast reconnect + optimized timing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 !.gitignore
 !README.adoc
 !subzero.yaml
+!cove-minimal-dishwasher.yaml
 !subzero_appliance.yaml

--- a/README.adoc
+++ b/README.adoc
@@ -15,6 +15,8 @@ This project reverse-engineers that BLE protocol and reimplements the connection
 
 === What You Get
 
+==== Refrigerator/Freezer Sensors
+
 [cols="1,3"]
 |===
 | Sensor | Description
@@ -24,21 +26,46 @@ This project reverse-engineers that BLE protocol and reimplements the connection
 | *Refrigerator Door* | Open/closed binary sensor
 | *Freezer Door* | Open/closed binary sensor _(optional)_
 | *Ice Maker* | On/off binary sensor _(optional)_
-| *Sabbath Mode* | On/off binary sensor
+| *Sabbath Mode* | On/off binary sensor _(optional)_
 | *Service Required* | Alerts when the appliance flags a service need
 | *Appliance Model* | Model number (e.g. `DEU2450R`, `313`)
 | *Appliance Uptime* | Time since last power cycle
 | *Raw JSON* | Full JSON response for debugging
 |===
 
+==== Dishwasher Sensors
+
+[cols="1,3"]
+|===
+| Sensor | Description
+
+| *Door* | Open/closed binary sensor
+| *Wash Cycle Active* | Whether a wash cycle is currently running
+| *Wash Status* | Numeric wash status code
+| *Wash Cycle* | Current wash cycle number
+| *Heated Dry* | Heated dry option enabled
+| *Extended Dry* | Extended dry option enabled
+| *High Temp Wash* | High temperature wash option enabled
+| *Sanitize Rinse* | Sanitize rinse option enabled
+| *Rinse Aid Low* | Rinse aid level is low (problem sensor)
+| *Light* | Interior light on/off
+| *Remote Ready* | Appliance is ready for remote commands
+| *Delay Start* | Delay start timer is active
+| *Service Required* | Alerts when the appliance flags a service need
+| *Appliance Model* | Model number (e.g. `DW2450`)
+| *Appliance Uptime* | Time since last power cycle
+| *Raw JSON* | Full JSON response for debugging
+|===
+
 === Tested Appliances
 
-[cols="1,1,1"]
+[cols="1,1,1,1"]
 |===
-| Model | Type | Status
+| Brand | Model | Type | Status
 
-| DEU2450R | Under-counter refrigerator | ✅ Fully working
-| 313 | French-door fridge/freezer with ice maker | ✅ Fully working
+| Sub-Zero | DEU2450R | Under-counter refrigerator | ✅ Fully working
+| Sub-Zero | 313 | French-door fridge/freezer with ice maker | ✅ Fully working
+| Cove | DW2450 | Dishwasher | ✅ Fully working
 |===
 
 Other Sub-Zero, Wolf, and Cove appliances with BLE should work — they all use the same protocol.
@@ -115,13 +142,15 @@ After the first successful bond, the keys are stored and reconnection is automat
 Command Framing:: Every command written to D5 *must* end with a newline character (`\n`).
 The appliance's serial parser silently discards any command without it.
 
-Response Fragmentation:: The appliance sends JSON responses as BLE indications, fragmented into chunks of approximately 40 bytes each.
-A full `get_async` response can be 1200–1800 bytes depending on the appliance model, arriving as 30–45 consecutive indications.
+Response Fragmentation:: The appliance sends JSON responses as BLE indications, fragmented into chunks.
+Fridges typically fragment at ~40 bytes per indication (30–45 fragments for a 1200–1800 byte response), while dishwashers use larger ~244 byte fragments (8 fragments for a ~1736 byte response).
 The receiver must buffer and reassemble these fragments by tracking JSON brace depth (`{` / `}`) to detect message completion.
 
-D5 Discovery Timing:: The encrypted D5 characteristic is *not visible* in the GATT database until after bonding completes.
+D5 Discovery Timing:: On refrigerators, the encrypted D5 characteristic is *not visible* in the GATT database until after bonding completes.
 The implementation must refresh the GATT cache (`esp_ble_gattc_cache_refresh`) and re-run service discovery after encryption is established.
 The code polls up to three times with delays to handle timing variations across different appliance models.
++
+NOTE: Cove dishwashers expose D5 in the GATT database *before* bonding, but still require BLE-level encryption for writes (GATT status 5 = insufficient authentication without it). The code always requests encryption regardless of when D5 is discovered.
 
 MTU:: Negotiated to 517 bytes, though the appliance still fragments at ~40 bytes per indication.
 
@@ -191,7 +220,37 @@ All commands are JSON objects written to D5, terminated with `\n`.
 ----
 ====
 
-Different appliance types include different properties. Refrigerator-only units won't have `frz_*` or `ice_maker_*` keys. This can be made optional in the ESPHome config with the `*_internal` flags.
+.Cove dishwasher (DW2450) — ~1736 bytes
+[%collapsible]
+====
+[source,json]
+----
+{
+  "status": 0,
+  "resp": {
+    "appliance_model": "DW2450",
+    "appliance_serial": "33333333",
+    "uptime": "05:12:30",
+    "door_ajar": false,
+    "wash_cycle_on": false,
+    "wash_status": 6,
+    "wash_cycle": 0,
+    "heated_dry_on": false,
+    "extended_dry_on": false,
+    "high_temp_wash_on": false,
+    "sani_rinse_on": false,
+    "rinse_aid_low": false,
+    "light_on": false,
+    "remote_ready": true,
+    "delay_start_timer_active": false,
+    "service_required": false,
+    "notifs": []
+  }
+}
+----
+====
+
+Different appliance types include different properties. Refrigerator-only units won't have `frz_*` or `ice_maker_*` keys, and dishwashers use `door_ajar` instead of `ref_door_ajar` and have wash-specific properties. Sensor visibility is controlled per-appliance with `*_internal` substitution flags.
 
 [[getting-started]]
 == Getting Started
@@ -277,11 +336,61 @@ packages:
       appliance_pin: !secret main_fridge_pin
       freezer_sensors_internal: "false"       # <1>
       ice_maker_sensor_internal: "false"      # <2>
+      sabbath_sensor_internal: "false"        # <3>
 ----
 <1> Exposes freezer temperature and freezer door sensors
 <2> Exposes ice maker on/off sensor
+<3> Exposes Sabbath Mode sensor (hidden by default)
 
-By default these sensors are hidden (`internal: true`) since not all appliances have them.
+By default, freezer, ice maker, Sabbath, and dishwasher sensors are hidden (`internal: true`) since not all appliances have them.
+Fridge sensors (Set Temperature) are visible by default.
+
+==== Cove Dishwashers
+
+For Cove dishwashers, enable dishwasher sensors and hide fridge-only sensors:
+
+[source,yaml]
+----
+packages:
+  dishwasher: !include
+    file: subzero_appliance.yaml
+    vars:
+      prefix: "szg"
+      appliance_name: "Dishwasher"
+      appliance_mac: !secret dishwasher_mac
+      appliance_pin: !secret dishwasher_pin
+      dishwasher_sensors_internal: "false"    # <1>
+      fridge_sensors_internal: "true"         # <2>
+      freezer_sensors_internal: "true"        # <3>
+      ice_maker_sensor_internal: "true"       # <4>
+      sabbath_sensor_internal: "true"         # <5>
+----
+<1> Exposes all dishwasher-specific sensors (wash cycle, heated dry, etc.)
+<2> Hides fridge-only sensors (Set Temperature)
+<3> Hides freezer sensors
+<4> Hides ice maker sensor
+<5> Hides Sabbath Mode sensor
+
+See `cove-minimal-dishwasher.yaml` for a complete standalone example.
+
+NOTE: Cove dishwashers actively disconnect BLE ~10 seconds after connection. The integration handles this with optimized handshake timing and a fast reconnect path that caches GATT handles between connections.
+
+==== Sensor Visibility Reference
+
+All sensor groups can be shown or hidden per-appliance using substitution variables:
+
+[cols="2,1,2"]
+|===
+| Substitution | Default | Controls
+
+| `fridge_sensors_internal` | `"false"` | Set Temperature
+| `freezer_sensors_internal` | `"true"` | Freezer Temperature, Freezer Door
+| `ice_maker_sensor_internal` | `"true"` | Ice Maker
+| `sabbath_sensor_internal` | `"true"` | Sabbath Mode
+| `dishwasher_sensors_internal` | `"true"` | All dishwasher sensors (wash cycle, heated dry, etc.)
+|===
+
+Set to `"false"` to expose sensors, `"true"` to hide them.
 
 ==== Multiple Appliances
 
@@ -402,6 +511,9 @@ If you experience crashes (typically `__cxa_allocate_exception` → `operator ne
 
 | *Appliance disconnects after 5 minutes*
 | This is the reconnect timeout working as designed. The ESP32 will automatically reconnect.
+
+| *Dishwasher disconnects after ~10 seconds*
+| This is normal for Cove dishwashers. The integration uses a fast reconnect path with cached GATT handles, and optimized handshake delays total ~3.25 seconds to complete the full poll within the connection window.
 |===
 
 == Project Structure
@@ -409,10 +521,11 @@ If you experience crashes (typically `__cxa_allocate_exception` → `operator ne
 [source]
 ----
 .
-├── README.adoc              # This file
-├── subzero_appliance.yaml   # Reusable package for any SZG appliance
-├── subzero.yaml             # Main ESPHome config (edit this)
-└── secrets.yaml             # Your WiFi/MAC/PIN secrets (git-ignored)
+├── README.adoc                    # This file
+├── subzero_appliance.yaml         # Reusable package for any SZG appliance
+├── subzero.yaml                   # Main config — two fridges (edit this)
+├── cove-minimal-dishwasher.yaml   # Standalone dishwasher config example
+└── secrets.yaml                   # Your WiFi/MAC/PIN secrets (git-ignored)
 ----
 
 == License

--- a/cove-minimal-dishwasher.yaml
+++ b/cove-minimal-dishwasher.yaml
@@ -1,0 +1,74 @@
+# Minimal ESPHome config for a single Sub-Zero/Cove appliance over BLE.
+# This example connects to a Cove DW2450 dishwasher.
+# Edit the substitutions and secrets to match your setup.
+
+substitutions:
+  name: "cove-dishwasher"
+  friendly_name: "Cove Dishwasher"
+
+packages:
+  right_dishwasher: !include
+    file: subzero_appliance.yaml
+    vars:
+      prefix: "szg"
+      appliance_name: "Right Dishwasher"
+      appliance_mac: !secret right_dishwasher_mac
+      appliance_pin: !secret right_dishwasher_pin
+      dishwasher_sensors_internal: "false"
+      fridge_sensors_internal: "true"
+      freezer_sensors_internal: "true"
+      ice_maker_sensor_internal: "true"
+      sabbath_sensor_internal: "true"
+
+esphome:
+  name: ${name}
+  friendly_name: ${friendly_name}
+  name_add_mac_suffix: true
+  on_boot:
+    priority: -100
+    then:
+      - lambda: |-
+          // BLE security: SC_MITM_BOND + keyboard_only (passkey entry)
+          esp_ble_auth_req_t auth_req = ESP_LE_AUTH_REQ_SC_MITM_BOND;
+          uint8_t key_size = 16;
+          uint8_t init_key = ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK;
+          uint8_t rsp_key = ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK;
+          esp_ble_io_cap_t io_cap = ESP_IO_CAP_IN;
+          esp_ble_gap_set_security_param(ESP_BLE_SM_AUTHEN_REQ_MODE, &auth_req, sizeof(auth_req));
+          esp_ble_gap_set_security_param(ESP_BLE_SM_MAX_KEY_SIZE, &key_size, sizeof(key_size));
+          esp_ble_gap_set_security_param(ESP_BLE_SM_SET_INIT_KEY, &init_key, sizeof(init_key));
+          esp_ble_gap_set_security_param(ESP_BLE_SM_SET_RSP_KEY, &rsp_key, sizeof(rsp_key));
+          esp_ble_gap_set_security_param(ESP_BLE_SM_IOCAP_MODE, &io_cap, sizeof(io_cap));
+          ESP_LOGI("ble", "BLE security: SC_MITM_BOND + IO_CAP_IN (keyboard_only)");
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+    version: 5.5.3.1
+    sdkconfig_options:
+      CONFIG_BT_GATTC_CACHE_NVS_FLASH: "n"
+
+esp32_ble:
+  io_capability: keyboard_only
+
+logger:
+  level: DEBUG
+  logs:
+    esp32_ble_client: INFO
+    ble_client: DEBUG
+    ble_sensor: WARN
+    esp32_ble_tracker: WARN
+    BT_GATTC: WARN
+
+api:
+  reboot_timeout: 5min
+
+ota:
+  - platform: esphome
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+esp32_ble_tracker:

--- a/subzero_appliance.yaml
+++ b/subzero_appliance.yaml
@@ -21,10 +21,25 @@
 #         appliance_pin: !secret main_fridge_pin
 #         freezer_sensors_internal: "false"
 #         ice_maker_sensor_internal: "false"
+#     right_dishwasher: !include
+#       file: subzero_appliance.yaml
+#       vars:
+#         prefix: "szg"
+#         appliance_name: "Right Dishwasher"
+#         appliance_mac: !secret right_dishwasher_mac
+#         appliance_pin: !secret right_dishwasher_pin
+#         dishwasher_sensors_internal: "false"
+#         fridge_sensors_internal: "true"
+#         freezer_sensors_internal: "true"
+#         ice_maker_sensor_internal: "true"
+#         sabbath_sensor_internal: "true"
 
 substitutions:
   freezer_sensors_internal: "true"
   ice_maker_sensor_internal: "true"
+  sabbath_sensor_internal: "true"
+  dishwasher_sensors_internal: "true"
+  fridge_sensors_internal: "false"
 
 globals:
   - id: ${prefix}_phase
@@ -47,6 +62,9 @@ globals:
     type: bool
     restore_value: true
     initial_value: "true"
+  - id: ${prefix}_poll_ok
+    type: bool
+    initial_value: "false"
 
 ble_client:
   - mac_address: ${appliance_mac}
@@ -70,6 +88,13 @@ ble_client:
     on_connect:
       then:
         - lambda: |-
+            // Fast path: handles cached from previous successful connection
+            if (id(${prefix}_d5_handle) > 0 && id(${prefix}_poll_ok)) {
+              ESP_LOGI("ble", "[${appliance_name}] Reconnected (fast path, d5=%d)", id(${prefix}_d5_handle));
+              id(${prefix}_debug).publish_state("Reconnected, encrypting...");
+              id(${prefix}_fast_reconnect).execute();
+              return;
+            }
             int phase = id(${prefix}_phase);
             if (phase == 0) {
               id(${prefix}_phase) = 1;
@@ -93,13 +118,19 @@ ble_client:
     on_disconnect:
       then:
         - lambda: |-
-            id(${prefix}_phase) = 0;
-            id(${prefix}_d4_handle) = 0;
-            id(${prefix}_d5_handle) = 0;
             id(${prefix}_json_buf).clear();
             id(${prefix}_post_bond).stop();
             id(${prefix}_subscribe).stop();
-            ESP_LOGI("ble", "[${appliance_name}] Disconnected");
+            id(${prefix}_fast_reconnect).stop();
+            if (id(${prefix}_poll_ok) && id(${prefix}_d5_handle) > 0) {
+              // Keep handles cached for fast reconnect
+              ESP_LOGI("ble", "[${appliance_name}] Disconnected (handles cached)");
+            } else {
+              id(${prefix}_phase) = 0;
+              id(${prefix}_d4_handle) = 0;
+              id(${prefix}_d5_handle) = 0;
+              ESP_LOGI("ble", "[${appliance_name}] Disconnected");
+            }
             id(${prefix}_debug).publish_state("Disconnected");
 
 sensor:
@@ -111,6 +142,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 0
     icon: "mdi:thermometer"
+    internal: ${fridge_sensors_internal}
 
   - platform: template
     name: "${appliance_name} Freezer Temperature"
@@ -121,6 +153,20 @@ sensor:
     accuracy_decimals: 0
     icon: "mdi:snowflake-thermometer"
     internal: ${freezer_sensors_internal}
+
+  - platform: template
+    name: "${appliance_name} Wash Status"
+    id: ${prefix}_wash_status
+    icon: "mdi:dishwasher"
+    accuracy_decimals: 0
+    internal: ${dishwasher_sensors_internal}
+
+  - platform: template
+    name: "${appliance_name} Wash Cycle"
+    id: ${prefix}_wash_cycle
+    icon: "mdi:counter"
+    accuracy_decimals: 0
+    internal: ${dishwasher_sensors_internal}
 
   - platform: ble_client
     type: characteristic
@@ -158,6 +204,7 @@ binary_sensor:
     name: "${appliance_name} Sabbath Mode"
     id: ${prefix}_sabbath_on
     icon: "mdi:candelabra"
+    internal: ${sabbath_sensor_internal}
 
   - platform: template
     name: "${appliance_name} Freezer Door"
@@ -175,6 +222,60 @@ binary_sensor:
     name: "${appliance_name} Service Required"
     id: ${prefix}_svc_required
     device_class: problem
+
+  - platform: template
+    name: "${appliance_name} Wash Cycle Active"
+    id: ${prefix}_wash_cycle_on
+    icon: "mdi:dishwasher"
+    internal: ${dishwasher_sensors_internal}
+
+  - platform: template
+    name: "${appliance_name} Heated Dry"
+    id: ${prefix}_heated_dry
+    icon: "mdi:heat-wave"
+    internal: ${dishwasher_sensors_internal}
+
+  - platform: template
+    name: "${appliance_name} Extended Dry"
+    id: ${prefix}_extended_dry
+    icon: "mdi:heat-wave"
+    internal: ${dishwasher_sensors_internal}
+
+  - platform: template
+    name: "${appliance_name} High Temp Wash"
+    id: ${prefix}_high_temp_wash
+    icon: "mdi:thermometer-high"
+    internal: ${dishwasher_sensors_internal}
+
+  - platform: template
+    name: "${appliance_name} Sanitize Rinse"
+    id: ${prefix}_sani_rinse
+    icon: "mdi:hand-wash"
+    internal: ${dishwasher_sensors_internal}
+
+  - platform: template
+    name: "${appliance_name} Rinse Aid Low"
+    id: ${prefix}_rinse_aid_low
+    device_class: problem
+    internal: ${dishwasher_sensors_internal}
+
+  - platform: template
+    name: "${appliance_name} Light"
+    id: ${prefix}_light_on
+    icon: "mdi:lightbulb"
+    internal: ${dishwasher_sensors_internal}
+
+  - platform: template
+    name: "${appliance_name} Remote Ready"
+    id: ${prefix}_remote_ready
+    icon: "mdi:remote"
+    internal: ${dishwasher_sensors_internal}
+
+  - platform: template
+    name: "${appliance_name} Delay Start"
+    id: ${prefix}_delay_start
+    icon: "mdi:timer-sand"
+    internal: ${dishwasher_sensors_internal}
 
 text_sensor:
   - platform: template
@@ -336,8 +437,10 @@ interval:
     then:
       - lambda: |-
           if (!id(${prefix}_pin_confirmed)) return;
+          if (id(${prefix}_subscribe).is_running() || id(${prefix}_post_bond).is_running() || id(${prefix}_fast_reconnect).is_running()) return;
           uint16_t d5 = id(${prefix}_d5_handle);
           if (d5 == 0) return;
+          id(${prefix}_poll_ok) = false;
           auto *client = id(${prefix}_appliance);
           std::string cmd = "{\"cmd\":\"get_async\"}\n";
           esp_ble_gattc_write_char(
@@ -411,6 +514,7 @@ script:
             float temp = find_num("\"ref_set_temp\"");
             if (!std::isnan(temp)) id(${prefix}_set_temp).publish_state(temp);
             int door = find_bool("\"ref_door_ajar\"");
+            if (door < 0) door = find_bool("\"door_ajar\"");
             if (door >= 0) id(${prefix}_door_ajar).publish_state(door == 1);
             float frz_temp = find_num("\"frz_set_temp\"");
             if (!std::isnan(frz_temp)) id(${prefix}_frz_temp).publish_state(frz_temp);
@@ -435,18 +539,45 @@ script:
               buf[end - p] = 0;
               return true;
             };
+            // Dishwasher-specific sensors
+            int wash_on = find_bool("\"wash_cycle_on\"");
+            if (wash_on >= 0) id(${prefix}_wash_cycle_on).publish_state(wash_on == 1);
+            int heated = find_bool("\"heated_dry_on\"");
+            if (heated >= 0) id(${prefix}_heated_dry).publish_state(heated == 1);
+            int ext_dry = find_bool("\"extended_dry_on\"");
+            if (ext_dry >= 0) id(${prefix}_extended_dry).publish_state(ext_dry == 1);
+            int hi_temp = find_bool("\"high_temp_wash_on\"");
+            if (hi_temp >= 0) id(${prefix}_high_temp_wash).publish_state(hi_temp == 1);
+            int sani = find_bool("\"sani_rinse_on\"");
+            if (sani >= 0) id(${prefix}_sani_rinse).publish_state(sani == 1);
+            int rinse_aid = find_bool("\"rinse_aid_low\"");
+            if (rinse_aid >= 0) id(${prefix}_rinse_aid_low).publish_state(rinse_aid == 1);
+            int light = find_bool("\"light_on\"");
+            if (light >= 0) id(${prefix}_light_on).publish_state(light == 1);
+            int remote = find_bool("\"remote_ready\"");
+            if (remote >= 0) id(${prefix}_remote_ready).publish_state(remote == 1);
+            int delay_st = find_bool("\"delay_start_timer_active\"");
+            if (delay_st >= 0) id(${prefix}_delay_start).publish_state(delay_st == 1);
+            float ws = find_num("\"wash_status\"");
+            if (!std::isnan(ws)) id(${prefix}_wash_status).publish_state(ws);
+            float wc = find_num("\"wash_cycle\"");
+            if (!std::isnan(wc)) id(${prefix}_wash_cycle).publish_state(wc);
             char val[64];
             if (extract_str("\"appliance_model\"", val, sizeof(val)))
               id(${prefix}_model).publish_state(val);
             if (extract_str("\"uptime\"", val, sizeof(val)))
               id(${prefix}_uptime).publish_state(val);
           }
+          // Only mark poll_ok for full appliance responses, not PIN confirmations
+          if (json.size() > 100) {
+            id(${prefix}_poll_ok) = true;
+          }
           json.clear();
 
   - id: ${prefix}_post_bond
     mode: restart
     then:
-      - delay: 2s
+      - delay: 500ms
       - lambda: |-
           auto *client = id(${prefix}_appliance);
           esp_gattc_db_elem_t db[64];
@@ -480,20 +611,27 @@ script:
               }
             }
           }
-          if (id(${prefix}_d5_handle) > 0) {
-            ESP_LOGI("ble", "[${appliance_name}] D5 found immediately!");
-            id(${prefix}_debug).publish_state("D5 found! Starting unlock...");
-            id(${prefix}_subscribe).execute();
-            return;
-          }
-          ESP_LOGI("ble", "[${appliance_name}] No D5 yet. Requesting encryption...");
+          // Always request encryption — some appliances (dishwashers) expose D5
+          // before bonding but still require encryption for writes (status=5).
+          ESP_LOGI("ble", "[${appliance_name}] D5 %s. Requesting encryption...",
+            id(${prefix}_d5_handle) > 0 ? "found immediately" : "not yet visible");
           uint8_t addr[6];
           memcpy(addr, client->get_remote_bda(), 6);
           esp_ble_set_encryption(addr, ESP_BLE_SEC_ENCRYPT_MITM);
-          id(${prefix}_debug).publish_state("Requesting encryption...");
-      - delay: 5s
+          if (id(${prefix}_d5_handle) > 0) {
+            id(${prefix}_debug).publish_state("D5 found! Encrypting...");
+          } else {
+            id(${prefix}_debug).publish_state("Requesting encryption...");
+          }
+      - delay: 1s
       - lambda: |-
-          if (id(${prefix}_d5_handle) > 0) return;
+          if (id(${prefix}_d5_handle) > 0) {
+            // D5 was found before encryption (e.g. dishwashers).
+            // Encryption should be established by now — proceed to subscribe.
+            ESP_LOGI("ble", "[${appliance_name}] Post-encryption: D5 already known, subscribing...");
+            id(${prefix}_subscribe).execute();
+            return;
+          }
           auto *client = id(${prefix}_appliance);
           ESP_LOGI("ble", "[${appliance_name}] Post-encryption: refreshing GATT cache...");
           esp_bd_addr_t addr;
@@ -574,6 +712,20 @@ script:
             - ble_client.connect:
                 id: ${prefix}_appliance
 
+  - id: ${prefix}_fast_reconnect
+    mode: restart
+    then:
+      # Fast path: skip GATT dump, just encrypt + subscribe + unlock (no auto-poll)
+      - lambda: |-
+          auto *client = id(${prefix}_appliance);
+          uint8_t addr[6];
+          memcpy(addr, client->get_remote_bda(), 6);
+          esp_ble_set_encryption(addr, ESP_BLE_SEC_ENCRYPT_MITM);
+          ESP_LOGI("ble", "[${appliance_name}] Fast reconnect: encryption requested");
+      - delay: 750ms
+      - lambda: |-
+          id(${prefix}_subscribe).execute();
+
   - id: ${prefix}_subscribe
     mode: restart
     then:
@@ -590,27 +742,17 @@ script:
           id(${prefix}_d5_notify)->handle = d5;
           ESP_LOGI("ble", "[${appliance_name}] Injected D5 handle %d", d5);
           uint16_t d4 = id(${prefix}_d4_handle);
-          uint8_t ind_en[2] = {0x02, 0x00};
-          uint16_t d5_cccd = d5 + 2;
-          esp_err_t err = esp_ble_gattc_write_char_descr(
-            client->get_gattc_if(), client->get_conn_id(),
-            d5_cccd, 2, ind_en,
-            ESP_GATT_WRITE_TYPE_RSP, ESP_GATT_AUTH_REQ_NONE);
-          ESP_LOGI("ble", "[${appliance_name}] Subscribe D5 (h=%d, CCCD=%d): err=%d", d5, d5_cccd, err);
+          // register_for_notify handles CCCD subscription automatically
           esp_ble_gattc_register_for_notify(
             client->get_gattc_if(), client->get_remote_bda(), d5);
+          ESP_LOGI("ble", "[${appliance_name}] Subscribe D5 (h=%d)", d5);
           if (d4 > 0) {
-            uint16_t d4_cccd = d4 + 2;
-            esp_ble_gattc_write_char_descr(
-              client->get_gattc_if(), client->get_conn_id(),
-              d4_cccd, 2, ind_en,
-              ESP_GATT_WRITE_TYPE_RSP, ESP_GATT_AUTH_REQ_NONE);
             esp_ble_gattc_register_for_notify(
               client->get_gattc_if(), client->get_remote_bda(), d4);
             ESP_LOGI("ble", "[${appliance_name}] Subscribe D4 (h=%d) for diagnostics", d4);
           }
           id(${prefix}_json_buf).clear();
-      - delay: 2s
+      - delay: 500ms
       - lambda: |-
           auto *client = id(${prefix}_appliance);
           uint16_t d5 = id(${prefix}_d5_handle);
@@ -627,9 +769,14 @@ script:
             ESP_GATT_WRITE_TYPE_RSP, ESP_GATT_AUTH_REQ_NONE);
           ESP_LOGI("ble", "[${appliance_name}] Auto-unlock (PIN=%s) err=%d", pin.c_str(), err);
           id(${prefix}_debug).publish_state("Auto-unlocking...");
-      - delay: 3s
+      - delay: 500ms
       - lambda: |-
           if (!id(${prefix}_pin_confirmed)) return;
+          if (id(${prefix}_poll_ok)) {
+            ESP_LOGI("ble", "[${appliance_name}] Data cached, skipping auto-poll");
+            id(${prefix}_debug).publish_state("Connected (idle).");
+            return;
+          }
           auto *client = id(${prefix}_appliance);
           uint16_t d5 = id(${prefix}_d5_handle);
           std::string cmd = "{\"cmd\":\"get_async\"}\n";


### PR DESCRIPTION
Add support for Cove DW2450 dishwashers alongside existing Sub-Zero refrigerators.

- 11 binary sensors: wash cycle active, heated dry, extended dry, high temp wash, sanitize rinse, rinse aid low, light, remote ready, delay start, door, service required
- 2 numeric sensors: wash status code, wash cycle number
- JSON parser handles both fridge keys (`ref_door_ajar`, `ref_set_temp`) and dishwasher keys (`door_ajar`, `wash_cycle_on`, `wash_status`, etc.)

- New substitutions: `dishwasher_sensors_internal`, `fridge_sensors_internal`, `sabbath_sensor_internal`
- Each appliance config declares which sensor groups to expose or hide
- Fridges and dishwashers share the same `subzero_appliance.yaml` package

- After a successful poll, GATT handles are cached across disconnects
- Reconnections skip the full GATT service dump and go straight to encrypt → subscribe → idle
- Critical for Cove dishwashers which actively disconnect BLE after ~10 seconds

- Reduced total handshake time from ~8.5s to ~3.25s
- Ensures the full JSON response (~1736 bytes, 8 BLE fragments) completes within the dishwasher's ~10s connection window
- No impact on refrigerator connections (verified on DEU2450R and 313)

- Use `esp_ble_gattc_register_for_notify()` instead of manual CCCD descriptor writes — cleaner and handles CCCD automatically
- Always request encryption even when D5 is visible pre-bonding (dishwashers expose D5 before bonding but reject writes without encryption)

- `cove-minimal-dishwasher.yaml` — standalone config example for a Cove dishwasher

- ✅ Cove DW2450 dishwasher — all sensors populating
- ✅ Sub-Zero DEU2450R under-counter fridge — no regression
- ✅ Sub-Zero 313 french-door fridge/freezer — no regression
- ESP32dev (Everything Presence One), ESPHome 2026.3.0, esp-idf 5.5.3.1