### PR TITLE
docs: add tested appliance models (BI36UFDID, IR36550ST)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -410,6 +410,8 @@ For ranges with two ovens, enable the second oven sensors using `hide_oven2: "fa
 | Sub-Zero | IW30R | Wine storage (dual-zone) | Fully working
 | Sub-Zero | IT36CIID | Refrigerator/Freezer with Ice Maker | Fully working
 | Sub-Zero | 48SID | Refrigerator/Freezer with Ice Maker | Fully working
+| Sub-Zero | BI36UFDID | Built-in Refrigerator/Freezer with Ice Maker | Fully working
+| Wolf | IR36550ST | Induction Range | Fully working
 |===
 
 Other Sub-Zero, Wolf, and Cove appliances with BLE should work - they all use the same protocol. If you test with a different model, please open an issue or PR to update this table. See link:docs/advanced.adoc#_debug_mode[Debug Mode] for how to capture your appliance's data.


### PR DESCRIPTION
## Summary
- Add Sub-Zero BI36UFDID (built-in refrigerator/freezer with ice maker) to tested models
- Add Wolf IR36550ST (induction range) to tested models

Both models confirmed fully working with the ESPHome integration.

## Test plan
- [x] Tested BI36UFDID fridge - connects, polls, reports all sensors
- [x] Tested IR36550ST range - connects, polls, reports oven temperature/status

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded tested appliances list with two newly verified models: Sub-Zero Built-in Refrigerator/Freezer with Ice Maker and Wolf Induction Range, both confirmed fully working.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->