### PR TITLE
chore: mv duplicated `esphome` block into appliance yml

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -172,6 +172,7 @@ The full handshake follows these steps:
 BLE Security:: The appliance requires *Secure Connections with MITM protection and bonding* (`SC_MITM_BOND`).
 The ESP32 must be configured with `IO_CAP_IN` (keyboard-only) so the user can enter the 6-digit passkey displayed on the appliance.
 After the first successful bond, the keys are stored and reconnection is automatic.
+If the bond becomes stale (e.g. appliance-side timeout overnight), the integration detects repeated auth failures (3 attempts) and automatically clears the stale bond, then re-pairs from scratch.
 
 Command Framing:: Every command written to D5 *must* end with a newline character (`\n`).
 The appliance's serial parser silently discards any command without it.
@@ -179,6 +180,9 @@ The appliance's serial parser silently discards any command without it.
 Response Fragmentation:: The appliance sends JSON responses as BLE indications, fragmented into chunks.
 Fridges typically fragment at ~40 bytes per indication (30–45 fragments for a 1200–1800 byte response), while dishwashers and ranges use larger ~244 byte fragments (7–8 fragments for a ~1600–1736 byte response).
 The receiver must buffer and reassemble these fragments by tracking JSON brace depth (`{` / `}`) to detect message completion.
+
+Push Notifications:: In addition to polled responses (`{"status":0,"resp":{...}}`), appliances send real-time push notifications for state changes (e.g. door open/close, light toggle).
+These use the format `{"seq":N,"props":{...},"msg_types":2}` — the parser handles both formats, extracting sensor data from `"resp"` (polls) or `"props"` (pushes).
 
 D5 Discovery Timing:: On refrigerators, the encrypted D5 characteristic is *not visible* in the GATT database until after bonding completes.
 The implementation must refresh the GATT cache (`esp_ble_gattc_cache_refresh`) and re-run service discovery after encryption is established.
@@ -616,6 +620,9 @@ If you experience crashes (typically `__cxa_allocate_exception` → `operator ne
 
 | *Appliance disconnects after 5 minutes*
 | This is the reconnect timeout working as designed. The ESP32 will automatically reconnect.
+
+| *Auth failures overnight (auth fail reason=102)*
+| The BLE bond went stale. The integration automatically detects this after 3 consecutive fast-reconnect failures, clears the old bond, and re-pairs. No action needed — recovery is automatic.
 
 | *Dishwasher disconnects after ~10 seconds*
 | This is normal for Cove dishwashers. The integration uses a fast reconnect path with cached GATT handles, and optimized handshake delays total ~3.25 seconds to complete the full poll within the connection window.

--- a/cove-minimal-dishwasher.yaml
+++ b/cove-minimal-dishwasher.yaml
@@ -24,22 +24,6 @@ esphome:
   name: ${name}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
-  on_boot:
-    priority: -100
-    then:
-      - lambda: |-
-          // BLE security: SC_MITM_BOND + keyboard_only (passkey entry)
-          esp_ble_auth_req_t auth_req = ESP_LE_AUTH_REQ_SC_MITM_BOND;
-          uint8_t key_size = 16;
-          uint8_t init_key = ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK;
-          uint8_t rsp_key = ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK;
-          esp_ble_io_cap_t io_cap = ESP_IO_CAP_IN;
-          esp_ble_gap_set_security_param(ESP_BLE_SM_AUTHEN_REQ_MODE, &auth_req, sizeof(auth_req));
-          esp_ble_gap_set_security_param(ESP_BLE_SM_MAX_KEY_SIZE, &key_size, sizeof(key_size));
-          esp_ble_gap_set_security_param(ESP_BLE_SM_SET_INIT_KEY, &init_key, sizeof(init_key));
-          esp_ble_gap_set_security_param(ESP_BLE_SM_SET_RSP_KEY, &rsp_key, sizeof(rsp_key));
-          esp_ble_gap_set_security_param(ESP_BLE_SM_IOCAP_MODE, &io_cap, sizeof(io_cap));
-          ESP_LOGI("ble", "BLE security: SC_MITM_BOND + IO_CAP_IN (keyboard_only)");
 
 esp32:
   board: esp32dev
@@ -48,9 +32,6 @@ esp32:
     version: 5.5.3.1
     sdkconfig_options:
       CONFIG_BT_GATTC_CACHE_NVS_FLASH: "n"
-
-esp32_ble:
-  io_capability: keyboard_only
 
 logger:
   level: DEBUG

--- a/subzero.yaml
+++ b/subzero.yaml
@@ -37,19 +37,6 @@ esphome:
     priority: -100
     then:
       - switch.turn_on: mmwave_sensor
-      - lambda: |-
-          // BLE security: SC_MITM_BOND + keyboard_only (passkey entry)
-          esp_ble_auth_req_t auth_req = ESP_LE_AUTH_REQ_SC_MITM_BOND;
-          uint8_t key_size = 16;
-          uint8_t init_key = ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK;
-          uint8_t rsp_key = ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK;
-          esp_ble_io_cap_t io_cap = ESP_IO_CAP_IN;
-          esp_ble_gap_set_security_param(ESP_BLE_SM_AUTHEN_REQ_MODE, &auth_req, sizeof(auth_req));
-          esp_ble_gap_set_security_param(ESP_BLE_SM_MAX_KEY_SIZE, &key_size, sizeof(key_size));
-          esp_ble_gap_set_security_param(ESP_BLE_SM_SET_INIT_KEY, &init_key, sizeof(init_key));
-          esp_ble_gap_set_security_param(ESP_BLE_SM_SET_RSP_KEY, &rsp_key, sizeof(rsp_key));
-          esp_ble_gap_set_security_param(ESP_BLE_SM_IOCAP_MODE, &io_cap, sizeof(io_cap));
-          ESP_LOGI("ble", "BLE security: SC_MITM_BOND + IO_CAP_IN (keyboard_only)");
 
 esp32:
   board: esp32dev
@@ -58,9 +45,6 @@ esp32:
     version: 5.5.3.1
     sdkconfig_options:
       CONFIG_BT_GATTC_CACHE_NVS_FLASH: "n"
-
-esp32_ble:
-  io_capability: keyboard_only
 
 logger:
   level: DEBUG

--- a/subzero_appliance.yaml
+++ b/subzero_appliance.yaml
@@ -45,6 +45,26 @@ substitutions:
 
 json:
 
+esphome:
+  on_boot:
+    priority: -100
+    then:
+      - lambda: |-
+          esp_ble_auth_req_t auth_req = ESP_LE_AUTH_REQ_SC_MITM_BOND;
+          uint8_t key_size = 16;
+          uint8_t init_key = ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK;
+          uint8_t rsp_key = ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK;
+          esp_ble_io_cap_t io_cap = ESP_IO_CAP_IN;
+          esp_ble_gap_set_security_param(ESP_BLE_SM_AUTHEN_REQ_MODE, &auth_req, sizeof(auth_req));
+          esp_ble_gap_set_security_param(ESP_BLE_SM_MAX_KEY_SIZE, &key_size, sizeof(key_size));
+          esp_ble_gap_set_security_param(ESP_BLE_SM_SET_INIT_KEY, &init_key, sizeof(init_key));
+          esp_ble_gap_set_security_param(ESP_BLE_SM_SET_RSP_KEY, &rsp_key, sizeof(rsp_key));
+          esp_ble_gap_set_security_param(ESP_BLE_SM_IOCAP_MODE, &io_cap, sizeof(io_cap));
+          ESP_LOGI("ble", "BLE security: SC_MITM_BOND + IO_CAP_IN (keyboard_only)");
+
+esp32_ble:
+  io_capability: keyboard_only
+
 globals:
   - id: ${prefix}_phase
     type: int
@@ -69,6 +89,9 @@ globals:
   - id: ${prefix}_poll_ok
     type: bool
     initial_value: "false"
+  - id: ${prefix}_fast_retries
+    type: int
+    initial_value: "0"
 
 ble_client:
   - mac_address: ${appliance_mac}
@@ -94,10 +117,25 @@ ble_client:
         - lambda: |-
             // Fast path: handles cached from previous connection (bonded)
             if (id(${prefix}_d5_handle) > 0 && id(${prefix}_phase) >= 1) {
-              ESP_LOGI("ble", "[${appliance_name}] Reconnected (fast path, d5=%d)", id(${prefix}_d5_handle));
-              id(${prefix}_debug).publish_state("Reconnected, encrypting...");
-              id(${prefix}_fast_reconnect).execute();
-              return;
+              if (id(${prefix}_fast_retries) >= 3) {
+                // Bond is likely stale — clear cached state and start fresh
+                ESP_LOGW("ble", "[${appliance_name}] Fast reconnect failed %d times, clearing bond & rediscovering",
+                  id(${prefix}_fast_retries));
+                auto *client = id(${prefix}_appliance);
+                esp_ble_remove_bond_device(*(esp_bd_addr_t*)client->get_remote_bda());
+                id(${prefix}_d5_handle) = 0;
+                id(${prefix}_d4_handle) = 0;
+                id(${prefix}_phase) = 0;
+                id(${prefix}_fast_retries) = 0;
+                id(${prefix}_debug).publish_state("Bond stale, re-pairing...");
+                // Fall through to phase==0 path below
+              } else {
+                ESP_LOGI("ble", "[${appliance_name}] Reconnected (fast path, d5=%d, attempt %d)",
+                  id(${prefix}_d5_handle), id(${prefix}_fast_retries) + 1);
+                id(${prefix}_debug).publish_state("Reconnected, encrypting...");
+                id(${prefix}_fast_reconnect).execute();
+                return;
+              }
             }
             int phase = id(${prefix}_phase);
             if (phase == 0) {
@@ -128,7 +166,9 @@ ble_client:
             id(${prefix}_fast_reconnect).stop();
             if (id(${prefix}_d5_handle) > 0 && id(${prefix}_phase) >= 1) {
               // Keep handles cached for fast reconnect (bonded)
-              ESP_LOGI("ble", "[${appliance_name}] Disconnected (handles cached, d5=%d)", id(${prefix}_d5_handle));
+              id(${prefix}_fast_retries) += 1;
+              ESP_LOGI("ble", "[${appliance_name}] Disconnected (handles cached, d5=%d, retries=%d)",
+                id(${prefix}_d5_handle), id(${prefix}_fast_retries));
             } else {
               id(${prefix}_phase) = 0;
               id(${prefix}_d4_handle) = 0;
@@ -715,6 +755,7 @@ script:
           });
           if (buf.size() > 100) {
             id(${prefix}_poll_ok) = true;
+            id(${prefix}_fast_retries) = 0;
           }
           buf.clear();
 

--- a/wolf-minimal-range.yaml
+++ b/wolf-minimal-range.yaml
@@ -25,22 +25,6 @@ esphome:
   name: ${name}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
-  on_boot:
-    priority: -100
-    then:
-      - lambda: |-
-          // BLE security: SC_MITM_BOND + keyboard_only (passkey entry)
-          esp_ble_auth_req_t auth_req = ESP_LE_AUTH_REQ_SC_MITM_BOND;
-          uint8_t key_size = 16;
-          uint8_t init_key = ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK;
-          uint8_t rsp_key = ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK;
-          esp_ble_io_cap_t io_cap = ESP_IO_CAP_IN;
-          esp_ble_gap_set_security_param(ESP_BLE_SM_AUTHEN_REQ_MODE, &auth_req, sizeof(auth_req));
-          esp_ble_gap_set_security_param(ESP_BLE_SM_MAX_KEY_SIZE, &key_size, sizeof(key_size));
-          esp_ble_gap_set_security_param(ESP_BLE_SM_SET_INIT_KEY, &init_key, sizeof(init_key));
-          esp_ble_gap_set_security_param(ESP_BLE_SM_SET_RSP_KEY, &rsp_key, sizeof(rsp_key));
-          esp_ble_gap_set_security_param(ESP_BLE_SM_IOCAP_MODE, &io_cap, sizeof(io_cap));
-          ESP_LOGI("ble", "BLE security: SC_MITM_BOND + IO_CAP_IN (keyboard_only)");
 
 esp32:
   board: esp32dev
@@ -49,9 +33,6 @@ esp32:
     version: 5.5.3.1
     sdkconfig_options:
       CONFIG_BT_GATTC_CACHE_NVS_FLASH: "n"
-
-esp32_ble:
-  io_capability: keyboard_only
 
 logger:
   level: DEBUG


### PR DESCRIPTION
also add retry logic to try to account for when connections fail