### PR TITLE
fix: add acl corruption protection

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -257,6 +257,9 @@ TIP: Sub-Zero appliance BLE MAC addresses typically start with `00:06:80`. You c
 
 | *Range disconnects before data arrives*
 | Wolf ranges have tight BLE windows. Add `fast_connect: true` and `power_save_mode: none` to your WiFi config.
+
+| *"ACL packet too short" / first push notification lost*
+| Known ESP-IDF BLE controller bug (https://github.com/espressif/esp-idf/issues/18323[espressif/esp-idf#18323]) on ESP32-S3. When an appliance sends a rapid burst of push notifications (e.g. activating gourmet mode), the first message may be dropped. The integration detects this and recovers for subsequent messages, but the first state change in the burst is lost. Fixed in ESP-IDF 5.5.4, pending ESPHome/PlatformIO adoption.
 |===
 
 == Supported Sensors

--- a/docs/ble-protocol.adoc
+++ b/docs/ble-protocol.adoc
@@ -135,6 +135,13 @@ NOTE: Cove dishwashers expose D5 in the GATT database *before* bonding, but stil
 
 MTU:: Negotiated to 517 bytes, though the appliance still fragments at ~40 bytes per indication (fridges) or ~244 bytes (dishwashers/ranges).
 
+ACL Fragment Drops (ESP32-S3):: A https://github.com/espressif/esp-idf/issues/18323[known bug] in the ESP-IDF BLE controller (present in 5.5.3 and earlier) causes the HCI layer to drop ACL fragments during rapid bursts of indications.
+This manifests as `BT_HCI: ACL packet too short` and `reassemble_and_dispatch found unfinished packet` errors.
+When a fragment is dropped, the JSON reassembly buffer is left with incomplete data.
+The integration detects this (a new `{` arriving while the buffer is non-empty) and discards the corrupt buffer, allowing subsequent messages to parse normally.
+However, the *first push notification in a burst* is typically lost - for example, `cav_gourmet_mode_on` during gourmet mode activation.
+This is fixed in ESP-IDF 5.5.4, which is not yet available in ESPHome/PlatformIO.
+
 == Command Reference
 
 Commands are JSON objects terminated with `\n`. The target characteristic depends on the appliance type and command.

--- a/subzero_base.yaml
+++ b/subzero_base.yaml
@@ -162,6 +162,13 @@ sensor:
     lambda: |-
       auto &buf = id(${prefix}_json_buf);
       if (buf.capacity() < 2048) buf.reserve(2048);
+      // ACL corruption recovery: ESP-IDF bug (espressif/esp-idf#18323) can
+      // drop BLE fragments during rapid bursts, leaving unbalanced JSON in
+      // the buffer. Detect this when a new '{' arrives with stale data.
+      if (x.size() > 0 && x[0] == '{' && !buf.empty()) {
+        ESP_LOGW("ble", "[${appliance_name}] Discarding %d bytes of incomplete JSON (ACL drop)", buf.size());
+        buf.clear();
+      }
       if (buf.size() > 4096) { buf.clear(); return {}; }
       buf.append((char*)x.data(), x.size());
       // Any notification = connection alive (resets zombie detection)

--- a/subzero_fridge.yaml
+++ b/subzero_fridge.yaml
@@ -77,6 +77,10 @@ sensor:
     lambda: |-
       auto &buf = id(${prefix}_json_buf);
       if (buf.capacity() < 2048) buf.reserve(2048);
+      if (x.size() > 0 && x[0] == '{' && !buf.empty()) {
+        ESP_LOGW("ble", "[${appliance_name}] Discarding %d bytes of incomplete JSON (ACL drop)", buf.size());
+        buf.clear();
+      }
       if (buf.size() > 4096) { buf.clear(); return {}; }
       buf.append((char*)x.data(), x.size());
       id(${prefix}_poll_ok) = true;


### PR DESCRIPTION
a known ESP-IDF bug (espressif/esp-idf#18323, present in 5.5.3 and earlier) drops ACL fragments during rapid indication bursts, leaving the JSON reassembly buffer with incomplete data that never completes. without this fix, one corrupted burst poisons the buffer and all subsequent messages are lost

the fix detects when a new JSON object starts ('{') while the buffer still has incomplete data, discards the corrupt buffer, and allows the next message to parse immediately. Only the first message in a corrupted burst is lost; all subsequent messages recover normally.

Documented as a known limitation in README troubleshooting and BLE protocol reference. Root cause fix is in ESP-IDF 5.5.4, pending ESPHome/PlatformIO adoption.