### PR TITLE
feat: additional fridge style support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -179,7 +179,19 @@ vars:
 | `hide_ice_maker` | `"false"` | Ice Maker
 | `hide_sabbath` | `"false"` | Sabbath Mode
 | `hide_wine` | `"true"` | Wine Door, Wine Zone Upper Temperature, Wine Zone Lower Temperature, Wine Temperature Alert
+| `hide_ref_drawer` | `"true"` | Refrigerator Drawer Temperature, Refrigerator Drawer Door
 |===
+
+.Fridge with Refrigerator Drawer (e.g. PRO3650G)
+[source,yaml]
+----
+vars:
+  prefix: "szg"
+  appliance_name: "Fridge"
+  appliance_mac: "00:06:80:XX:XX:XX"
+  appliance_pin: "123456"
+  hide_ref_drawer: "false"
+----
 
 .Wine Fridge (dual-zone, no freezer or ice maker)
 [source,yaml]
@@ -265,6 +277,8 @@ TIP: Sub-Zero appliance BLE MAC addresses typically start with `00:06:80`. You c
 | *Wine Zone Upper Temperature* | Upper zone setpoint (°F) _(optional)_
 | *Wine Zone Lower Temperature* | Lower zone setpoint (°F) _(optional)_
 | *Wine Temperature Alert* | Temperature alert binary sensor _(optional)_
+| *Refrigerator Drawer Temperature* | Drawer compartment setpoint (°F) _(optional)_
+| *Refrigerator Drawer Door* | Drawer open/closed binary sensor _(optional)_
 | *Service Required* | Alerts when the appliance flags a service need
 | *Appliance Model* | Model number (e.g. `DEU2450R`, `313`)
 | *Appliance Uptime* | Time since last power cycle

--- a/subzero_fridge.yaml
+++ b/subzero_fridge.yaml
@@ -39,12 +39,24 @@
 #         hide_freezer: "true"
 #         hide_ice_maker: "true"
 #         hide_wine: "false"
+#
+# Example (fridge with refrigerator drawer - e.g. PRO3650G):
+#   packages:
+#     fridge: !include
+#       file: subzero_fridge.yaml
+#       vars:
+#         prefix: "szg"
+#         appliance_name: "Fridge"
+#         appliance_mac: !secret fridge_mac
+#         appliance_pin: !secret fridge_pin
+#         hide_ref_drawer: "false"
 
 substitutions:
   hide_freezer: "false"
   hide_ice_maker: "false"
   hide_sabbath: "false"
   hide_wine: "true"
+  hide_ref_drawer: "true"
 
 packages:
   base: !include subzero_base.yaml
@@ -118,6 +130,16 @@ sensor:
     icon: "mdi:glass-wine"
     internal: ${hide_wine}
 
+  - platform: template
+    name: "${appliance_name} Refrigerator Drawer Temperature"
+    id: ${prefix}_ref2_temp
+    unit_of_measurement: "°F"
+    device_class: temperature
+    state_class: measurement
+    accuracy_decimals: 0
+    icon: "mdi:thermometer"
+    internal: ${hide_ref_drawer}
+
 binary_sensor:
   - platform: template
     name: "${appliance_name} Sabbath Mode"
@@ -148,6 +170,12 @@ binary_sensor:
     id: ${prefix}_wine_temp_alert
     device_class: problem
     internal: ${hide_wine}
+
+  - platform: template
+    name: "${appliance_name} Refrigerator Drawer Door"
+    id: ${prefix}_ref2_door_ajar
+    device_class: door
+    internal: ${hide_ref_drawer}
 
 button:
   - platform: template
@@ -234,6 +262,11 @@ script:
               id(${prefix}_frz_door_ajar).publish_state(data["frz_door_ajar"].as<bool>());
             if (data["ice_maker_on"].is<bool>())
               id(${prefix}_ice_maker).publish_state(data["ice_maker_on"].as<bool>());
+            // --- Refrigerator drawer sensors ---
+            if (data["ref2_set_temp"].is<float>())
+              id(${prefix}_ref2_temp).publish_state(data["ref2_set_temp"].as<float>());
+            if (data["ref2_door_ajar"].is<bool>())
+              id(${prefix}_ref2_door_ajar).publish_state(data["ref2_door_ajar"].as<bool>());
             // --- Wine sensors ---
             if (data["wine_door_ajar"].is<bool>())
               id(${prefix}_wine_door_ajar).publish_state(data["wine_door_ajar"].as<bool>());


### PR DESCRIPTION
example shown for `PRO3650G`, `hide_ref_drawer: "false"` can be added to display temp/door sensors