### PR TITLE
feat: standalone fridge/freezer support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -179,6 +179,9 @@ vars:
 | `hide_sabbath` | `"false"` | Sabbath Mode
 | `hide_wine` | `"true"` | Wine Door, Wine Zone Upper Temperature, Wine Zone Lower Temperature, Wine Temperature Alert
 | `hide_ref_drawer` | `"true"` | Refrigerator Drawer Temperature, Refrigerator Drawer Door
+| `hide_crisper` | `"true"` | Crisper Drawer Temperature
+| `hide_air_filter` | `"true"` | Air Filter, Air Filter Remaining
+| `hide_water_filter` | `"true"` | Water Filter Remaining
 | `hide_softener` | `"true"` | Water softener on a dishwasher
 |===
 
@@ -191,6 +194,19 @@ vars:
   appliance_mac: "00:06:80:XX:XX:XX"
   appliance_pin: "123456"
   hide_ref_drawer: "false"
+----
+
+.Fridge with Crisper & Filters (e.g. DEC3650RID)
+[source,yaml]
+----
+vars:
+  prefix: "szg"
+  appliance_name: "Fridge"
+  appliance_mac: "00:06:80:XX:XX:XX"
+  appliance_pin: "123456"
+  hide_crisper: "false"
+  hide_air_filter: "false"
+  hide_water_filter: "false"
 ----
 
 .Wine Fridge (dual-zone, no freezer or ice maker)
@@ -270,7 +286,7 @@ TIP: Sub-Zero appliance BLE MAC addresses typically start with `00:06:80`. You c
 |===
 | Sensor | Description
 
-| *Refrigerator Set Temperature* | Current fridge setpoint (°F)
+| *Refrigerator Set Temperature* | Current fridge setpoint (°F). For standalone freezer units, falls back to the freezer setpoint.
 | *Freezer Set Temperature* | Current freezer setpoint (°F) _(optional)_
 | *Refrigerator Door* | Open/closed binary sensor
 | *Freezer Door* | Open/closed binary sensor _(optional)_
@@ -282,6 +298,10 @@ TIP: Sub-Zero appliance BLE MAC addresses typically start with `00:06:80`. You c
 | *Wine Temperature Alert* | Temperature alert binary sensor _(optional)_
 | *Refrigerator Drawer Temperature* | Drawer compartment setpoint (°F) _(optional)_
 | *Refrigerator Drawer Door* | Drawer open/closed binary sensor _(optional)_
+| *Crisper Drawer Temperature* | Crisper drawer setpoint (°F) _(optional)_
+| *Air Filter* | Air filter on/off binary sensor _(optional)_
+| *Air Filter Remaining* | Air filter life remaining (%) _(optional)_
+| *Water Filter Remaining* | Water filter life remaining (%) _(optional)_
 | *Service Required* | Alerts when the appliance flags a service need
 | *Appliance Model* | Model number (e.g. `DEU2450R`, `313`)
 | *Appliance Uptime* | Time since last power cycle

--- a/subzero_fridge.yaml
+++ b/subzero_fridge.yaml
@@ -4,6 +4,9 @@
 #   hide_freezer: "true" to hide freezer temp & door (default: "false")
 #   hide_ice_maker: "true" to hide ice maker (default: "false")
 #   hide_sabbath: "true" to hide sabbath mode (default: "false")
+#   hide_crisper: "false" to show crisper drawer temp (default: "true")
+#   hide_air_filter: "false" to show air filter sensors (default: "true")
+#   hide_water_filter: "false" to show water filter sensor (default: "true")
 #
 # Example (fridge/freezer combo - all sensors exposed):
 #   packages:
@@ -57,6 +60,9 @@ substitutions:
   hide_sabbath: "false"
   hide_wine: "true"
   hide_ref_drawer: "true"
+  hide_crisper: "true"
+  hide_air_filter: "true"
+  hide_water_filter: "true"
 
 packages:
   base: !include subzero_base.yaml
@@ -144,6 +150,34 @@ sensor:
     icon: "mdi:thermometer"
     internal: ${hide_ref_drawer}
 
+  - platform: template
+    name: "${appliance_name} Crisper Drawer Temperature"
+    id: ${prefix}_crisp_temp
+    unit_of_measurement: "°F"
+    device_class: temperature
+    state_class: measurement
+    accuracy_decimals: 0
+    icon: "mdi:thermometer"
+    internal: ${hide_crisper}
+
+  - platform: template
+    name: "${appliance_name} Air Filter Remaining"
+    id: ${prefix}_air_filter_pct
+    unit_of_measurement: "%"
+    state_class: measurement
+    accuracy_decimals: 0
+    icon: "mdi:air-filter"
+    internal: ${hide_air_filter}
+
+  - platform: template
+    name: "${appliance_name} Water Filter Remaining"
+    id: ${prefix}_water_filter_pct
+    unit_of_measurement: "%"
+    state_class: measurement
+    accuracy_decimals: 0
+    icon: "mdi:water-percent"
+    internal: ${hide_water_filter}
+
 binary_sensor:
   - platform: template
     name: "${appliance_name} Sabbath Mode"
@@ -180,6 +214,12 @@ binary_sensor:
     id: ${prefix}_ref2_door_ajar
     device_class: door
     internal: ${hide_ref_drawer}
+
+  - platform: template
+    name: "${appliance_name} Air Filter"
+    id: ${prefix}_air_filter_on
+    icon: "mdi:air-filter"
+    internal: ${hide_air_filter}
 
 button:
   - platform: template
@@ -254,6 +294,8 @@ script:
             // --- Fridge sensors ---
             if (data["ref_set_temp"].is<float>())
               id(${prefix}_set_temp).publish_state(data["ref_set_temp"].as<float>());
+            else if (data["frz_set_temp"].is<float>() && !data["ref_set_temp"].is<float>())
+              id(${prefix}_set_temp).publish_state(data["frz_set_temp"].as<float>());
             // Door (fallback chain: ref_door_ajar -> door_ajar)
             if (data["ref_door_ajar"].is<bool>())
               id(${prefix}_door_ajar).publish_state(data["ref_door_ajar"].as<bool>());
@@ -280,6 +322,16 @@ script:
               id(${prefix}_wine2_temp).publish_state(data["wine2_set_temp"].as<float>());
             if (data["wine_temp_alert_on"].is<bool>())
               id(${prefix}_wine_temp_alert).publish_state(data["wine_temp_alert_on"].as<bool>());
+            // --- Crisper drawer sensors ---
+            if (data["crisp_set_temp"].is<float>())
+              id(${prefix}_crisp_temp).publish_state(data["crisp_set_temp"].as<float>());
+            // --- Filter sensors ---
+            if (data["air_filter_on"].is<bool>())
+              id(${prefix}_air_filter_on).publish_state(data["air_filter_on"].as<bool>());
+            if (data["air_filter_pct_remaining"].is<float>())
+              id(${prefix}_air_filter_pct).publish_state(data["air_filter_pct_remaining"].as<float>());
+            if (data["water_filter_pct_remaining"].is<float>())
+              id(${prefix}_water_filter_pct).publish_state(data["water_filter_pct_remaining"].as<float>());
             // --- Common sensors ---
             if (data["sabbath_on"].is<bool>())
               id(${prefix}_sabbath_on).publish_state(data["sabbath_on"].as<bool>());


### PR DESCRIPTION
new options: added `hide_crisper`, `hide_air_filter`, and `hide_water_filter` rows
Supported Sensors table: Added Crisper Drawer Temperature, Air Filter, Air Filter Remaining, and Water Filter Remaining
Refrigerator Set Temperature: Updated description noting the fallback to freezer setpoint for standalone freezer units
New example config: Added a "Fridge with Crisper & Filters" example block for models like the `DEC3650RID`

closes https://github.com/JonGilmore/esphome-subzero-ble/issues/34