### PR TITLE
feat: add cove with WS support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -259,7 +259,7 @@ TIP: Sub-Zero appliance BLE MAC addresses typically start with `00:06:80`. You c
 | Wolf ranges have tight BLE windows. Add `fast_connect: true` and `power_save_mode: none` to your WiFi config.
 
 | *"ACL packet too short" / first push notification lost*
-| Known ESP-IDF BLE controller bug (https://github.com/espressif/esp-idf/issues/18323[espressif/esp-idf#18323]) on ESP32-S3. When an appliance sends a rapid burst of push notifications (e.g. activating gourmet mode), the first message may be dropped. The integration detects this and recovers for subsequent messages, but the first state change in the burst is lost. Fixed in ESP-IDF 5.5.4, pending ESPHome/PlatformIO adoption.
+| Known ESP-IDF Bluedroid HCI bug on ESP32-S3. When an appliance sends a rapid burst of push notifications (e.g. activating gourmet mode on a wall oven), the first message may be dropped due to ACL fragment reassembly failure. The integration detects this and recovers for subsequent messages, but the first state change in the burst is lost. This seems to primarily affect appliances using 40-byte indication fragments (fw 8.5); appliances using 244-byte fragments (fw 2.27) are unaffected since their push notifications fit in a single indication.
 |===
 
 == Supported Sensors
@@ -302,11 +302,12 @@ TIP: Sub-Zero appliance BLE MAC addresses typically start with `00:06:80`. You c
 | *High Temp Wash* | High temperature wash option enabled
 | *Sanitize Rinse* | Sanitize rinse option enabled
 | *Rinse Aid Low* | Rinse aid level is low (problem sensor)
+| *Softener Low* | Water softener level is low (problem sensor, DW2450WS only)
 | *Light* | Interior light on/off
 | *Remote Ready* | Appliance is ready for remote commands
 | *Delay Start* | Delay start timer is active
 | *Service Required* | Alerts when the appliance flags a service need
-| *Appliance Model* | Model number (e.g. `DW2450`)
+| *Appliance Model* | Model number (e.g. `DW2450`, `DW2450WS`)
 | *Appliance Uptime* | Time since last power cycle
 |===
 
@@ -375,6 +376,7 @@ For ranges with two ovens, enable the second oven sensors using `hide_oven2: "fa
 | Sub-Zero | DEU2450R | Under-counter refrigerator | Fully working
 | Sub-Zero | 313 | French-door fridge/freezer with ice maker | Fully working
 | Cove | DW2450 | Dishwasher | Fully working
+| Cove | DW2450WS | Dishwasher (with water softener) | Fully working
 | Wolf | DF36450GSP | Dual-fuel range | Fully working
 | Wolf | SO3050PESP | Wall oven | Fully working
 | Sub-Zero | IW30R | Wine storage (dual-zone) | Fully working

--- a/docs/ble-protocol.adoc
+++ b/docs/ble-protocol.adoc
@@ -135,12 +135,13 @@ NOTE: Cove dishwashers expose D5 in the GATT database *before* bonding, but stil
 
 MTU:: Negotiated to 517 bytes, though the appliance still fragments at ~40 bytes per indication (fridges) or ~244 bytes (dishwashers/ranges).
 
-ACL Fragment Drops (ESP32-S3):: A https://github.com/espressif/esp-idf/issues/18323[known bug] in the ESP-IDF BLE controller (present in 5.5.3 and earlier) causes the HCI layer to drop ACL fragments during rapid bursts of indications.
+ACL Fragment Drops (ESP32-S3):: A bug in the ESP-IDF Bluedroid HCI layer causes ACL fragment reassembly failures during rapid bursts of indications.
 This manifests as `BT_HCI: ACL packet too short` and `reassemble_and_dispatch found unfinished packet` errors.
 When a fragment is dropped, the JSON reassembly buffer is left with incomplete data.
 The integration detects this (a new `{` arriving while the buffer is non-empty) and discards the corrupt buffer, allowing subsequent messages to parse normally.
 However, the *first push notification in a burst* is typically lost - for example, `cav_gourmet_mode_on` during gourmet mode activation.
-This is fixed in ESP-IDF 5.5.4, which is not yet available in ESPHome/PlatformIO.
+This seems to only affect appliances using 40-byte indication fragments (API 5.4 / fw 8.5, e.g. SO3050PESP wall oven, 313 fridge, possibly others).
+Appliances using 244-byte fragments (API 5.5 / fw 2.27, e.g. DF36450GSP range, DW2450 dishwasher) are unaffected since their push notifications fit in a single indication.
 
 == Command Reference
 

--- a/subzero_dishwasher.yaml
+++ b/subzero_dishwasher.yaml
@@ -1,5 +1,7 @@
 # Cove Dishwasher BLE Package
 # Include with vars: prefix, appliance_name, appliance_mac, appliance_pin
+# Optional vars:
+#   hide_softener: "false" to show water softener sensor (default: "true")
 #
 # Example:
 #   packages:
@@ -10,6 +12,20 @@
 #         appliance_name: "Right Dishwasher"
 #         appliance_mac: !secret right_dishwasher_mac
 #         appliance_pin: !secret right_dishwasher_pin
+#
+# Example (DW2450WS with water softener):
+#   packages:
+#     dishwasher: !include
+#       file: subzero_dishwasher.yaml
+#       vars:
+#         prefix: "szg"
+#         appliance_name: "Dishwasher"
+#         appliance_mac: !secret dishwasher_mac
+#         appliance_pin: !secret dishwasher_pin
+#         hide_softener: "false"
+
+substitutions:
+  hide_softener: "true"
 
 packages:
   base: !include subzero_base.yaml
@@ -72,6 +88,12 @@ binary_sensor:
     name: "${appliance_name} Delay Start"
     id: ${prefix}_delay_start
     icon: "mdi:timer-sand"
+
+  - platform: template
+    name: "${appliance_name} Softener Low"
+    id: ${prefix}_softener_low
+    device_class: problem
+    internal: ${hide_softener}
 
 button:
   - platform: template
@@ -157,6 +179,8 @@ script:
               id(${prefix}_sani_rinse).publish_state(data["sani_rinse_on"].as<bool>());
             if (data["rinse_aid_low"].is<bool>())
               id(${prefix}_rinse_aid_low).publish_state(data["rinse_aid_low"].as<bool>());
+            if (data["softener_low"].is<bool>())
+              id(${prefix}_softener_low).publish_state(data["softener_low"].as<bool>());
             if (data["light_on"].is<bool>())
               id(${prefix}_light_on).publish_state(data["light_on"].as<bool>());
             if (data["remote_ready"].is<bool>())


### PR DESCRIPTION
optional water softener sensor support, use `hide_softener: "false"` to enable the sensor

https://community.home-assistant.io/t/sub-zero-integration-with-home-assistant/221456/101?u=jon102034050