### PR TITLE
refactor: split monolithic appliance yaml into per-type packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,7 @@
 !subzero.yaml
 !cove-minimal-dishwasher.yaml
 !wolf-minimal-range.yaml
-!subzero_appliance.yaml
+!subzero_fridge.yaml
+!subzero_dishwasher.yaml
+!subzero_range.yaml
+!subzero_base.yaml

--- a/README.adoc
+++ b/README.adoc
@@ -169,8 +169,10 @@ The full handshake follows these steps:
 
 ==== Key Protocol Details
 
-BLE Security:: The appliance requires *Secure Connections with MITM protection and bonding* (`SC_MITM_BOND`).
+BLE Security:: The appliance requires *Legacy Pairing with MITM protection and bonding*.
 The ESP32 must be configured with `IO_CAP_IN` (keyboard-only) so the user can enter the 6-digit passkey displayed on the appliance.
++
+NOTE: Sub-Zero's BLE module seems to only support Legacy Pairing, *not* BLE Secure Connections (LESC). Do not set `ESP_LE_AUTH_REQ_SC_MITM_BOND` — it causes pairing to silently fall back to "Just Works" with no passkey exchange.
 After the first successful bond, the keys are stored and reconnection is automatic.
 If the bond becomes stale (e.g. appliance-side timeout overnight), the integration detects repeated auth failures (3 attempts) and automatically clears the stale bond, then re-pairs from scratch.
 
@@ -326,7 +328,7 @@ All commands are JSON objects written to D5, terminated with `\n`.
 ----
 ====
 
-Different appliance types include different properties. Refrigerator-only units won't have `frz_*` or `ice_maker_*` keys, dishwashers use `door_ajar` instead of `ref_door_ajar` and have wash-specific properties, and ranges use `cav_door_ajar` with oven-specific `cav_*` and `kitchen_timer*` properties. Sensor visibility is controlled per-appliance with `*_internal` substitution flags.
+Different appliance types include different properties. Refrigerator-only units won't have `frz_*` or `ice_maker_*` keys, dishwashers use `door_ajar` instead of `ref_door_ajar` and have wash-specific properties, and ranges use `cav_door_ajar` with oven-specific `cav_*` and `kitchen_timer*` properties. Each appliance type has its own package file that only includes the relevant sensors.
 
 [[getting-started]]
 == Getting Started
@@ -378,13 +380,26 @@ TIP: Sub-Zero appliance BLE MAC addresses seem to always start with `00:06:80` -
 
 === 5. Configure Your Appliances
 
-Edit `subzero.yaml` and set up your appliance packages:
+Choose the package file that matches your appliance type:
+
+[cols="1,1"]
+|===
+| Appliance Type | Package File
+
+| Sub-Zero refrigerator/freezer | `subzero_fridge.yaml`
+| Cove dishwasher | `subzero_dishwasher.yaml`
+| Wolf range/oven | `subzero_range.yaml`
+|===
+
+Each package only includes sensors relevant to that appliance type — no need to toggle visibility flags.
+
+==== Sub-Zero Refrigerators
 
 [source,yaml]
 ----
 packages:
   my_fridge: !include
-    file: subzero_appliance.yaml
+    file: subzero_fridge.yaml
     vars:
       prefix: "szg"                         # <1>
       appliance_name: "Kitchen Fridge"      # <2>
@@ -396,56 +411,47 @@ packages:
 <3> BLE MAC address from `secrets.yaml`
 <4> 6-digit PIN from `secrets.yaml`
 
-==== Appliances With Freezer / Ice Maker
-
-For appliances that have a freezer compartment and/or ice maker, enable those sensors:
+All fridge/freezer sensors are exposed by default. For fridge-only units (no freezer or ice maker) have the option to hide the irrelevant sensors:
 
 [source,yaml]
 ----
 packages:
-  main_fridge: !include
-    file: subzero_appliance.yaml
+  basement_fridge: !include
+    file: subzero_fridge.yaml
     vars:
-      prefix: "szg2"
-      appliance_name: "Main Fridge"
-      appliance_mac: !secret main_fridge_mac
-      appliance_pin: !secret main_fridge_pin
-      freezer_sensors_internal: "false"       # <1>
-      ice_maker_sensor_internal: "false"      # <2>
-      sabbath_sensor_internal: "false"        # <3>
+      prefix: "szg"
+      appliance_name: "Basement Fridge"
+      appliance_mac: !secret basement_fridge_mac
+      appliance_pin: !secret basement_fridge_pin
+      hide_freezer: "true"      # <1>
+      hide_ice_maker: "true"    # <2>
 ----
-<1> Exposes freezer temperature and freezer door sensors
-<2> Exposes ice maker on/off sensor
-<3> Exposes Sabbath Mode sensor (hidden by default)
+<1> Hides freezer temperature and freezer door sensors
+<2> Hides ice maker sensor
 
-By default, freezer, ice maker, Sabbath, and dishwasher sensors are hidden (`internal: true`) since not all appliances have them.
-Fridge sensors (Set Temperature) are visible by default.
+.Available options for `subzero_fridge.yaml`
+[cols="1,1,2"]
+|===
+| Option | Default | Hides
+
+| `hide_freezer` | `"false"` | Freezer Temperature, Freezer Door
+| `hide_ice_maker` | `"false"` | Ice Maker
+| `hide_sabbath` | `"false"` | Sabbath Mode
+|===
 
 ==== Cove Dishwashers
-
-For Cove dishwashers, enable dishwasher sensors and hide fridge-only sensors:
 
 [source,yaml]
 ----
 packages:
   dishwasher: !include
-    file: subzero_appliance.yaml
+    file: subzero_dishwasher.yaml
     vars:
       prefix: "szg"
       appliance_name: "Dishwasher"
       appliance_mac: !secret dishwasher_mac
       appliance_pin: !secret dishwasher_pin
-      dishwasher_sensors_internal: "false"    # <1>
-      fridge_sensors_internal: "true"         # <2>
-      freezer_sensors_internal: "true"        # <3>
-      ice_maker_sensor_internal: "true"       # <4>
-      sabbath_sensor_internal: "true"         # <5>
 ----
-<1> Exposes all dishwasher-specific sensors (wash cycle, heated dry, etc.)
-<2> Hides fridge-only sensors (Set Temperature)
-<3> Hides freezer sensors
-<4> Hides ice maker sensor
-<5> Hides Sabbath Mode sensor
 
 See `cove-minimal-dishwasher.yaml` for a complete standalone example.
 
@@ -453,80 +459,53 @@ NOTE: Cove dishwashers actively disconnect BLE ~10 seconds after connection. The
 
 ==== Wolf Ranges
 
-For Wolf ranges, enable range sensors and hide fridge-only sensors:
-
 [source,yaml]
 ----
 packages:
   range: !include
-    file: subzero_appliance.yaml
+    file: subzero_range.yaml
     vars:
       prefix: "szg"
       appliance_name: "Kitchen Range"
       appliance_mac: !secret range_mac
       appliance_pin: !secret range_pin
-      range_sensors_internal: "false"          # <1>
-      fridge_sensors_internal: "true"           # <2>
-      freezer_sensors_internal: "true"          # <3>
-      ice_maker_sensor_internal: "true"         # <4>
-      sabbath_sensor_internal: "true"           # <5>
-      dishwasher_sensors_internal: "true"       # <6>
 ----
-<1> Exposes all range/oven sensors (cavity temp, probe, cook mode, timers, etc.)
-<2> Hides fridge-only sensors (Set Temperature)
-<3> Hides freezer sensors
-<4> Hides ice maker sensor
-<5> Hides Sabbath Mode sensor
-<6> Hides dishwasher sensors
 
 See `wolf-minimal-range.yaml` for a complete standalone example.
 
 NOTE: Wolf ranges disconnect BLE connections quickly, similar to Cove dishwashers. For best results, use `fast_connect: true` and `power_save_mode: none` in your WiFi config to minimize BLE/WiFi coexistence interference during data transfer.
 
-==== Sensor Visibility Reference
-
-All sensor groups can be shown or hidden per-appliance using substitution variables:
-
-[cols="2,1,2"]
-|===
-| Substitution | Default | Controls
-
-| `fridge_sensors_internal` | `"false"` | Set Temperature
-| `freezer_sensors_internal` | `"true"` | Freezer Temperature, Freezer Door
-| `ice_maker_sensor_internal` | `"true"` | Ice Maker
-| `sabbath_sensor_internal` | `"true"` | Sabbath Mode
-| `dishwasher_sensors_internal` | `"true"` | All dishwasher sensors (wash cycle, heated dry, etc.)
-| `range_sensors_internal` | `"true"` | All range/oven sensors (cavity temp, probe, cook mode, timers, etc.)
-|===
-
-Set to `"false"` to expose sensors, `"true"` to hide them.
-
 ==== Multiple Appliances
 
-You can monitor multiple appliances from a single ESP32 — just add more package includes with unique prefixes:
+You can monitor multiple appliances from a single ESP32 — just add more package includes with unique prefixes. You can mix appliance types:
 
 [source,yaml]
 ----
 packages:
-  fridge_1: !include
-    file: subzero_appliance.yaml
+  fridge: !include
+    file: subzero_fridge.yaml
     vars:
       prefix: "szg"
-      appliance_name: "Under-Counter Fridge"
-      appliance_mac: !secret fridge_1_mac
-      appliance_pin: !secret fridge_1_pin
-  fridge_2: !include
-    file: subzero_appliance.yaml
+      appliance_name: "Main Fridge"
+      appliance_mac: !secret fridge_mac
+      appliance_pin: !secret fridge_pin
+  range: !include
+    file: subzero_range.yaml
     vars:
       prefix: "szg2"
-      appliance_name: "Main Fridge"
-      appliance_mac: !secret fridge_2_mac
-      appliance_pin: !secret fridge_2_pin
-      freezer_sensors_internal: "false"
-      ice_maker_sensor_internal: "false"
+      appliance_name: "Kitchen Range"
+      appliance_mac: !secret range_mac
+      appliance_pin: !secret range_pin
+  dishwasher: !include
+    file: subzero_dishwasher.yaml
+    vars:
+      prefix: "szg3"
+      appliance_name: "Dishwasher"
+      appliance_mac: !secret dishwasher_mac
+      appliance_pin: !secret dishwasher_pin
 ----
 
-NOTE: Two concurrent BLE appliance connections is the practical limit on a standard ESP32 - heap usage is tight
+NOTE: Be cautious about how many appliances you add here, heap usage is tight
 
 == ESPHome Commands
 
@@ -580,6 +559,59 @@ esphome logs subzero.yaml --device /dev/cu.usbserial-210
 ----
 esphome logs subzero.yaml --device 192.168.x.x
 ----
+
+== BLE Stack Tuning (sdkconfig_options)
+
+The ESP-IDF BLE stack has several compile-time settings that affect reliability and connection limits.
+These are set in your device YAML under `esp32: framework: sdkconfig_options:`.
+
+=== Required for All Configs
+
+[source,yaml]
+----
+esp32:
+  board: esp32-s3-devkitc-1
+  framework:
+    type: esp-idf
+    version: 5.5.3.1
+    sdkconfig_options:
+      CONFIG_BT_GATTC_CACHE_NVS_FLASH: "n"
+----
+
+Disables persisting the GATT client cache to flash.
+Without this, stale cached GATT data causes D5 characteristic discovery failures after re-pairing or bond changes.
+This is already set in all example configs.
+
+=== Required for 2+ Concurrent Appliances
+
+If you are connecting to *two or more* appliances from a single ESP32, add these options:
+
+[source,yaml]
+----
+esp32:
+  board: esp32-s3-devkitc-1
+  framework:
+    type: esp-idf
+    version: 5.5.3.1
+    sdkconfig_options:
+      # Disable GATT cache persistence — stale cached data causes D5 discovery
+      # failures after re-pairing. Required for all configs.
+      CONFIG_BT_GATTC_CACHE_NVS_FLASH: "n"
+      # The options below are only needed when running 2+ concurrent BLE
+      # appliance connections. They increase the max connection count (default 3)
+      # and enlarge the ACL buffer pool to avoid dropping indication fragments
+      # during rapid 40-byte JSON transfers across multiple connections.
+      CONFIG_BT_ACL_CONNECTIONS: "4"        # <1>
+      CONFIG_BT_BLE_ACL_BUF_COUNT: "20"     # <2>
+      CONFIG_BT_BLE_ACL_BUF_SIZE: "255"     # <3>
+----
+<1> Maximum simultaneous BLE connections. Default is 3. Set to the number of appliances + 1 for headroom.
+<2> Number of ACL data buffers in the BLE controller pool. Default is 10. More buffers prevent dropped indication fragments when multiple appliances send data concurrently.
+<3> Size of each ACL buffer in bytes. Default is 251. Increase to 255 to accommodate full-size BLE packets.
+
+WARNING: These options increase RAM usage in the BLE stack. An ESP32-S3 with PSRAM can handle more.
+
+If you only have *one* appliance, you do not need these — the defaults work fine.
 
 == Memory Considerations
 
@@ -637,8 +669,11 @@ If you experience crashes (typically `__cxa_allocate_exception` → `operator ne
 ----
 .
 ├── README.adoc                    # This file
-├── subzero_appliance.yaml         # Reusable package for any SZG appliance
-├── subzero.yaml                   # Main config — two fridges (edit this)
+├── subzero_base.yaml              # Shared BLE connection logic (included by type packages)
+├── subzero_fridge.yaml            # Sub-Zero refrigerator/freezer package
+├── subzero_dishwasher.yaml        # Cove dishwasher package
+├── subzero_range.yaml             # Wolf range/oven package
+├── subzero.yaml                   # Example config — two fridges (edit this)
 ├── cove-minimal-dishwasher.yaml   # Standalone dishwasher config example
 ├── wolf-minimal-range.yaml        # Standalone range config example
 └── secrets.yaml                   # Your WiFi/MAC/PIN secrets (git-ignored)

--- a/cove-minimal-dishwasher.yaml
+++ b/cove-minimal-dishwasher.yaml
@@ -8,17 +8,12 @@ substitutions:
 
 packages:
   right_dishwasher: !include
-    file: subzero_appliance.yaml
+    file: subzero_dishwasher.yaml
     vars:
       prefix: "szg"
       appliance_name: "Right Dishwasher"
       appliance_mac: !secret right_dishwasher_mac
       appliance_pin: !secret right_dishwasher_pin
-      dishwasher_sensors_internal: "false"
-      fridge_sensors_internal: "true"
-      freezer_sensors_internal: "true"
-      ice_maker_sensor_internal: "true"
-      sabbath_sensor_internal: "true"
 
 esphome:
   name: ${name}
@@ -32,6 +27,13 @@ esp32:
     version: 5.5.3.1
     sdkconfig_options:
       CONFIG_BT_GATTC_CACHE_NVS_FLASH: "n"
+      # The options below are only needed when running 2+ concurrent BLE
+      # appliance connections. They increase the max connection count (default 3)
+      # and enlarge the ACL buffer pool to avoid dropping indication fragments
+      # during rapid 40-byte JSON transfers across multiple connections.
+      # CONFIG_BT_ACL_CONNECTIONS: "4"
+      # CONFIG_BT_BLE_ACL_BUF_COUNT: "20"
+      # CONFIG_BT_BLE_ACL_BUF_SIZE: "255"
 
 logger:
   level: DEBUG

--- a/subzero.yaml
+++ b/subzero.yaml
@@ -10,21 +10,19 @@ substitutions:
 
 packages:
   basement_fridge: !include
-    file: subzero_appliance.yaml
+    file: subzero_fridge.yaml
     vars:
       prefix: "szg"
       appliance_name: "Basement Fridge"
       appliance_mac: !secret basement_fridge_mac
       appliance_pin: !secret basement_fridge_pin
   main_fridge: !include
-    file: subzero_appliance.yaml
+    file: subzero_fridge.yaml
     vars:
       prefix: "szg2"
       appliance_name: "Main Fridge"
       appliance_mac: !secret main_fridge_mac
       appliance_pin: !secret main_fridge_pin
-      freezer_sensors_internal: "false"
-      ice_maker_sensor_internal: "false"
 
 esphome:
   name: ${name}
@@ -45,6 +43,13 @@ esp32:
     version: 5.5.3.1
     sdkconfig_options:
       CONFIG_BT_GATTC_CACHE_NVS_FLASH: "n"
+      # The options below are only needed when running 2+ concurrent BLE
+      # appliance connections. They increase the max connection count (default 3)
+      # and enlarge the ACL buffer pool to avoid dropping indication fragments
+      # during rapid 40-byte JSON transfers across multiple connections.
+      CONFIG_BT_ACL_CONNECTIONS: "4"
+      CONFIG_BT_BLE_ACL_BUF_COUNT: "20"
+      CONFIG_BT_BLE_ACL_BUF_SIZE: "255"
 
 logger:
   level: DEBUG

--- a/subzero_base.yaml
+++ b/subzero_base.yaml
@@ -1,66 +1,13 @@
-# Sub-Zero / Wolf / Cove Appliance BLE Package
-# Include with vars: prefix, appliance_name, appliance_mac, appliance_pin
-# Optional vars: freezer_sensors_internal, ice_maker_sensor_internal,
-#   dishwasher_sensors_internal, range_sensors_internal
-#   Set to "false" to expose appliance-specific sensors in HA
-#
-# Example:
-#   packages:
-#     basement_fridge: !include
-#       file: subzero_appliance.yaml
-#       vars:
-#         prefix: "szg"
-#         appliance_name: "Basement Fridge"
-#         appliance_mac: !secret basement_fridge_mac
-#         appliance_pin: !secret basement_fridge_pin
-#     main_fridge: !include
-#       file: subzero_appliance.yaml
-#       vars:
-#         prefix: "szg2"
-#         appliance_name: "Main Fridge"
-#         appliance_mac: !secret main_fridge_mac
-#         appliance_pin: !secret main_fridge_pin
-#         freezer_sensors_internal: "false"
-#         ice_maker_sensor_internal: "false"
-#     right_dishwasher: !include
-#       file: subzero_appliance.yaml
-#       vars:
-#         prefix: "szg"
-#         appliance_name: "Right Dishwasher"
-#         appliance_mac: !secret right_dishwasher_mac
-#         appliance_pin: !secret right_dishwasher_pin
-#         dishwasher_sensors_internal: "false"
-#         fridge_sensors_internal: "true"
-#         freezer_sensors_internal: "true"
-#         ice_maker_sensor_internal: "true"
-#         sabbath_sensor_internal: "true"
+# Sub-Zero / Wolf / Cove — Shared BLE Package
+# Do not include this file directly. Use one of the appliance-type packages:
+#   subzero_fridge.yaml      — Sub-Zero refrigerators and freezers
+#   subzero_dishwasher.yaml  — Cove dishwashers
+#   subzero_range.yaml       — Wolf ranges and ovens
 
 substitutions:
-  freezer_sensors_internal: "true"
-  ice_maker_sensor_internal: "true"
-  sabbath_sensor_internal: "true"
-  dishwasher_sensors_internal: "true"
-  range_sensors_internal: "true"
-  fridge_sensors_internal: "false"
+  poll_offset: "0s"
 
 json:
-
-esphome:
-  on_boot:
-    priority: -100
-    then:
-      - lambda: |-
-          esp_ble_auth_req_t auth_req = ESP_LE_AUTH_REQ_SC_MITM_BOND;
-          uint8_t key_size = 16;
-          uint8_t init_key = ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK;
-          uint8_t rsp_key = ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK;
-          esp_ble_io_cap_t io_cap = ESP_IO_CAP_IN;
-          esp_ble_gap_set_security_param(ESP_BLE_SM_AUTHEN_REQ_MODE, &auth_req, sizeof(auth_req));
-          esp_ble_gap_set_security_param(ESP_BLE_SM_MAX_KEY_SIZE, &key_size, sizeof(key_size));
-          esp_ble_gap_set_security_param(ESP_BLE_SM_SET_INIT_KEY, &init_key, sizeof(init_key));
-          esp_ble_gap_set_security_param(ESP_BLE_SM_SET_RSP_KEY, &rsp_key, sizeof(rsp_key));
-          esp_ble_gap_set_security_param(ESP_BLE_SM_IOCAP_MODE, &io_cap, sizeof(io_cap));
-          ESP_LOGI("ble", "BLE security: SC_MITM_BOND + IO_CAP_IN (keyboard_only)");
 
 esp32_ble:
   io_capability: keyboard_only
@@ -92,6 +39,9 @@ globals:
   - id: ${prefix}_fast_retries
     type: int
     initial_value: "0"
+  - id: ${prefix}_poll_miss
+    type: int
+    initial_value: "0"
 
 ble_client:
   - mac_address: ${appliance_mac}
@@ -115,27 +65,17 @@ ble_client:
     on_connect:
       then:
         - lambda: |-
+            // Request large MTU — fridge firmware sends 40-byte chunks at default MTU,
+            // but may use larger chunks if we negotiate higher (dishwasher/range use 244).
+            auto *cl = id(${prefix}_appliance);
+            esp_ble_gattc_send_mtu_req(cl->get_gattc_if(), cl->get_conn_id());
             // Fast path: handles cached from previous connection (bonded)
             if (id(${prefix}_d5_handle) > 0 && id(${prefix}_phase) >= 1) {
-              if (id(${prefix}_fast_retries) >= 3) {
-                // Bond is likely stale — clear cached state and start fresh
-                ESP_LOGW("ble", "[${appliance_name}] Fast reconnect failed %d times, clearing bond & rediscovering",
-                  id(${prefix}_fast_retries));
-                auto *client = id(${prefix}_appliance);
-                esp_ble_remove_bond_device(*(esp_bd_addr_t*)client->get_remote_bda());
-                id(${prefix}_d5_handle) = 0;
-                id(${prefix}_d4_handle) = 0;
-                id(${prefix}_phase) = 0;
-                id(${prefix}_fast_retries) = 0;
-                id(${prefix}_debug).publish_state("Bond stale, re-pairing...");
-                // Fall through to phase==0 path below
-              } else {
-                ESP_LOGI("ble", "[${appliance_name}] Reconnected (fast path, d5=%d, attempt %d)",
-                  id(${prefix}_d5_handle), id(${prefix}_fast_retries) + 1);
-                id(${prefix}_debug).publish_state("Reconnected, encrypting...");
-                id(${prefix}_fast_reconnect).execute();
-                return;
-              }
+              ESP_LOGI("ble", "[${appliance_name}] Reconnected (fast path, d5=%d, retries=%d)",
+                id(${prefix}_d5_handle), id(${prefix}_fast_retries));
+              id(${prefix}_debug).publish_state("Reconnected, encrypting...");
+              id(${prefix}_fast_reconnect).execute();
+              return;
             }
             int phase = id(${prefix}_phase);
             if (phase == 0) {
@@ -165,10 +105,22 @@ ble_client:
             id(${prefix}_subscribe).stop();
             id(${prefix}_fast_reconnect).stop();
             if (id(${prefix}_d5_handle) > 0 && id(${prefix}_phase) >= 1) {
-              // Keep handles cached for fast reconnect (bonded)
               id(${prefix}_fast_retries) += 1;
-              ESP_LOGI("ble", "[${appliance_name}] Disconnected (handles cached, d5=%d, retries=%d)",
-                id(${prefix}_d5_handle), id(${prefix}_fast_retries));
+              if (id(${prefix}_fast_retries) >= 3) {
+                // Stale bond — clear while disconnected so next connect starts fresh
+                ESP_LOGW("ble", "[${appliance_name}] Stale bond (%d failures), clearing for re-pair",
+                  id(${prefix}_fast_retries));
+                auto *client = id(${prefix}_appliance);
+                esp_ble_remove_bond_device(*(esp_bd_addr_t*)client->get_remote_bda());
+                id(${prefix}_d5_handle) = 0;
+                id(${prefix}_d4_handle) = 0;
+                id(${prefix}_phase) = 0;
+                id(${prefix}_fast_retries) = 0;
+                id(${prefix}_debug).publish_state("Bond cleared, re-pairing on next connect...");
+              } else {
+                ESP_LOGI("ble", "[${appliance_name}] Disconnected (handles cached, d5=%d, retries=%d)",
+                  id(${prefix}_d5_handle), id(${prefix}_fast_retries));
+              }
             } else {
               id(${prefix}_phase) = 0;
               id(${prefix}_d4_handle) = 0;
@@ -178,88 +130,6 @@ ble_client:
             id(${prefix}_debug).publish_state("Disconnected");
 
 sensor:
-  - platform: template
-    name: "${appliance_name} Set Temperature"
-    id: ${prefix}_set_temp
-    unit_of_measurement: "°F"
-    device_class: temperature
-    state_class: measurement
-    accuracy_decimals: 0
-    icon: "mdi:thermometer"
-    internal: ${fridge_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} Freezer Temperature"
-    id: ${prefix}_frz_temp
-    unit_of_measurement: "°F"
-    device_class: temperature
-    state_class: measurement
-    accuracy_decimals: 0
-    icon: "mdi:snowflake-thermometer"
-    internal: ${freezer_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} Wash Status"
-    id: ${prefix}_wash_status
-    icon: "mdi:dishwasher"
-    accuracy_decimals: 0
-    internal: ${dishwasher_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} Wash Cycle"
-    id: ${prefix}_wash_cycle
-    icon: "mdi:counter"
-    accuracy_decimals: 0
-    internal: ${dishwasher_sensors_internal}
-
-  # --- Range / Oven sensors ---
-  - platform: template
-    name: "${appliance_name} Oven Temperature"
-    id: ${prefix}_cav_temp
-    unit_of_measurement: "°F"
-    device_class: temperature
-    state_class: measurement
-    accuracy_decimals: 0
-    icon: "mdi:thermometer"
-    internal: ${range_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} Oven Set Temperature"
-    id: ${prefix}_cav_set_temp
-    unit_of_measurement: "°F"
-    device_class: temperature
-    state_class: measurement
-    accuracy_decimals: 0
-    icon: "mdi:thermometer-check"
-    internal: ${range_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} Cook Mode"
-    id: ${prefix}_cav_cook_mode
-    icon: "mdi:stove"
-    accuracy_decimals: 0
-    internal: ${range_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} Probe Temperature"
-    id: ${prefix}_probe_temp
-    unit_of_measurement: "°F"
-    device_class: temperature
-    state_class: measurement
-    accuracy_decimals: 0
-    icon: "mdi:thermometer-probe"
-    internal: ${range_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} Probe Set Temperature"
-    id: ${prefix}_probe_set_temp
-    unit_of_measurement: "°F"
-    device_class: temperature
-    state_class: measurement
-    accuracy_decimals: 0
-    icon: "mdi:thermometer-probe-off"
-    internal: ${range_sensors_internal}
-
   - platform: ble_client
     type: characteristic
     ble_client_id: ${prefix}_appliance
@@ -275,6 +145,8 @@ sensor:
       if (buf.capacity() < 2048) buf.reserve(2048);
       if (buf.size() > 4096) { buf.clear(); return {}; }
       buf.append((char*)x.data(), x.size());
+      // Any notification = connection alive (resets zombie detection)
+      id(${prefix}_poll_ok) = true;
       int depth = 0;
       bool complete = false;
       for (char c : buf) {
@@ -293,160 +165,9 @@ binary_sensor:
     device_class: door
 
   - platform: template
-    name: "${appliance_name} Sabbath Mode"
-    id: ${prefix}_sabbath_on
-    icon: "mdi:candelabra"
-    internal: ${sabbath_sensor_internal}
-
-  - platform: template
-    name: "${appliance_name} Freezer Door"
-    id: ${prefix}_frz_door_ajar
-    device_class: door
-    internal: ${freezer_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} Ice Maker"
-    id: ${prefix}_ice_maker
-    icon: "mdi:ice-cream"
-    internal: ${ice_maker_sensor_internal}
-
-  - platform: template
     name: "${appliance_name} Service Required"
     id: ${prefix}_svc_required
     device_class: problem
-
-  - platform: template
-    name: "${appliance_name} Wash Cycle Active"
-    id: ${prefix}_wash_cycle_on
-    icon: "mdi:dishwasher"
-    internal: ${dishwasher_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} Heated Dry"
-    id: ${prefix}_heated_dry
-    icon: "mdi:heat-wave"
-    internal: ${dishwasher_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} Extended Dry"
-    id: ${prefix}_extended_dry
-    icon: "mdi:heat-wave"
-    internal: ${dishwasher_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} High Temp Wash"
-    id: ${prefix}_high_temp_wash
-    icon: "mdi:thermometer-high"
-    internal: ${dishwasher_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} Sanitize Rinse"
-    id: ${prefix}_sani_rinse
-    icon: "mdi:hand-wash"
-    internal: ${dishwasher_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} Rinse Aid Low"
-    id: ${prefix}_rinse_aid_low
-    device_class: problem
-    internal: ${dishwasher_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} Light"
-    id: ${prefix}_light_on
-    icon: "mdi:lightbulb"
-    internal: ${dishwasher_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} Remote Ready"
-    id: ${prefix}_remote_ready
-    icon: "mdi:remote"
-    internal: ${dishwasher_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} Delay Start"
-    id: ${prefix}_delay_start
-    icon: "mdi:timer-sand"
-    internal: ${dishwasher_sensors_internal}
-
-  # --- Range / Oven binary sensors ---
-  - platform: template
-    name: "${appliance_name} Oven"
-    id: ${prefix}_cav_unit_on
-    icon: "mdi:stove"
-    internal: ${range_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} Oven At Temperature"
-    id: ${prefix}_cav_at_set_temp
-    icon: "mdi:thermometer-check"
-    internal: ${range_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} Oven Light"
-    id: ${prefix}_cav_light_on
-    icon: "mdi:lightbulb"
-    internal: ${range_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} Oven Remote Ready"
-    id: ${prefix}_cav_remote_ready
-    icon: "mdi:remote"
-    internal: ${range_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} Probe Inserted"
-    id: ${prefix}_cav_probe_on
-    icon: "mdi:thermometer-probe"
-    internal: ${range_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} Probe At Temperature"
-    id: ${prefix}_cav_probe_at_temp
-    icon: "mdi:thermometer-probe"
-    internal: ${range_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} Probe Within 10°"
-    id: ${prefix}_cav_probe_near
-    icon: "mdi:thermometer-probe"
-    internal: ${range_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} Gourmet Mode"
-    id: ${prefix}_cav_gourmet
-    icon: "mdi:chef-hat"
-    internal: ${range_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} Cook Timer Complete"
-    id: ${prefix}_cook_timer_done
-    icon: "mdi:timer-alert"
-    internal: ${range_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} Kitchen Timer Active"
-    id: ${prefix}_ktimer_active
-    icon: "mdi:timer"
-    internal: ${range_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} Kitchen Timer Complete"
-    id: ${prefix}_ktimer_done
-    icon: "mdi:timer-alert"
-    internal: ${range_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} Kitchen Timer 2 Active"
-    id: ${prefix}_ktimer2_active
-    icon: "mdi:timer"
-    internal: ${range_sensors_internal}
-
-  - platform: template
-    name: "${appliance_name} Kitchen Timer 2 Complete"
-    id: ${prefix}_ktimer2_done
-    icon: "mdi:timer-alert"
-    internal: ${range_sensors_internal}
 
 text_sensor:
   - platform: template
@@ -588,176 +309,80 @@ button:
     icon: "mdi:bluetooth-settings"
     entity_category: config
     on_press:
-      - logger.log: "[${appliance_name}] Removing bond..."
+      - logger.log: "[${appliance_name}] Full pairing reset..."
       - lambda: |-
           id(${prefix}_pin_confirmed) = false;
+          id(${prefix}_d5_handle) = 0;
+          id(${prefix}_d4_handle) = 0;
+          id(${prefix}_phase) = 0;
+          id(${prefix}_fast_retries) = 0;
+          id(${prefix}_poll_miss) = 0;
+          id(${prefix}_json_buf).clear();
           auto *client = id(${prefix}_appliance);
           esp_bd_addr_t addr;
           memcpy(addr, client->get_remote_bda(), 6);
+          // Clear GATT client cache
           esp_ble_gattc_cache_clean(addr);
+          // Remove bond from ESP-IDF BLE security manager
+          esp_ble_remove_bond_device(addr);
+          ESP_LOGW("ble", "[${appliance_name}] Bond removed, GATT cache cleared, all state reset");
       - ble_client.disconnect:
           id: ${prefix}_appliance
       - delay: 1s
       - ble_client.remove_bond:
           id: ${prefix}_appliance
       - lambda: |-
-          id(${prefix}_debug).publish_state("Pairing reset. Press Connect to re-pair.");
+          id(${prefix}_debug).publish_state("Pairing fully reset. Power-cycle appliance, then press Connect.");
 
 interval:
   - interval: 120s
     then:
+      - script.execute: ${prefix}_periodic_poll
+
+script:
+  # === Periodic poll — staggered to avoid concurrent BLE transfers ===
+  - id: ${prefix}_periodic_poll
+    mode: single
+    then:
+      - delay: ${poll_offset}
       - lambda: |-
           if (!id(${prefix}_pin_confirmed)) return;
           if (id(${prefix}_subscribe).is_running() || id(${prefix}_post_bond).is_running() || id(${prefix}_fast_reconnect).is_running()) return;
           uint16_t d5 = id(${prefix}_d5_handle);
           if (d5 == 0) return;
-          id(${prefix}_poll_ok) = false;
           auto *client = id(${prefix}_appliance);
+          if (!client->connected()) return;
+          // Zombie detection: no notifications since last poll interval
+          if (id(${prefix}_poll_ok)) {
+            id(${prefix}_poll_miss) = 0;
+          } else {
+            id(${prefix}_poll_miss) += 1;
+            if (id(${prefix}_poll_miss) >= 15) {
+              ESP_LOGW("szg", "[${appliance_name}] Connection stale (%d intervals, no data), forcing reconnect",
+                id(${prefix}_poll_miss));
+              id(${prefix}_poll_miss) = 0;
+              id(${prefix}_json_buf).clear();
+              id(${prefix}_debug).publish_state("Connection stale, reconnecting...");
+              client->disconnect();
+              return;
+            }
+          }
+          id(${prefix}_poll_ok) = false;
+          // Clear any stale partial JSON from interrupted previous transfer
+          id(${prefix}_json_buf).clear();
           std::string cmd = "{\"cmd\":\"get_async\"}\n";
-          esp_ble_gattc_write_char(
+          esp_err_t err = esp_ble_gattc_write_char(
             client->get_gattc_if(), client->get_conn_id(),
             d5, cmd.size(), (uint8_t*)cmd.data(),
             ESP_GATT_WRITE_TYPE_RSP, ESP_GATT_AUTH_REQ_NONE);
-          ESP_LOGD("szg", "[${appliance_name}] Periodic get_async");
-
-script:
-  # === JSON parser — runs in main loop (NOT in BLE callback) ===
-  - id: ${prefix}_parse_json
-    mode: single
-    then:
-      - lambda: |-
-          auto &buf = id(${prefix}_json_buf);
-          size_t start = buf.find('{');
-          if (start == std::string::npos) { buf.clear(); return; }
-          if (start > 0) buf.erase(0, start);
-          ESP_LOGI("szg", "[${appliance_name}] Parsing JSON (%d bytes)", buf.size());
-          if (buf.size() < 255) {
-            id(${prefix}_raw_json).publish_state(buf);
-          } else {
-            ESP_LOGI("szg", "[${appliance_name}] Response: %.200s...", buf.c_str());
+          if (err != ESP_OK) {
+            ESP_LOGW("szg", "[${appliance_name}] Write failed (err=%d), forcing reconnect", err);
+            id(${prefix}_debug).publish_state("Write failed, reconnecting...");
+            client->disconnect();
+            return;
           }
-          json::parse_json(buf, [](JsonObject root) -> bool {
-            // Determine data source: full poll ("resp") or push notification ("props")
-            JsonObject data;
-            if (root["status"].is<int>()) {
-              if (root["status"].as<int>() != 0) {
-                ESP_LOGW("szg", "[${appliance_name}] status=%d, skipping", root["status"].as<int>());
-                return false;
-              }
-              data = root["resp"].as<JsonObject>();
-            } else if (root["props"].is<JsonObject>()) {
-              data = root["props"].as<JsonObject>();
-              ESP_LOGD("szg", "[${appliance_name}] Push update (seq %d)", root["seq"].as<int>());
-            } else {
-              ESP_LOGW("szg", "[${appliance_name}] Unknown JSON format, skipping");
-              return false;
-            }
-            if (data.isNull()) return false;
-            // PIN confirmation (unlock_channel response)
-            if (data["pin"].is<const char*>()) {
-              const char *pin = data["pin"].as<const char*>();
-              if (pin && strlen(pin) <= 10) {
-                id(${prefix}_stored_pin) = pin;
-                id(${prefix}_pin_confirmed) = true;
-                id(${prefix}_pin_input).publish_state(pin);
-                ESP_LOGI("szg", "[${appliance_name}] PIN confirmed: %s", pin);
-                id(${prefix}_debug).publish_state("PIN confirmed! Channel unlocked.");
-              }
-            }
-            // --- Fridge sensors ---
-            if (data["ref_set_temp"].is<float>())
-              id(${prefix}_set_temp).publish_state(data["ref_set_temp"].as<float>());
-            // Door (fallback chain: ref_door_ajar -> door_ajar -> cav_door_ajar)
-            if (data["ref_door_ajar"].is<bool>())
-              id(${prefix}_door_ajar).publish_state(data["ref_door_ajar"].as<bool>());
-            else if (data["door_ajar"].is<bool>())
-              id(${prefix}_door_ajar).publish_state(data["door_ajar"].as<bool>());
-            else if (data["cav_door_ajar"].is<bool>())
-              id(${prefix}_door_ajar).publish_state(data["cav_door_ajar"].as<bool>());
-            // --- Freezer sensors ---
-            if (data["frz_set_temp"].is<float>())
-              id(${prefix}_frz_temp).publish_state(data["frz_set_temp"].as<float>());
-            if (data["frz_door_ajar"].is<bool>())
-              id(${prefix}_frz_door_ajar).publish_state(data["frz_door_ajar"].as<bool>());
-            if (data["ice_maker_on"].is<bool>())
-              id(${prefix}_ice_maker).publish_state(data["ice_maker_on"].as<bool>());
-            // --- Common sensors ---
-            if (data["sabbath_on"].is<bool>())
-              id(${prefix}_sabbath_on).publish_state(data["sabbath_on"].as<bool>());
-            if (data["service_required"].is<bool>())
-              id(${prefix}_svc_required).publish_state(data["service_required"].as<bool>());
-            // --- Dishwasher sensors ---
-            if (data["wash_cycle_on"].is<bool>())
-              id(${prefix}_wash_cycle_on).publish_state(data["wash_cycle_on"].as<bool>());
-            if (data["heated_dry_on"].is<bool>())
-              id(${prefix}_heated_dry).publish_state(data["heated_dry_on"].as<bool>());
-            if (data["extended_dry_on"].is<bool>())
-              id(${prefix}_extended_dry).publish_state(data["extended_dry_on"].as<bool>());
-            if (data["high_temp_wash_on"].is<bool>())
-              id(${prefix}_high_temp_wash).publish_state(data["high_temp_wash_on"].as<bool>());
-            if (data["sani_rinse_on"].is<bool>())
-              id(${prefix}_sani_rinse).publish_state(data["sani_rinse_on"].as<bool>());
-            if (data["rinse_aid_low"].is<bool>())
-              id(${prefix}_rinse_aid_low).publish_state(data["rinse_aid_low"].as<bool>());
-            if (data["light_on"].is<bool>())
-              id(${prefix}_light_on).publish_state(data["light_on"].as<bool>());
-            if (data["remote_ready"].is<bool>())
-              id(${prefix}_remote_ready).publish_state(data["remote_ready"].as<bool>());
-            if (data["delay_start_timer_active"].is<bool>())
-              id(${prefix}_delay_start).publish_state(data["delay_start_timer_active"].as<bool>());
-            if (data["wash_status"].is<float>())
-              id(${prefix}_wash_status).publish_state(data["wash_status"].as<float>());
-            if (data["wash_cycle"].is<float>())
-              id(${prefix}_wash_cycle).publish_state(data["wash_cycle"].as<float>());
-            // --- Range / Oven sensors ---
-            if (data["cav_unit_on"].is<bool>())
-              id(${prefix}_cav_unit_on).publish_state(data["cav_unit_on"].as<bool>());
-            if (data["cav_at_set_temp"].is<bool>())
-              id(${prefix}_cav_at_set_temp).publish_state(data["cav_at_set_temp"].as<bool>());
-            if (data["cav_light_on"].is<bool>())
-              id(${prefix}_cav_light_on).publish_state(data["cav_light_on"].as<bool>());
-            if (data["cav_remote_ready"].is<bool>())
-              id(${prefix}_cav_remote_ready).publish_state(data["cav_remote_ready"].as<bool>());
-            if (data["cav_probe_on"].is<bool>())
-              id(${prefix}_cav_probe_on).publish_state(data["cav_probe_on"].as<bool>());
-            if (data["cav_probe_at_set_temp"].is<bool>())
-              id(${prefix}_cav_probe_at_temp).publish_state(data["cav_probe_at_set_temp"].as<bool>());
-            if (data["cav_probe_within_10deg"].is<bool>())
-              id(${prefix}_cav_probe_near).publish_state(data["cav_probe_within_10deg"].as<bool>());
-            if (data["cav_gourmet_mode_on"].is<bool>())
-              id(${prefix}_cav_gourmet).publish_state(data["cav_gourmet_mode_on"].as<bool>());
-            if (data["cav_cook_timer_complete"].is<bool>())
-              id(${prefix}_cook_timer_done).publish_state(data["cav_cook_timer_complete"].as<bool>());
-            if (data["kitchen_timer_active"].is<bool>())
-              id(${prefix}_ktimer_active).publish_state(data["kitchen_timer_active"].as<bool>());
-            if (data["kitchen_timer_complete"].is<bool>())
-              id(${prefix}_ktimer_done).publish_state(data["kitchen_timer_complete"].as<bool>());
-            if (data["kitchen_timer2_active"].is<bool>())
-              id(${prefix}_ktimer2_active).publish_state(data["kitchen_timer2_active"].as<bool>());
-            if (data["kitchen_timer2_complete"].is<bool>())
-              id(${prefix}_ktimer2_done).publish_state(data["kitchen_timer2_complete"].as<bool>());
-            if (data["cav_temp"].is<float>())
-              id(${prefix}_cav_temp).publish_state(data["cav_temp"].as<float>());
-            if (data["cav_set_temp"].is<float>())
-              id(${prefix}_cav_set_temp).publish_state(data["cav_set_temp"].as<float>());
-            if (data["cav_cook_mode"].is<float>())
-              id(${prefix}_cav_cook_mode).publish_state(data["cav_cook_mode"].as<float>());
-            if (data["cav_probe_temp"].is<float>())
-              id(${prefix}_probe_temp).publish_state(data["cav_probe_temp"].as<float>());
-            if (data["cav_probe_set_temp"].is<float>())
-              id(${prefix}_probe_set_temp).publish_state(data["cav_probe_set_temp"].as<float>());
-            // --- Text sensors ---
-            if (data["appliance_model"].is<const char*>())
-              id(${prefix}_model).publish_state(data["appliance_model"].as<std::string>());
-            if (data["uptime"].is<const char*>())
-              id(${prefix}_uptime).publish_state(data["uptime"].as<std::string>());
-            return true;
-          });
-          if (buf.size() > 100) {
-            id(${prefix}_poll_ok) = true;
-            id(${prefix}_fast_retries) = 0;
-          }
-          buf.clear();
+          ESP_LOGI("szg", "[${appliance_name}] Periodic poll (miss=%d, retries=%d)",
+            id(${prefix}_poll_miss), id(${prefix}_fast_retries));
 
   - id: ${prefix}_post_bond
     mode: restart
@@ -907,7 +532,7 @@ script:
           memcpy(addr, client->get_remote_bda(), 6);
           esp_ble_set_encryption(addr, ESP_BLE_SEC_ENCRYPT_MITM);
           ESP_LOGI("ble", "[${appliance_name}] Fast reconnect: encryption requested");
-      - delay: 500ms
+      - delay: 1500ms
       - lambda: |-
           id(${prefix}_subscribe).execute();
 
@@ -927,7 +552,9 @@ script:
           id(${prefix}_d5_notify)->handle = d5;
           ESP_LOGI("ble", "[${appliance_name}] Injected D5 handle %d", d5);
           uint16_t d4 = id(${prefix}_d4_handle);
-          // register_for_notify handles CCCD subscription automatically
+          // register_for_notify for local callback, then manual CCCD write
+          // (fast reconnect GATT cache may be incomplete → register_for_notify
+          //  fails to find CCCD handle internally, so we write it directly)
           esp_ble_gattc_register_for_notify(
             client->get_gattc_if(), client->get_remote_bda(), d5);
           ESP_LOGI("ble", "[${appliance_name}] Subscribe D5 (h=%d)", d5);
@@ -935,6 +562,21 @@ script:
             esp_ble_gattc_register_for_notify(
               client->get_gattc_if(), client->get_remote_bda(), d4);
             ESP_LOGI("ble", "[${appliance_name}] Subscribe D4 (h=%d) for diagnostics", d4);
+          }
+          // Manually write CCCD enable value (0x0002 = indications on)
+          // CCCD descriptor is at char_value_handle + 2 (standard BLE layout)
+          uint8_t cccd_on[2] = {0x02, 0x00};
+          esp_ble_gattc_write_char(
+            client->get_gattc_if(), client->get_conn_id(),
+            d5 + 2, sizeof(cccd_on), cccd_on,
+            ESP_GATT_WRITE_TYPE_RSP, ESP_GATT_AUTH_REQ_NONE);
+          ESP_LOGI("ble", "[${appliance_name}] CCCD write D5 (h=%d)", d5 + 2);
+          if (d4 > 0) {
+            esp_ble_gattc_write_char(
+              client->get_gattc_if(), client->get_conn_id(),
+              d4 + 2, sizeof(cccd_on), cccd_on,
+              ESP_GATT_WRITE_TYPE_RSP, ESP_GATT_AUTH_REQ_NONE);
+            ESP_LOGI("ble", "[${appliance_name}] CCCD write D4 (h=%d)", d4 + 2);
           }
           id(${prefix}_json_buf).clear();
       - delay: 500ms
@@ -954,7 +596,7 @@ script:
             ESP_GATT_WRITE_TYPE_RSP, ESP_GATT_AUTH_REQ_NONE);
           ESP_LOGI("ble", "[${appliance_name}] Auto-unlock (PIN=%s) err=%d", pin.c_str(), err);
           id(${prefix}_debug).publish_state("Auto-unlocking...");
-      - delay: 500ms
+      - delay: 1s
       - lambda: |-
           if (!id(${prefix}_pin_confirmed)) return;
           auto *client = id(${prefix}_appliance);

--- a/subzero_dishwasher.yaml
+++ b/subzero_dishwasher.yaml
@@ -1,0 +1,157 @@
+# Cove Dishwasher BLE Package
+# Include with vars: prefix, appliance_name, appliance_mac, appliance_pin
+#
+# Example:
+#   packages:
+#     right_dishwasher: !include
+#       file: subzero_dishwasher.yaml
+#       vars:
+#         prefix: "szg"
+#         appliance_name: "Right Dishwasher"
+#         appliance_mac: !secret right_dishwasher_mac
+#         appliance_pin: !secret right_dishwasher_pin
+
+packages:
+  base: !include subzero_base.yaml
+
+sensor:
+  - platform: template
+    name: "${appliance_name} Wash Status"
+    id: ${prefix}_wash_status
+    icon: "mdi:dishwasher"
+    accuracy_decimals: 0
+
+  - platform: template
+    name: "${appliance_name} Wash Cycle"
+    id: ${prefix}_wash_cycle
+    icon: "mdi:counter"
+    accuracy_decimals: 0
+
+binary_sensor:
+  - platform: template
+    name: "${appliance_name} Wash Cycle Active"
+    id: ${prefix}_wash_cycle_on
+    icon: "mdi:dishwasher"
+
+  - platform: template
+    name: "${appliance_name} Heated Dry"
+    id: ${prefix}_heated_dry
+    icon: "mdi:heat-wave"
+
+  - platform: template
+    name: "${appliance_name} Extended Dry"
+    id: ${prefix}_extended_dry
+    icon: "mdi:heat-wave"
+
+  - platform: template
+    name: "${appliance_name} High Temp Wash"
+    id: ${prefix}_high_temp_wash
+    icon: "mdi:thermometer-high"
+
+  - platform: template
+    name: "${appliance_name} Sanitize Rinse"
+    id: ${prefix}_sani_rinse
+    icon: "mdi:hand-wash"
+
+  - platform: template
+    name: "${appliance_name} Rinse Aid Low"
+    id: ${prefix}_rinse_aid_low
+    device_class: problem
+
+  - platform: template
+    name: "${appliance_name} Light"
+    id: ${prefix}_light_on
+    icon: "mdi:lightbulb"
+
+  - platform: template
+    name: "${appliance_name} Remote Ready"
+    id: ${prefix}_remote_ready
+    icon: "mdi:remote"
+
+  - platform: template
+    name: "${appliance_name} Delay Start"
+    id: ${prefix}_delay_start
+    icon: "mdi:timer-sand"
+
+script:
+  - id: ${prefix}_parse_json
+    mode: single
+    then:
+      - lambda: |-
+          auto &buf = id(${prefix}_json_buf);
+          size_t start = buf.find('{');
+          if (start == std::string::npos) { buf.clear(); return; }
+          if (start > 0) buf.erase(0, start);
+          ESP_LOGI("szg", "[${appliance_name}] Parsing JSON (%d bytes)", buf.size());
+          if (buf.size() < 255) {
+            id(${prefix}_raw_json).publish_state(buf);
+          } else {
+            ESP_LOGI("szg", "[${appliance_name}] Response: %.200s...", buf.c_str());
+          }
+          json::parse_json(buf, [](JsonObject root) -> bool {
+            // Determine data source: full poll ("resp") or push notification ("props")
+            JsonObject data;
+            if (root["status"].is<int>()) {
+              if (root["status"].as<int>() != 0) {
+                ESP_LOGW("szg", "[${appliance_name}] status=%d, skipping", root["status"].as<int>());
+                return false;
+              }
+              data = root["resp"].as<JsonObject>();
+            } else if (root["props"].is<JsonObject>()) {
+              data = root["props"].as<JsonObject>();
+              ESP_LOGD("szg", "[${appliance_name}] Push update (seq %d)", root["seq"].as<int>());
+            } else {
+              ESP_LOGW("szg", "[${appliance_name}] Unknown JSON format, skipping");
+              return false;
+            }
+            if (data.isNull()) return false;
+            // PIN confirmation (unlock_channel response)
+            if (data["pin"].is<const char*>()) {
+              const char *pin = data["pin"].as<const char*>();
+              if (pin && strlen(pin) <= 10) {
+                id(${prefix}_stored_pin) = pin;
+                id(${prefix}_pin_confirmed) = true;
+                id(${prefix}_pin_input).publish_state(pin);
+                ESP_LOGI("szg", "[${appliance_name}] PIN confirmed: %s", pin);
+                id(${prefix}_debug).publish_state("PIN confirmed! Channel unlocked.");
+              }
+            }
+            // Door (fallback: door_ajar)
+            if (data["door_ajar"].is<bool>())
+              id(${prefix}_door_ajar).publish_state(data["door_ajar"].as<bool>());
+            // --- Dishwasher sensors ---
+            if (data["wash_cycle_on"].is<bool>())
+              id(${prefix}_wash_cycle_on).publish_state(data["wash_cycle_on"].as<bool>());
+            if (data["heated_dry_on"].is<bool>())
+              id(${prefix}_heated_dry).publish_state(data["heated_dry_on"].as<bool>());
+            if (data["extended_dry_on"].is<bool>())
+              id(${prefix}_extended_dry).publish_state(data["extended_dry_on"].as<bool>());
+            if (data["high_temp_wash_on"].is<bool>())
+              id(${prefix}_high_temp_wash).publish_state(data["high_temp_wash_on"].as<bool>());
+            if (data["sani_rinse_on"].is<bool>())
+              id(${prefix}_sani_rinse).publish_state(data["sani_rinse_on"].as<bool>());
+            if (data["rinse_aid_low"].is<bool>())
+              id(${prefix}_rinse_aid_low).publish_state(data["rinse_aid_low"].as<bool>());
+            if (data["light_on"].is<bool>())
+              id(${prefix}_light_on).publish_state(data["light_on"].as<bool>());
+            if (data["remote_ready"].is<bool>())
+              id(${prefix}_remote_ready).publish_state(data["remote_ready"].as<bool>());
+            if (data["delay_start_timer_active"].is<bool>())
+              id(${prefix}_delay_start).publish_state(data["delay_start_timer_active"].as<bool>());
+            if (data["wash_status"].is<float>())
+              id(${prefix}_wash_status).publish_state(data["wash_status"].as<float>());
+            if (data["wash_cycle"].is<float>())
+              id(${prefix}_wash_cycle).publish_state(data["wash_cycle"].as<float>());
+            // --- Common sensors ---
+            if (data["service_required"].is<bool>())
+              id(${prefix}_svc_required).publish_state(data["service_required"].as<bool>());
+            // --- Text sensors ---
+            if (data["appliance_model"].is<const char*>())
+              id(${prefix}_model).publish_state(data["appliance_model"].as<std::string>());
+            if (data["uptime"].is<const char*>())
+              id(${prefix}_uptime).publish_state(data["uptime"].as<std::string>());
+            return true;
+          });
+          id(${prefix}_poll_ok) = true;
+          id(${prefix}_fast_retries) = 0;
+          buf.clear();

--- a/subzero_fridge.yaml
+++ b/subzero_fridge.yaml
@@ -1,0 +1,149 @@
+# Sub-Zero Fridge/Freezer BLE Package
+# Include with vars: prefix, appliance_name, appliance_mac, appliance_pin
+# Optional vars:
+#   hide_freezer: "true" to hide freezer temp & door (default: "false")
+#   hide_ice_maker: "true" to hide ice maker (default: "false")
+#   hide_sabbath: "true" to hide sabbath mode (default: "false")
+#
+# Example (fridge/freezer combo — all sensors exposed):
+#   packages:
+#     main_fridge: !include
+#       file: subzero_fridge.yaml
+#       vars:
+#         prefix: "szg"
+#         appliance_name: "Main Fridge"
+#         appliance_mac: !secret main_fridge_mac
+#         appliance_pin: !secret main_fridge_pin
+#
+# Example (fridge-only — no freezer or ice maker):
+#   packages:
+#     basement_fridge: !include
+#       file: subzero_fridge.yaml
+#       vars:
+#         prefix: "szg"
+#         appliance_name: "Basement Fridge"
+#         appliance_mac: !secret basement_fridge_mac
+#         appliance_pin: !secret basement_fridge_pin
+#         hide_freezer: "true"
+#         hide_ice_maker: "true"
+
+substitutions:
+  hide_freezer: "false"
+  hide_ice_maker: "false"
+  hide_sabbath: "false"
+
+packages:
+  base: !include subzero_base.yaml
+
+sensor:
+  - platform: template
+    name: "${appliance_name} Set Temperature"
+    id: ${prefix}_set_temp
+    unit_of_measurement: "°F"
+    device_class: temperature
+    state_class: measurement
+    accuracy_decimals: 0
+    icon: "mdi:thermometer"
+
+  - platform: template
+    name: "${appliance_name} Freezer Temperature"
+    id: ${prefix}_frz_temp
+    unit_of_measurement: "°F"
+    device_class: temperature
+    state_class: measurement
+    accuracy_decimals: 0
+    icon: "mdi:snowflake-thermometer"
+    internal: ${hide_freezer}
+
+binary_sensor:
+  - platform: template
+    name: "${appliance_name} Sabbath Mode"
+    id: ${prefix}_sabbath_on
+    icon: "mdi:candelabra"
+    internal: ${hide_sabbath}
+
+  - platform: template
+    name: "${appliance_name} Freezer Door"
+    id: ${prefix}_frz_door_ajar
+    device_class: door
+    internal: ${hide_freezer}
+
+  - platform: template
+    name: "${appliance_name} Ice Maker"
+    id: ${prefix}_ice_maker
+    icon: "mdi:ice-cream"
+    internal: ${hide_ice_maker}
+
+script:
+  - id: ${prefix}_parse_json
+    mode: single
+    then:
+      - lambda: |-
+          auto &buf = id(${prefix}_json_buf);
+          size_t start = buf.find('{');
+          if (start == std::string::npos) { buf.clear(); return; }
+          if (start > 0) buf.erase(0, start);
+          ESP_LOGI("szg", "[${appliance_name}] Parsing JSON (%d bytes)", buf.size());
+          if (buf.size() < 255) {
+            id(${prefix}_raw_json).publish_state(buf);
+          } else {
+            ESP_LOGI("szg", "[${appliance_name}] Response: %.200s...", buf.c_str());
+          }
+          json::parse_json(buf, [](JsonObject root) -> bool {
+            // Determine data source: full poll ("resp") or push notification ("props")
+            JsonObject data;
+            if (root["status"].is<int>()) {
+              if (root["status"].as<int>() != 0) {
+                ESP_LOGW("szg", "[${appliance_name}] status=%d, skipping", root["status"].as<int>());
+                return false;
+              }
+              data = root["resp"].as<JsonObject>();
+            } else if (root["props"].is<JsonObject>()) {
+              data = root["props"].as<JsonObject>();
+              ESP_LOGD("szg", "[${appliance_name}] Push update (seq %d)", root["seq"].as<int>());
+            } else {
+              ESP_LOGW("szg", "[${appliance_name}] Unknown JSON format, skipping");
+              return false;
+            }
+            if (data.isNull()) return false;
+            // PIN confirmation (unlock_channel response)
+            if (data["pin"].is<const char*>()) {
+              const char *pin = data["pin"].as<const char*>();
+              if (pin && strlen(pin) <= 10) {
+                id(${prefix}_stored_pin) = pin;
+                id(${prefix}_pin_confirmed) = true;
+                id(${prefix}_pin_input).publish_state(pin);
+                ESP_LOGI("szg", "[${appliance_name}] PIN confirmed: %s", pin);
+                id(${prefix}_debug).publish_state("PIN confirmed! Channel unlocked.");
+              }
+            }
+            // --- Fridge sensors ---
+            if (data["ref_set_temp"].is<float>())
+              id(${prefix}_set_temp).publish_state(data["ref_set_temp"].as<float>());
+            // Door (fallback chain: ref_door_ajar -> door_ajar)
+            if (data["ref_door_ajar"].is<bool>())
+              id(${prefix}_door_ajar).publish_state(data["ref_door_ajar"].as<bool>());
+            else if (data["door_ajar"].is<bool>())
+              id(${prefix}_door_ajar).publish_state(data["door_ajar"].as<bool>());
+            // --- Freezer sensors ---
+            if (data["frz_set_temp"].is<float>())
+              id(${prefix}_frz_temp).publish_state(data["frz_set_temp"].as<float>());
+            if (data["frz_door_ajar"].is<bool>())
+              id(${prefix}_frz_door_ajar).publish_state(data["frz_door_ajar"].as<bool>());
+            if (data["ice_maker_on"].is<bool>())
+              id(${prefix}_ice_maker).publish_state(data["ice_maker_on"].as<bool>());
+            // --- Common sensors ---
+            if (data["sabbath_on"].is<bool>())
+              id(${prefix}_sabbath_on).publish_state(data["sabbath_on"].as<bool>());
+            if (data["service_required"].is<bool>())
+              id(${prefix}_svc_required).publish_state(data["service_required"].as<bool>());
+            // --- Text sensors ---
+            if (data["appliance_model"].is<const char*>())
+              id(${prefix}_model).publish_state(data["appliance_model"].as<std::string>());
+            if (data["uptime"].is<const char*>())
+              id(${prefix}_uptime).publish_state(data["uptime"].as<std::string>());
+            return true;
+          });
+          id(${prefix}_poll_ok) = true;
+          id(${prefix}_fast_retries) = 0;
+          buf.clear();

--- a/subzero_range.yaml
+++ b/subzero_range.yaml
@@ -1,0 +1,230 @@
+# Wolf Range/Oven BLE Package
+# Include with vars: prefix, appliance_name, appliance_mac, appliance_pin
+#
+# Example:
+#   packages:
+#     kitchen_range: !include
+#       file: subzero_range.yaml
+#       vars:
+#         prefix: "szg"
+#         appliance_name: "Kitchen Range"
+#         appliance_mac: !secret kitchen_range_mac
+#         appliance_pin: !secret kitchen_range_pin
+
+packages:
+  base: !include subzero_base.yaml
+
+sensor:
+  - platform: template
+    name: "${appliance_name} Oven Temperature"
+    id: ${prefix}_cav_temp
+    unit_of_measurement: "°F"
+    device_class: temperature
+    state_class: measurement
+    accuracy_decimals: 0
+    icon: "mdi:thermometer"
+
+  - platform: template
+    name: "${appliance_name} Oven Set Temperature"
+    id: ${prefix}_cav_set_temp
+    unit_of_measurement: "°F"
+    device_class: temperature
+    state_class: measurement
+    accuracy_decimals: 0
+    icon: "mdi:thermometer-check"
+
+  - platform: template
+    name: "${appliance_name} Cook Mode"
+    id: ${prefix}_cav_cook_mode
+    icon: "mdi:stove"
+    accuracy_decimals: 0
+
+  - platform: template
+    name: "${appliance_name} Probe Temperature"
+    id: ${prefix}_probe_temp
+    unit_of_measurement: "°F"
+    device_class: temperature
+    state_class: measurement
+    accuracy_decimals: 0
+    icon: "mdi:thermometer-probe"
+
+  - platform: template
+    name: "${appliance_name} Probe Set Temperature"
+    id: ${prefix}_probe_set_temp
+    unit_of_measurement: "°F"
+    device_class: temperature
+    state_class: measurement
+    accuracy_decimals: 0
+    icon: "mdi:thermometer-probe-off"
+
+binary_sensor:
+  - platform: template
+    name: "${appliance_name} Sabbath Mode"
+    id: ${prefix}_sabbath_on
+    icon: "mdi:candelabra"
+
+  - platform: template
+    name: "${appliance_name} Oven"
+    id: ${prefix}_cav_unit_on
+    icon: "mdi:stove"
+
+  - platform: template
+    name: "${appliance_name} Oven At Temperature"
+    id: ${prefix}_cav_at_set_temp
+    icon: "mdi:thermometer-check"
+
+  - platform: template
+    name: "${appliance_name} Oven Light"
+    id: ${prefix}_cav_light_on
+    icon: "mdi:lightbulb"
+
+  - platform: template
+    name: "${appliance_name} Oven Remote Ready"
+    id: ${prefix}_cav_remote_ready
+    icon: "mdi:remote"
+
+  - platform: template
+    name: "${appliance_name} Probe Inserted"
+    id: ${prefix}_cav_probe_on
+    icon: "mdi:thermometer-probe"
+
+  - platform: template
+    name: "${appliance_name} Probe At Temperature"
+    id: ${prefix}_cav_probe_at_temp
+    icon: "mdi:thermometer-probe"
+
+  - platform: template
+    name: "${appliance_name} Probe Within 10°"
+    id: ${prefix}_cav_probe_near
+    icon: "mdi:thermometer-probe"
+
+  - platform: template
+    name: "${appliance_name} Gourmet Mode"
+    id: ${prefix}_cav_gourmet
+    icon: "mdi:chef-hat"
+
+  - platform: template
+    name: "${appliance_name} Cook Timer Complete"
+    id: ${prefix}_cook_timer_done
+    icon: "mdi:timer-alert"
+
+  - platform: template
+    name: "${appliance_name} Kitchen Timer Active"
+    id: ${prefix}_ktimer_active
+    icon: "mdi:timer"
+
+  - platform: template
+    name: "${appliance_name} Kitchen Timer Complete"
+    id: ${prefix}_ktimer_done
+    icon: "mdi:timer-alert"
+
+  - platform: template
+    name: "${appliance_name} Kitchen Timer 2 Active"
+    id: ${prefix}_ktimer2_active
+    icon: "mdi:timer"
+
+  - platform: template
+    name: "${appliance_name} Kitchen Timer 2 Complete"
+    id: ${prefix}_ktimer2_done
+    icon: "mdi:timer-alert"
+
+script:
+  - id: ${prefix}_parse_json
+    mode: single
+    then:
+      - lambda: |-
+          auto &buf = id(${prefix}_json_buf);
+          size_t start = buf.find('{');
+          if (start == std::string::npos) { buf.clear(); return; }
+          if (start > 0) buf.erase(0, start);
+          ESP_LOGI("szg", "[${appliance_name}] Parsing JSON (%d bytes)", buf.size());
+          if (buf.size() < 255) {
+            id(${prefix}_raw_json).publish_state(buf);
+          } else {
+            ESP_LOGI("szg", "[${appliance_name}] Response: %.200s...", buf.c_str());
+          }
+          json::parse_json(buf, [](JsonObject root) -> bool {
+            // Determine data source: full poll ("resp") or push notification ("props")
+            JsonObject data;
+            if (root["status"].is<int>()) {
+              if (root["status"].as<int>() != 0) {
+                ESP_LOGW("szg", "[${appliance_name}] status=%d, skipping", root["status"].as<int>());
+                return false;
+              }
+              data = root["resp"].as<JsonObject>();
+            } else if (root["props"].is<JsonObject>()) {
+              data = root["props"].as<JsonObject>();
+              ESP_LOGD("szg", "[${appliance_name}] Push update (seq %d)", root["seq"].as<int>());
+            } else {
+              ESP_LOGW("szg", "[${appliance_name}] Unknown JSON format, skipping");
+              return false;
+            }
+            if (data.isNull()) return false;
+            // PIN confirmation (unlock_channel response)
+            if (data["pin"].is<const char*>()) {
+              const char *pin = data["pin"].as<const char*>();
+              if (pin && strlen(pin) <= 10) {
+                id(${prefix}_stored_pin) = pin;
+                id(${prefix}_pin_confirmed) = true;
+                id(${prefix}_pin_input).publish_state(pin);
+                ESP_LOGI("szg", "[${appliance_name}] PIN confirmed: %s", pin);
+                id(${prefix}_debug).publish_state("PIN confirmed! Channel unlocked.");
+              }
+            }
+            // Door (fallback: cav_door_ajar -> door_ajar)
+            if (data["cav_door_ajar"].is<bool>())
+              id(${prefix}_door_ajar).publish_state(data["cav_door_ajar"].as<bool>());
+            else if (data["door_ajar"].is<bool>())
+              id(${prefix}_door_ajar).publish_state(data["door_ajar"].as<bool>());
+            // --- Range / Oven sensors ---
+            if (data["cav_unit_on"].is<bool>())
+              id(${prefix}_cav_unit_on).publish_state(data["cav_unit_on"].as<bool>());
+            if (data["cav_at_set_temp"].is<bool>())
+              id(${prefix}_cav_at_set_temp).publish_state(data["cav_at_set_temp"].as<bool>());
+            if (data["cav_light_on"].is<bool>())
+              id(${prefix}_cav_light_on).publish_state(data["cav_light_on"].as<bool>());
+            if (data["cav_remote_ready"].is<bool>())
+              id(${prefix}_cav_remote_ready).publish_state(data["cav_remote_ready"].as<bool>());
+            if (data["cav_probe_on"].is<bool>())
+              id(${prefix}_cav_probe_on).publish_state(data["cav_probe_on"].as<bool>());
+            if (data["cav_probe_at_set_temp"].is<bool>())
+              id(${prefix}_cav_probe_at_temp).publish_state(data["cav_probe_at_set_temp"].as<bool>());
+            if (data["cav_probe_within_10deg"].is<bool>())
+              id(${prefix}_cav_probe_near).publish_state(data["cav_probe_within_10deg"].as<bool>());
+            if (data["cav_gourmet_mode_on"].is<bool>())
+              id(${prefix}_cav_gourmet).publish_state(data["cav_gourmet_mode_on"].as<bool>());
+            if (data["cav_cook_timer_complete"].is<bool>())
+              id(${prefix}_cook_timer_done).publish_state(data["cav_cook_timer_complete"].as<bool>());
+            if (data["kitchen_timer_active"].is<bool>())
+              id(${prefix}_ktimer_active).publish_state(data["kitchen_timer_active"].as<bool>());
+            if (data["kitchen_timer_complete"].is<bool>())
+              id(${prefix}_ktimer_done).publish_state(data["kitchen_timer_complete"].as<bool>());
+            if (data["kitchen_timer2_active"].is<bool>())
+              id(${prefix}_ktimer2_active).publish_state(data["kitchen_timer2_active"].as<bool>());
+            if (data["kitchen_timer2_complete"].is<bool>())
+              id(${prefix}_ktimer2_done).publish_state(data["kitchen_timer2_complete"].as<bool>());
+            if (data["cav_temp"].is<float>())
+              id(${prefix}_cav_temp).publish_state(data["cav_temp"].as<float>());
+            if (data["cav_set_temp"].is<float>())
+              id(${prefix}_cav_set_temp).publish_state(data["cav_set_temp"].as<float>());
+            if (data["cav_cook_mode"].is<float>())
+              id(${prefix}_cav_cook_mode).publish_state(data["cav_cook_mode"].as<float>());
+            if (data["cav_probe_temp"].is<float>())
+              id(${prefix}_probe_temp).publish_state(data["cav_probe_temp"].as<float>());
+            if (data["cav_probe_set_temp"].is<float>())
+              id(${prefix}_probe_set_temp).publish_state(data["cav_probe_set_temp"].as<float>());
+            // --- Common sensors ---
+            if (data["sabbath_on"].is<bool>())
+              id(${prefix}_sabbath_on).publish_state(data["sabbath_on"].as<bool>());
+            if (data["service_required"].is<bool>())
+              id(${prefix}_svc_required).publish_state(data["service_required"].as<bool>());
+            // --- Text sensors ---
+            if (data["appliance_model"].is<const char*>())
+              id(${prefix}_model).publish_state(data["appliance_model"].as<std::string>());
+            if (data["uptime"].is<const char*>())
+              id(${prefix}_uptime).publish_state(data["uptime"].as<std::string>());
+            return true;
+          });
+          id(${prefix}_poll_ok) = true;
+          id(${prefix}_fast_retries) = 0;
+          buf.clear();

--- a/wolf-minimal-range.yaml
+++ b/wolf-minimal-range.yaml
@@ -8,18 +8,12 @@ substitutions:
 
 packages:
   kitchen_range: !include
-    file: subzero_appliance.yaml
+    file: subzero_range.yaml
     vars:
       prefix: "szg"
       appliance_name: "Kitchen Range"
       appliance_mac: !secret kitchen_range_mac
       appliance_pin: !secret kitchen_range_pin
-      fridge_sensors_internal: "true"
-      freezer_sensors_internal: "true"
-      ice_maker_sensor_internal: "true"
-      sabbath_sensor_internal: "true"
-      dishwasher_sensors_internal: "true"
-      range_sensors_internal: "false"
 
 esphome:
   name: ${name}
@@ -33,6 +27,13 @@ esp32:
     version: 5.5.3.1
     sdkconfig_options:
       CONFIG_BT_GATTC_CACHE_NVS_FLASH: "n"
+      # The options below are only needed when running 2+ concurrent BLE
+      # appliance connections. They increase the max connection count (default 3)
+      # and enlarge the ACL buffer pool to avoid dropping indication fragments
+      # during rapid 40-byte JSON transfers across multiple connections.
+      # CONFIG_BT_ACL_CONNECTIONS: "4"
+      # CONFIG_BT_BLE_ACL_BUF_COUNT: "20"
+      # CONFIG_BT_BLE_ACL_BUF_SIZE: "255"
 
 logger:
   level: DEBUG


### PR DESCRIPTION
split `subzero_appliance.yaml` into a base + three appliance-type packages:
- `subzero_base.yaml` — shared BLE connection logic, globals, scripts, buttons
- `subzero_fridge.yaml` — Sub-Zero refrigerator/freezer sensors + JSON parser
- `subzero_dishwasher.yaml` — Cove dishwasher sensors + JSON parser
- `subzero_range.yaml` — Wolf range/oven sensors + JSON parser

each type package includes only the sensors relevant to that appliance, eliminating the `*_sensors_internal` toggle pattern. Device configs now reference the specific type file instead of the monolithic one. the previous sensor toggle pattern was confusing and poorly named, the new way has clearer named boolean values

also updates README with new file structure, BLE stack tuning docs (sdkconfig_options for multi-appliance setups), and corrects BLE security docs (Legacy Pairing, not Secure Connections).