### PR TITLE
feat: add wine fridge (IW30R) support and correct BLE protocol docs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -178,7 +178,21 @@ vars:
 | `hide_freezer` | `"false"` | Freezer Temperature, Freezer Door
 | `hide_ice_maker` | `"false"` | Ice Maker
 | `hide_sabbath` | `"false"` | Sabbath Mode
+| `hide_wine` | `"true"` | Wine Door, Wine Zone Upper Temperature, Wine Zone Lower Temperature, Wine Temperature Alert
 |===
+
+.Wine Fridge (dual-zone, no freezer or ice maker)
+[source,yaml]
+----
+vars:
+  prefix: "szg"
+  appliance_name: "Wine Fridge"
+  appliance_mac: "00:06:80:XX:XX:XX"
+  appliance_pin: "123456"
+  hide_freezer: "true"
+  hide_ice_maker: "true"
+  hide_wine: "false"
+----
 
 === 3. Compile and Flash
 
@@ -247,6 +261,10 @@ TIP: Sub-Zero appliance BLE MAC addresses typically start with `00:06:80`. You c
 | *Freezer Door* | Open/closed binary sensor _(optional)_
 | *Ice Maker* | On/off binary sensor _(optional)_
 | *Sabbath Mode* | On/off binary sensor _(optional)_
+| *Wine Door* | Open/closed binary sensor _(optional)_
+| *Wine Zone Upper Temperature* | Upper zone setpoint (°F) _(optional)_
+| *Wine Zone Lower Temperature* | Lower zone setpoint (°F) _(optional)_
+| *Wine Temperature Alert* | Temperature alert binary sensor _(optional)_
 | *Service Required* | Alerts when the appliance flags a service need
 | *Appliance Model* | Model number (e.g. `DEU2450R`, `313`)
 | *Appliance Uptime* | Time since last power cycle
@@ -316,6 +334,7 @@ TIP: Sub-Zero appliance BLE MAC addresses typically start with `00:06:80`. You c
 | Cove | DW2450 | Dishwasher | Fully working
 | Wolf | DF36450GSP | Dual-fuel range | Fully working
 | Wolf | SO3050PESP | Wall oven | Fully working
+| Sub-Zero | IW30R | Wine storage (dual-zone) | Fully working
 |===
 
 Other Sub-Zero, Wolf, and Cove appliances with BLE should work - they all use the same protocol. If you test with a different model, please open an issue or PR to update this table. See link:docs/advanced.adoc#_debug_mode[Debug Mode] for how to capture your appliance's data.

--- a/docs/advanced.adoc
+++ b/docs/advanced.adoc
@@ -149,11 +149,11 @@ Dishwashers and ranges respond to polls on the D5 (encrypted) channel with their
 
 Fridges behave differently from dishwashers and ranges. They have 5 BLE characteristics (D4-D8) instead of 2 (D4-D5), and the command routing is different:
 
-* *D4* (open channel) - responds to `get_async` with basic diagnostic data (model, doors, uptime)
-* *D5* (encrypted channel) - sends *push notifications* for state changes but does not respond to poll commands
+* *D4* (open channel) - responds to `get_async` with basic diagnostic data (model, doors, uptime), no unlock needed
+* *D5* (encrypted channel) - responds to `get_async` with the full appliance state after a fresh `unlock_channel`, but the unlock session expires after some time (possibly hours); push notifications continue regardless of session state
 * *D6-D8* - accept writes but do not respond
 
-Because of this, capturing the full set of keys from a fridge requires two steps:
+The *Log Debug Info* button polls D4, which always works without an unlock session. To capture the full set of keys from a fridge:
 
 . Press *Log Debug Info* - this polls D4 and logs the basic diagnostic keys.
 . *Interact with the appliance* - open/close doors, change the set temperature on the panel, toggle the ice maker, etc. Each change triggers a push notification on D5 with the relevant keys, which debug mode captures and logs.

--- a/docs/ble-protocol.adoc
+++ b/docs/ble-protocol.adoc
@@ -39,26 +39,26 @@ The characteristics serve different roles depending on the appliance type:
 
 | *D4*
 | Open (unencrypted) diagnostic channel
-| Open channel — responds to `get_async` with basic diagnostic data; also mirrors D5 push notifications with `msg_types: 8`
+| Open channel - responds to `get_async` with basic diagnostic data; also mirrors D5 push notifications with `msg_types: 8`
 
 | *D5*
-| Encrypted command/response channel — handles `unlock_channel`, `get_async`, `display_pin`, and delivers push notifications
-| Encrypted channel — delivers push notifications (`msg_types: 2`) for state changes, but *does not respond* to poll commands (`get_async`, `get`)
+| Encrypted command/response channel - handles `unlock_channel`, `get_async`, `display_pin`, and delivers push notifications
+| Encrypted channel - delivers push notifications (`msg_types: 2`) for state changes; also responds to `get_async` after a successful `unlock_channel`, but the unlock session expires after some time (possibly hours), after which command responses stop until a fresh unlock is performed
 
 | *D6*
 | _Not present_
-| Encrypted channel — accepts writes, no observed responses
+| Encrypted channel - accepts writes, no observed responses
 
 | *D7*
 | _Not present_
-| Open channel — accepts writes, no observed responses
+| Open channel - accepts writes, no observed responses
 
 | *D8*
 | _Not present_
-| Open channel — accepts writes, no observed responses
+| Open channel - accepts writes, no observed responses
 |===
 
-NOTE: The behavioral differences may be related to firmware versions. Tested fridges run API 5.4 / fw 8.5, while tested dishwashers and ranges run API 5.5 / fw 2.27. It is unknown whether newer fridge firmware versions behave like dishwashers/ranges.
+NOTE: Firmware versions are model-dependent, not simply split by appliance category. The Sub-Zero 313 fridge and Wolf SO3050PESP wall oven both run API 5.4 / fw 8.5, while the Sub-Zero IW30R wine fridge, Cove dishwashers, and Wolf ranges run API 5.5 / fw 2.27.
 
 == Connection & Authentication Flow
 
@@ -98,10 +98,10 @@ The full handshake follows these steps (shown for dishwashers/ranges where D5 is
 
 Fridges follow the same connection and bonding flow, but command/response routing differs:
 
-* *Polling:* `get_async` must be sent to *D4* (not D5). The response contains basic diagnostic data (model, door status, uptime) but not the full sensor state.
-* *Sensor data:* Full sensor data (set temperatures, ice maker status, sabbath mode, etc.) arrives via *D5 push notifications* triggered by state changes on the appliance — not via polling.
+* *D4 polling:* `get_async` on *D4* works without an unlock and returns basic diagnostic data (model, door status, uptime) but not the full sensor state.
+* *D5 polling:* `get_async` on *D5* returns the full sensor state (set temperatures, ice maker status, sabbath mode, wine zones, etc.) *after a successful `unlock_channel`*. However, the unlock session appears to expire after some time (possibly hours). After expiry, writes to D5 are still accepted (GATT write status 0) but produce no indication response - a fresh `unlock_channel` restores command functionality.
+* *Push notifications:* Full sensor data also arrives via *D5 push notifications* triggered by state changes on the appliance. Push notifications continue even after the unlock session expires (they are CCCD-based, not session-based).
 * *Push mirroring:* Fridges send each push notification on *both* D4 (`msg_types: 8`) and D5 (`msg_types: 2`) simultaneously with identical `props` content.
-* *Command responses:* `unlock_channel` and `get_async` writes to D5 are accepted (GATT write status 0) but produce no indication response.
 
 === Key Protocol Details
 
@@ -122,8 +122,8 @@ The receiver must buffer and reassemble these fragments by tracking JSON brace d
 Push Notifications:: In addition to polled responses (`{"status":0,"resp":{...}}`), appliances send real-time push notifications for state changes (e.g. door open/close, temperature change, light toggle).
 These use the format `{"seq":N,"props":{...},"msg_types":M}` where `msg_types` indicates the channel:
 +
-* `msg_types: 2` — D5 (encrypted channel)
-* `msg_types: 8` — D4 (open channel, fridges only)
+* `msg_types: 2` - D5 (encrypted channel)
+* `msg_types: 8` - D4 (open channel, fridges only)
 +
 The parser handles both poll and push formats, extracting sensor data from `"resp"` (polls) or `"props"` (pushes).
 
@@ -160,12 +160,13 @@ Fridges use different channels for different operations:
 |===
 | Command | Channel | Payload | Response
 
-| `get_async` | *D4* | `{"cmd":"get_async"}\n` | Basic diagnostic data (see <<D4 Response>>)
+| `get_async` | *D4* | `{"cmd":"get_async"}\n` | Basic diagnostic data, no unlock needed (see <<D4 Response>>)
+| `unlock_channel` | *D5* | `{"cmd":"unlock_channel","params":{"pin":"XXXXXX"}}\n` | `{"status": 0, "resp": {"pin": "XXXXXX"}}` (after successful unlock)
+| `get_async` | *D5* | `{"cmd":"get_async"}\n` | Full appliance state (requires prior `unlock_channel`; session expires after some time)
 | `display_pin` | D5 | `{"cmd":"display_pin","params":{"duration": 30}}\n` | Displays PIN on appliance display
-| `unlock_channel` | D5 | `{"cmd":"unlock_channel","params":{"pin":"XXXXXX"}}\n` | Write accepted, no indication response observed
 |===
 
-NOTE: Full sensor data (set temperatures, ice maker, sabbath mode, filter status, etc.) is not available via polling. It arrives via D5 push notifications when the appliance state changes.
+NOTE: D5 command responses require an active unlock session. After the session expires (possibly hours), `get_async` writes to D5 are accepted but produce no response. A fresh `unlock_channel` restores functionality. Push notifications on D5 continue regardless of session state.
 
 [[example-responses]]
 == Example Responses
@@ -276,7 +277,7 @@ Fridges respond to `get_async` on D4 with basic diagnostic data. This is a small
 ----
 ====
 
-NOTE: Keys like `ref_set_temp`, `frz_set_temp`, `ice_maker_on`, and `sabbath_on` are *not* included in D4 responses. These arrive only via D5 push notifications when the appliance state changes.
+NOTE: Keys like `ref_set_temp`, `frz_set_temp`, `ice_maker_on`, and `sabbath_on` are *not* included in D4 responses. These are available via D5 `get_async` (with an active unlock session) or D5 push notifications when the appliance state changes.
 
 === D5 Push Notification (Refrigerators)
 
@@ -294,7 +295,38 @@ Sensor data from fridges arrives as push notifications on D5. Each push contains
 {"msg_types": 2, "seq": 80, "props": {"ref_set_temp": 38}}
 ----
 
-The combined set of keys observed across D4 polls and D5 push notifications for fridge/freezer units includes: `ref_door_ajar`, `frz_door_ajar`, `ref_set_temp`, `frz_set_temp`, `ice_maker_on`, `max_ice_on`, `night_ice_on`, `sabbath_on`, `service_required`, `water_filter_gal_remaining`, `water_filter_pct_remaining`, `air_filter_pct_remaining`, `air_filter_on`, `appliance_model`, `uptime`, and others. Refrigerator-only units (no freezer) will not have `frz_*` or `ice_maker_*` keys.
+The combined set of keys observed across D4 polls and D5 push notifications for fridge/freezer units includes: `ref_door_ajar`, `frz_door_ajar`, `ref_set_temp`, `frz_set_temp`, `ice_maker_on`, `max_ice_on`, `night_ice_on`, `sabbath_on`, `service_required`, `water_filter_gal_remaining`, `water_filter_pct_remaining`, `air_filter_pct_remaining`, `air_filter_on`, `appliance_model`, `uptime`, and others. Refrigerator-only units (no freezer) will not have `frz_*` or `ice_maker_*` keys. Wine storage units include `wine_door_ajar`, `wine_set_temp`, `wine2_set_temp`, and `wine_temp_alert_on`.
+
+=== D5 `get_async` Response (Wine Fridge)
+
+Wine fridges respond to `get_async` on D5 after a successful `unlock_channel` with their full state, similar to dishwashers and ranges.
+
+.Sub-Zero wine storage (IW30R)
+[%collapsible]
+====
+[source,json]
+----
+{
+  "status": 0,
+  "resp": {
+    "accent_light_level": 0,
+    "ref_door_ajar": false,
+    "ref_set_temp": 38,
+    "sabbath_on": false,
+    "service_required": false,
+    "unit_on": true,
+    "wine_door_ajar": true,
+    "wine_set_temp": 55,
+    "wine_temp_alert_on": false,
+    "wine2_set_temp": 45,
+    "appliance_model": "IW30R",
+    "appliance_serial": "XXXXXXXX",
+    "uptime": "02:41:34",
+    "notifs": []
+  }
+}
+----
+====
 
 === GATT Handle Map (Refrigerator)
 

--- a/subzero_base.yaml
+++ b/subzero_base.yaml
@@ -1,8 +1,8 @@
-# Sub-Zero / Wolf / Cove — Shared BLE Package
+# Sub-Zero / Wolf / Cove - Shared BLE Package
 # Do not include this file directly. Use one of the appliance-type packages:
-#   subzero_fridge.yaml      — Sub-Zero refrigerators and freezers
-#   subzero_dishwasher.yaml  — Cove dishwashers
-#   subzero_range.yaml       — Wolf ranges and ovens
+#   subzero_fridge.yaml      - Sub-Zero refrigerators and freezers
+#   subzero_dishwasher.yaml  - Cove dishwashers
+#   subzero_range.yaml       - Wolf ranges and ovens
 
 substitutions:
   poll_offset: "0s"
@@ -78,7 +78,7 @@ ble_client:
     on_connect:
       then:
         - lambda: |-
-            // Request large MTU — fridge firmware sends 40-byte chunks at default MTU,
+            // Request large MTU - fridge firmware sends 40-byte chunks at default MTU,
             // but may use larger chunks if we negotiate higher (dishwasher/range use 244).
             auto *cl = id(${prefix}_appliance);
             esp_ble_gattc_send_mtu_req(cl->get_gattc_if(), cl->get_conn_id());
@@ -120,7 +120,7 @@ ble_client:
             if (id(${prefix}_d5_handle) > 0 && id(${prefix}_phase) >= 1) {
               id(${prefix}_fast_retries) += 1;
               if (id(${prefix}_fast_retries) >= 3) {
-                // Stale bond — clear while disconnected so next connect starts fresh
+                // Stale bond - clear while disconnected so next connect starts fresh
                 ESP_LOGW("ble", "[${appliance_name}] Stale bond (%d failures), clearing for re-pair",
                   id(${prefix}_fast_retries));
                 auto *client = id(${prefix}_appliance);
@@ -377,7 +377,7 @@ interval:
       - script.execute: ${prefix}_periodic_poll
 
 script:
-  # === Periodic poll — staggered to avoid concurrent BLE transfers ===
+  # === Periodic poll - staggered to avoid concurrent BLE transfers ===
   - id: ${prefix}_periodic_poll
     mode: single
     then:
@@ -462,7 +462,7 @@ script:
               }
             }
           }
-          // Always request encryption — some appliances (dishwashers) expose D5
+          // Always request encryption - some appliances (dishwashers) expose D5
           // before bonding but still require encryption for writes (status=5).
           ESP_LOGI("ble", "[${appliance_name}] D5 %s. Requesting encryption...",
             id(${prefix}_d5_handle) > 0 ? "found immediately" : "not yet visible");
@@ -478,7 +478,7 @@ script:
       - lambda: |-
           if (id(${prefix}_d5_handle) > 0) {
             // D5 was found before encryption (e.g. dishwashers).
-            // Encryption should be established by now — proceed to subscribe.
+            // Encryption should be established by now - proceed to subscribe.
             ESP_LOGI("ble", "[${appliance_name}] Post-encryption: D5 already known, subscribing...");
             id(${prefix}_subscribe).execute();
             return;
@@ -590,7 +590,7 @@ script:
     mode: restart
     then:
       # Subscribe D5, then auto-unlock if PIN is saved
-      # All commands MUST end with \n — the appliance's serial parser requires it!
+      # All commands MUST end with \n - the appliance's serial parser requires it!
       - lambda: |-
           auto *client = id(${prefix}_appliance);
           uint16_t d5 = id(${prefix}_d5_handle);

--- a/subzero_dishwasher.yaml
+++ b/subzero_dishwasher.yaml
@@ -95,7 +95,7 @@ button:
             d5, cmd.size(), (uint8_t*)cmd.data(),
             ESP_GATT_WRITE_TYPE_RSP, ESP_GATT_AUTH_REQ_NONE);
           ESP_LOGI("ble", "[${appliance_name}] Debug poll via D5 (h=%d) err=%d", d5, err);
-          id(${prefix}_debug).publish_state("Debug mode ON — full state logged");
+          id(${prefix}_debug).publish_state("Debug mode ON - full state logged");
 
 script:
   - id: ${prefix}_parse_json

--- a/subzero_fridge.yaml
+++ b/subzero_fridge.yaml
@@ -5,7 +5,7 @@
 #   hide_ice_maker: "true" to hide ice maker (default: "false")
 #   hide_sabbath: "true" to hide sabbath mode (default: "false")
 #
-# Example (fridge/freezer combo — all sensors exposed):
+# Example (fridge/freezer combo - all sensors exposed):
 #   packages:
 #     main_fridge: !include
 #       file: subzero_fridge.yaml
@@ -15,7 +15,7 @@
 #         appliance_mac: !secret main_fridge_mac
 #         appliance_pin: !secret main_fridge_pin
 #
-# Example (fridge-only — no freezer or ice maker):
+# Example (fridge-only - no freezer or ice maker):
 #   packages:
 #     basement_fridge: !include
 #       file: subzero_fridge.yaml
@@ -26,11 +26,25 @@
 #         appliance_pin: !secret basement_fridge_pin
 #         hide_freezer: "true"
 #         hide_ice_maker: "true"
+#
+# Example (wine fridge - dual zone, no freezer or ice maker):
+#   packages:
+#     wine_fridge: !include
+#       file: subzero_fridge.yaml
+#       vars:
+#         prefix: "szg"
+#         appliance_name: "Wine Fridge"
+#         appliance_mac: !secret wine_fridge_mac
+#         appliance_pin: !secret wine_fridge_pin
+#         hide_freezer: "true"
+#         hide_ice_maker: "true"
+#         hide_wine: "false"
 
 substitutions:
   hide_freezer: "false"
   hide_ice_maker: "false"
   hide_sabbath: "false"
+  hide_wine: "true"
 
 packages:
   base: !include subzero_base.yaml
@@ -84,6 +98,26 @@ sensor:
     icon: "mdi:snowflake-thermometer"
     internal: ${hide_freezer}
 
+  - platform: template
+    name: "${appliance_name} Wine Zone Upper Temperature"
+    id: ${prefix}_wine_temp
+    unit_of_measurement: "°F"
+    device_class: temperature
+    state_class: measurement
+    accuracy_decimals: 0
+    icon: "mdi:glass-wine"
+    internal: ${hide_wine}
+
+  - platform: template
+    name: "${appliance_name} Wine Zone Lower Temperature"
+    id: ${prefix}_wine2_temp
+    unit_of_measurement: "°F"
+    device_class: temperature
+    state_class: measurement
+    accuracy_decimals: 0
+    icon: "mdi:glass-wine"
+    internal: ${hide_wine}
+
 binary_sensor:
   - platform: template
     name: "${appliance_name} Sabbath Mode"
@@ -103,6 +137,18 @@ binary_sensor:
     icon: "mdi:ice-cream"
     internal: ${hide_ice_maker}
 
+  - platform: template
+    name: "${appliance_name} Wine Door"
+    id: ${prefix}_wine_door_ajar
+    device_class: door
+    internal: ${hide_wine}
+
+  - platform: template
+    name: "${appliance_name} Wine Temperature Alert"
+    id: ${prefix}_wine_temp_alert
+    device_class: problem
+    internal: ${hide_wine}
+
 button:
   - platform: template
     name: "${appliance_name} Log Debug Info"
@@ -110,7 +156,7 @@ button:
     entity_category: diagnostic
     on_press:
       # Fridges respond to get_async on D4 (open channel).
-      # Full sensor data comes via D5 push notifications — interact with the
+      # Full sensor data comes via D5 push notifications - interact with the
       # appliance (open door, change temp, toggle ice maker) with debug mode on.
       - lambda: |-
           uint16_t d4 = id(${prefix}_d4_handle);
@@ -127,7 +173,7 @@ button:
             d4, cmd.size(), (uint8_t*)cmd.data(),
             ESP_GATT_WRITE_TYPE_RSP, ESP_GATT_AUTH_REQ_NONE);
           ESP_LOGI("ble", "[${appliance_name}] Debug poll via D4 (h=%d) err=%d", d4, err);
-          id(${prefix}_debug).publish_state("Debug mode ON — polling D4, interact with appliance for full data");
+          id(${prefix}_debug).publish_state("Debug mode ON - polling D4, interact with appliance for full data");
 
 script:
   - id: ${prefix}_parse_json
@@ -188,6 +234,15 @@ script:
               id(${prefix}_frz_door_ajar).publish_state(data["frz_door_ajar"].as<bool>());
             if (data["ice_maker_on"].is<bool>())
               id(${prefix}_ice_maker).publish_state(data["ice_maker_on"].as<bool>());
+            // --- Wine sensors ---
+            if (data["wine_door_ajar"].is<bool>())
+              id(${prefix}_wine_door_ajar).publish_state(data["wine_door_ajar"].as<bool>());
+            if (data["wine_set_temp"].is<float>())
+              id(${prefix}_wine_temp).publish_state(data["wine_set_temp"].as<float>());
+            if (data["wine2_set_temp"].is<float>())
+              id(${prefix}_wine2_temp).publish_state(data["wine2_set_temp"].as<float>());
+            if (data["wine_temp_alert_on"].is<bool>())
+              id(${prefix}_wine_temp_alert).publish_state(data["wine_temp_alert_on"].as<bool>());
             // --- Common sensors ---
             if (data["sabbath_on"].is<bool>())
               id(${prefix}_sabbath_on).publish_state(data["sabbath_on"].as<bool>());

--- a/subzero_range.yaml
+++ b/subzero_range.yaml
@@ -150,7 +150,7 @@ button:
             d5, cmd.size(), (uint8_t*)cmd.data(),
             ESP_GATT_WRITE_TYPE_RSP, ESP_GATT_AUTH_REQ_NONE);
           ESP_LOGI("ble", "[${appliance_name}] Debug poll via D5 (h=%d) err=%d", d5, err);
-          id(${prefix}_debug).publish_state("Debug mode ON — full state logged");
+          id(${prefix}_debug).publish_state("Debug mode ON - full state logged");
 
 script:
   - id: ${prefix}_parse_json


### PR DESCRIPTION
Add wine-specific sensors to subzero_fridge.yaml (wine door, dual-zone temperatures, temperature alert) behind a hide_wine toggle, defaulting to hidden. Wine fridge users opt in with hide_wine: "false".

Correct BLE protocol documentation: fridges DO respond to get_async on D5 after a successful unlock_channel — the unlock session expires after some time, causing the earlier misdiagnosis of "D5 doesn't respond." Push notifications continue regardless of session state.