### PR TITLE
fix: rm acl corruption hack

### DIFF
--- a/cove-minimal-dishwasher.yaml
+++ b/cove-minimal-dishwasher.yaml
@@ -49,5 +49,3 @@ wifi:
   password: !secret wifi_password
   fast_connect: true
   power_save_mode: none
-
-esp32_ble_tracker:

--- a/subzero_base.yaml
+++ b/subzero_base.yaml
@@ -23,6 +23,10 @@ esp32_ble:
   io_capability: keyboard_only
   max_connections: 5
 
+esp32_ble_tracker:
+  scan_parameters:
+    active: false
+
 globals:
   - id: ${prefix}_phase
     type: int
@@ -172,13 +176,6 @@ sensor:
     lambda: |-
       auto &buf = id(${prefix}_json_buf);
       if (buf.capacity() < 2048) buf.reserve(2048);
-      // ACL corruption recovery: ESP-IDF bug (espressif/esp-idf#18323) can
-      // drop BLE fragments during rapid bursts, leaving unbalanced JSON in
-      // the buffer. Detect this when a new '{' arrives with stale data.
-      if (x.size() > 0 && x[0] == '{' && !buf.empty()) {
-        ESP_LOGW("ble", "[${appliance_name}] Discarding %d bytes of incomplete JSON (ACL drop)", buf.size());
-        buf.clear();
-      }
       if (buf.size() > 4096) { buf.clear(); return {}; }
       buf.append((char*)x.data(), x.size());
       // Any notification = connection alive (resets zombie detection)

--- a/subzero_fridge.yaml
+++ b/subzero_fridge.yaml
@@ -83,10 +83,6 @@ sensor:
     lambda: |-
       auto &buf = id(${prefix}_json_buf);
       if (buf.capacity() < 2048) buf.reserve(2048);
-      if (x.size() > 0 && x[0] == '{' && !buf.empty()) {
-        ESP_LOGW("ble", "[${appliance_name}] Discarding %d bytes of incomplete JSON (ACL drop)", buf.size());
-        buf.clear();
-      }
       if (buf.size() > 4096) { buf.clear(); return {}; }
       buf.append((char*)x.data(), x.size());
       id(${prefix}_poll_ok) = true;

--- a/wolf-minimal-fridge.yaml
+++ b/wolf-minimal-fridge.yaml
@@ -45,5 +45,3 @@ wifi:
   password: !secret wifi_password
   fast_connect: true
   power_save_mode: none
-
-esp32_ble_tracker:

--- a/wolf-minimal-range.yaml
+++ b/wolf-minimal-range.yaml
@@ -49,5 +49,3 @@ wifi:
   password: !secret wifi_password
   fast_connect: true
   power_save_mode: none
-
-esp32_ble_tracker:


### PR DESCRIPTION
now that the fix for `esp-idf` is in place, the acl corruption hacked fix seemed to be breaking large payloads on things like initial polling

back this out and it should also fix https://github.com/JonGilmore/esphome-subzero-ble/issues/41

this PR also adds:

```
esp32_ble_tracker:
  scan_parameters:
    active: false
```

as it seems to be unnecessary for SZG devices and causes unnecessary overhead.