### PR TITLE
docs: add 48SID to supported appliances

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -409,6 +409,7 @@ For ranges with two ovens, enable the second oven sensors using `hide_oven2: "fa
 | Wolf | SO3050PESP | Wall oven | Fully working
 | Sub-Zero | IW30R | Wine storage (dual-zone) | Fully working
 | Sub-Zero | IT36CIID | Refrigerator/Freezer with Ice Maker | Fully working
+| Sub-Zero | 48SID | Refrigerator/Freezer with Ice Maker | Fully working
 |===
 
 Other Sub-Zero, Wolf, and Cove appliances with BLE should work - they all use the same protocol. If you test with a different model, please open an issue or PR to update this table. See link:docs/advanced.adoc#_debug_mode[Debug Mode] for how to capture your appliance's data.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the list of tested appliances to include Sub-Zero model 48SID refrigerator/freezer with ice maker, marked as fully working.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->