### PR TITLE
feat: add diagnostic sensors, rename fridge setpoint sensors

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -174,12 +174,12 @@ vars:
 |===
 | Option | Default | Hides
 
-| `hide_freezer` | `"false"` | Freezer Temperature, Freezer Door
+| `hide_freezer` | `"false"` | Freezer Set Temperature, Freezer Door
 | `hide_ice_maker` | `"false"` | Ice Maker
 | `hide_sabbath` | `"false"` | Sabbath Mode
-| `hide_wine` | `"true"` | Wine Door, Wine Zone Upper Temperature, Wine Zone Lower Temperature, Wine Temperature Alert
-| `hide_ref_drawer` | `"true"` | Refrigerator Drawer Temperature, Refrigerator Drawer Door
-| `hide_crisper` | `"true"` | Crisper Drawer Temperature
+| `hide_wine` | `"true"` | Wine Door, Wine Zone Upper Set Temperature, Wine Zone Lower Set Temperature, Wine Temperature Alert
+| `hide_ref_drawer` | `"true"` | Refrigerator Drawer Set Temperature, Refrigerator Drawer Door
+| `hide_crisper` | `"true"` | Crisper Drawer Set Temperature
 | `hide_air_filter` | `"true"` | Air Filter, Air Filter Remaining
 | `hide_water_filter` | `"true"` | Water Filter Remaining
 | `hide_softener` | `"true"` | Water softener on a dishwasher
@@ -282,6 +282,8 @@ TIP: Sub-Zero appliance BLE MAC addresses typically start with `00:06:80`. You c
 
 === Refrigerator/Freezer
 
+NOTE: Sub-Zero fridge firmware only exposes _set points_ over BLE - actual/measured compartment temperatures are not available. Wolf ranges do expose measured cavity temperatures (see below).
+
 [cols="1,3"]
 |===
 | Sensor | Description
@@ -293,12 +295,12 @@ TIP: Sub-Zero appliance BLE MAC addresses typically start with `00:06:80`. You c
 | *Ice Maker* | On/off binary sensor _(optional)_
 | *Sabbath Mode* | On/off binary sensor _(optional)_
 | *Wine Door* | Open/closed binary sensor _(optional)_
-| *Wine Zone Upper Temperature* | Upper zone setpoint (°F) _(optional)_
-| *Wine Zone Lower Temperature* | Lower zone setpoint (°F) _(optional)_
+| *Wine Zone Upper Set Temperature* | Upper zone setpoint (°F) _(optional)_
+| *Wine Zone Lower Set Temperature* | Lower zone setpoint (°F) _(optional)_
 | *Wine Temperature Alert* | Temperature alert binary sensor _(optional)_
-| *Refrigerator Drawer Temperature* | Drawer compartment setpoint (°F) _(optional)_
+| *Refrigerator Drawer Set Temperature* | Drawer compartment setpoint (°F) _(optional)_
 | *Refrigerator Drawer Door* | Drawer open/closed binary sensor _(optional)_
-| *Crisper Drawer Temperature* | Crisper drawer setpoint (°F) _(optional)_
+| *Crisper Drawer Set Temperature* | Crisper drawer setpoint (°F) _(optional)_
 | *Air Filter* | Air filter on/off binary sensor _(optional)_
 | *Air Filter Remaining* | Air filter life remaining (%) _(optional)_
 | *Water Filter Remaining* | Water filter life remaining (%) _(optional)_
@@ -393,6 +395,26 @@ For ranges with two ovens, enable the second oven sensors using `hide_oven2: "fa
 | Option | Default | Hides
 
 | `hide_oven2` | `"true"` | All Oven 2 sensors (temperature, door, light, probe, cook mode, etc.)
+|===
+
+=== Diagnostics (All Appliances)
+
+These diagnostic text sensors are exposed under HA's Diagnostic section for every supported appliance type. Not every appliance populates every field - missing keys leave the sensor unknown. Useful for troubleshooting firmware-version-specific behavior or sharing context in bug reports.
+
+[cols="1,3"]
+|===
+| Sensor | Description
+
+| *Appliance Serial* | Hardware serial number (trimmed of padding spaces)
+| *Appliance Type* | Product type code (e.g. `17.5.2.0`, `1.1.1.12`)
+| *Diagnostic Status* | Hex bitmask of internal status flags (e.g. `0x00000003111`)
+| *Firmware Version* | Main firmware version (e.g. `2.27`, `8.5`)
+| *API Version* | BLE API protocol version (e.g. `5.5`)
+| *BLE App Version* | BLE application version
+| *OS Version* | Underlying OS version
+| *RTApp Version* | Realtime application version
+| *Appliance Board Version* | Raw composite string of sub-board versions (e.g. `main: 10.11.6877; mcb_ccm_lv: 9.4.4034; uim_typeA: 11.0.13`). Sub-fields vary by appliance - parse in a HA template if you need individual values.
+| *Build Date* | Firmware build timestamp
 |===
 
 === Tested Appliances

--- a/docs/ble-protocol.adoc
+++ b/docs/ble-protocol.adoc
@@ -305,6 +305,8 @@ Sensor data from fridges arrives as push notifications on D5. Each push contains
 
 The combined set of keys observed across D4 polls and D5 push notifications for fridge/freezer units includes: `ref_door_ajar`, `frz_door_ajar`, `ref_set_temp`, `frz_set_temp`, `ice_maker_on`, `max_ice_on`, `night_ice_on`, `sabbath_on`, `service_required`, `water_filter_gal_remaining`, `water_filter_pct_remaining`, `air_filter_pct_remaining`, `air_filter_on`, `appliance_model`, `uptime`, and others. Refrigerator-only units (no freezer) will not have `frz_*` or `ice_maker_*` keys. Wine storage units include `wine_door_ajar`, `wine_set_temp`, `wine2_set_temp`, and `wine_temp_alert_on`.
 
+IMPORTANT: Fridge firmware exposes only setpoints (`*_set_temp`) - no actual/measured compartment temperatures are published over BLE. This was confirmed empirically against an IW30R (fw 2.27) by capturing full `get_async` responses across a setpoint change that would drive the compressor; no `*_cur_temp`, `*_actual_temp`, or plain `*_temp` keys appeared in any response. The derived boolean `wine_temp_alert_on` shows the firmware tracks the real value internally, but it is not published. (Wolf ranges, by contrast, do expose `cav_temp` and `cav_probe_temp` as actual measurements distinct from their `*_set_temp` counterparts.)
+
 === D5 `get_async` Response (Wine Fridge)
 
 Wine fridges respond to `get_async` on D5 after a successful `unlock_channel` with their full state, similar to dishwashers and ranges.

--- a/subzero_base.yaml
+++ b/subzero_base.yaml
@@ -461,7 +461,9 @@ script:
   # cache refresh. ble_client.ble_write would fail to find D5 on fridges.
   #
   # Also includes "zombie detection": poll_ok is set by any D5 notification (push or
-  # poll response). If 15 poll intervals pass with no data, we force reconnect.
+  # poll response), and by any D4 notification on fridges (which subscribe to both
+  # channels). If 15 poll intervals pass with no data on either channel, we force
+  # reconnect.
   - id: ${prefix}_periodic_poll
     mode: single
     then:

--- a/subzero_base.yaml
+++ b/subzero_base.yaml
@@ -94,6 +94,7 @@ ble_client:
         - lambda: |-
             // Request large MTU - fridge firmware sends 40-byte chunks at default MTU,
             // but may use larger chunks if we negotiate higher (dishwasher/range use 244).
+            // Custom call required: ESPHome does not expose MTU negotiation.
             auto *cl = id(${prefix}_appliance);
             esp_ble_gattc_send_mtu_req(cl->get_gattc_if(), cl->get_conn_id());
             // Fast path: handles cached from previous connection (bonded)
@@ -222,6 +223,66 @@ text_sensor:
     name: "${appliance_name} Uptime"
     id: ${prefix}_uptime
     icon: "mdi:timer-outline"
+    entity_category: diagnostic
+
+  - platform: template
+    name: "${appliance_name} Appliance Serial"
+    id: ${prefix}_serial
+    icon: "mdi:identifier"
+    entity_category: diagnostic
+
+  - platform: template
+    name: "${appliance_name} Appliance Type"
+    id: ${prefix}_appliance_type
+    icon: "mdi:shape"
+    entity_category: diagnostic
+
+  - platform: template
+    name: "${appliance_name} Diagnostic Status"
+    id: ${prefix}_diag_status
+    icon: "mdi:stethoscope"
+    entity_category: diagnostic
+
+  - platform: template
+    name: "${appliance_name} Firmware Version"
+    id: ${prefix}_fw_version
+    icon: "mdi:chip"
+    entity_category: diagnostic
+
+  - platform: template
+    name: "${appliance_name} API Version"
+    id: ${prefix}_api_version
+    icon: "mdi:api"
+    entity_category: diagnostic
+
+  - platform: template
+    name: "${appliance_name} BLE App Version"
+    id: ${prefix}_bleapp_version
+    icon: "mdi:bluetooth"
+    entity_category: diagnostic
+
+  - platform: template
+    name: "${appliance_name} OS Version"
+    id: ${prefix}_os_version
+    icon: "mdi:memory"
+    entity_category: diagnostic
+
+  - platform: template
+    name: "${appliance_name} RTApp Version"
+    id: ${prefix}_rtapp_version
+    icon: "mdi:application-cog"
+    entity_category: diagnostic
+
+  - platform: template
+    name: "${appliance_name} Appliance Board Version"
+    id: ${prefix}_board_version
+    icon: "mdi:developer-board"
+    entity_category: diagnostic
+
+  - platform: template
+    name: "${appliance_name} Build Date"
+    id: ${prefix}_build_date
+    icon: "mdi:calendar-clock"
     entity_category: diagnostic
 
 text:
@@ -392,6 +453,15 @@ interval:
 
 script:
   # === Periodic poll - staggered to avoid concurrent BLE transfers ===
+  #
+  # All BLE command writes (here and in buttons/subscribe) use esp_ble_gattc_write_char
+  # directly by HANDLE rather than ESPHome's ble_client.ble_write action (which looks
+  # up by UUID). Reason: on fridges, D5 is not visible in the initial service discovery
+  # that populates ESPHome's characteristic database - it only appears after bonding +
+  # cache refresh. ble_client.ble_write would fail to find D5 on fridges.
+  #
+  # Also includes "zombie detection": poll_ok is set by any D5 notification (push or
+  # poll response). If 15 poll intervals pass with no data, we force reconnect.
   - id: ${prefix}_periodic_poll
     mode: single
     then:
@@ -436,6 +506,11 @@ script:
           ESP_LOGI("szg", "[${appliance_name}] Periodic poll (miss=%d, retries=%d)",
             id(${prefix}_poll_miss), id(${prefix}_fast_retries));
 
+  # Post-bond discovery sequence - custom because:
+  # 1. On fridges, D5 is not visible in GATT until after bonding + cache refresh.
+  #    ESPHome's ble_client performs discovery once at connect and doesn't re-run it.
+  # 2. We need to match D4/D5/D6/D7/D8 by UUID suffix and cache handles for fast reconnect.
+  # 3. ESPHome does not expose GATT cache management (cache_refresh, cache_clean).
   - id: ${prefix}_post_bond
     mode: restart
     then:
@@ -627,8 +702,11 @@ script:
               client->get_gattc_if(), client->get_remote_bda(), d4);
             ESP_LOGI("ble", "[${appliance_name}] Subscribe D4 (h=%d) for diagnostics", d4);
           }
-          // Manually write CCCD enable value (0x0002 = indications on)
-          // CCCD descriptor is at char_value_handle + 2 (standard BLE layout)
+          // Manually write CCCD enable value (0x0002 = indications on).
+          // CCCD descriptor is at char_value_handle + 2 (standard BLE layout).
+          // Custom write required: ESPHome's `notify: true` auto-writes 0x01 or 0x02
+          // based on characteristic properties (NOTIFY bit → 0x01). Sub-Zero requires
+          // 0x02 regardless; relying on ESPHome's auto-detection is unsafe.
           uint8_t cccd_on[2] = {0x02, 0x00};
           esp_ble_gattc_write_char(
             client->get_gattc_if(), client->get_conn_id(),

--- a/subzero_dishwasher.yaml
+++ b/subzero_dishwasher.yaml
@@ -259,6 +259,37 @@ script:
               id(${prefix}_model).publish_state(data["appliance_model"].as<std::string>());
             if (data["uptime"].is<const char*>())
               id(${prefix}_uptime).publish_state(data["uptime"].as<std::string>());
+            if (data["appliance_serial"].is<const char*>()) {
+              std::string s = data["appliance_serial"].as<std::string>();
+              size_t start = s.find_first_not_of(" \t");
+              size_t end = s.find_last_not_of(" \t");
+              if (start != std::string::npos)
+                id(${prefix}_serial).publish_state(s.substr(start, end - start + 1));
+            }
+            if (data["appliance_type"].is<const char*>())
+              id(${prefix}_appliance_type).publish_state(data["appliance_type"].as<std::string>());
+            if (data["diagnostic_status"].is<const char*>())
+              id(${prefix}_diag_status).publish_state(data["diagnostic_status"].as<std::string>());
+            if (data["version"].is<JsonObject>()) {
+              JsonObject v = data["version"].as<JsonObject>();
+              if (v["fw"].is<const char*>())
+                id(${prefix}_fw_version).publish_state(v["fw"].as<std::string>());
+              if (v["api"].is<const char*>())
+                id(${prefix}_api_version).publish_state(v["api"].as<std::string>());
+              if (v["bleapp"].is<const char*>())
+                id(${prefix}_bleapp_version).publish_state(v["bleapp"].as<std::string>());
+              if (v["os"].is<const char*>())
+                id(${prefix}_os_version).publish_state(v["os"].as<std::string>());
+              if (v["rtapp"].is<const char*>())
+                id(${prefix}_rtapp_version).publish_state(v["rtapp"].as<std::string>());
+              if (v["appliance"].is<const char*>())
+                id(${prefix}_board_version).publish_state(v["appliance"].as<std::string>());
+            }
+            if (data["build_info"].is<JsonObject>()) {
+              JsonObject b = data["build_info"].as<JsonObject>();
+              if (b["build_date"].is<const char*>())
+                id(${prefix}_build_date).publish_state(b["build_date"].as<std::string>());
+            }
             // Debug: log all keys in the response
             if (id(${prefix}_debug_mode)) {
               for (JsonPair kv : data) {

--- a/subzero_fridge.yaml
+++ b/subzero_fridge.yaml
@@ -107,8 +107,8 @@ sensor:
     icon: "mdi:thermometer"
 
   - platform: template
-    name: "${appliance_name} Freezer Temperature"
-    id: ${prefix}_frz_temp
+    name: "${appliance_name} Freezer Set Temperature"
+    id: ${prefix}_frz_set_temp
     unit_of_measurement: "°F"
     device_class: temperature
     state_class: measurement
@@ -117,8 +117,8 @@ sensor:
     internal: ${hide_freezer}
 
   - platform: template
-    name: "${appliance_name} Wine Zone Upper Temperature"
-    id: ${prefix}_wine_temp
+    name: "${appliance_name} Wine Zone Upper Set Temperature"
+    id: ${prefix}_wine_set_temp
     unit_of_measurement: "°F"
     device_class: temperature
     state_class: measurement
@@ -127,8 +127,8 @@ sensor:
     internal: ${hide_wine}
 
   - platform: template
-    name: "${appliance_name} Wine Zone Lower Temperature"
-    id: ${prefix}_wine2_temp
+    name: "${appliance_name} Wine Zone Lower Set Temperature"
+    id: ${prefix}_wine2_set_temp
     unit_of_measurement: "°F"
     device_class: temperature
     state_class: measurement
@@ -137,8 +137,8 @@ sensor:
     internal: ${hide_wine}
 
   - platform: template
-    name: "${appliance_name} Refrigerator Drawer Temperature"
-    id: ${prefix}_ref2_temp
+    name: "${appliance_name} Refrigerator Drawer Set Temperature"
+    id: ${prefix}_ref2_set_temp
     unit_of_measurement: "°F"
     device_class: temperature
     state_class: measurement
@@ -147,8 +147,8 @@ sensor:
     internal: ${hide_ref_drawer}
 
   - platform: template
-    name: "${appliance_name} Crisper Drawer Temperature"
-    id: ${prefix}_crisp_temp
+    name: "${appliance_name} Crisper Drawer Set Temperature"
+    id: ${prefix}_crisp_set_temp
     unit_of_measurement: "°F"
     device_class: temperature
     state_class: measurement
@@ -299,28 +299,28 @@ script:
               id(${prefix}_door_ajar).publish_state(data["door_ajar"].as<bool>());
             // --- Freezer sensors ---
             if (data["frz_set_temp"].is<float>())
-              id(${prefix}_frz_temp).publish_state(data["frz_set_temp"].as<float>());
+              id(${prefix}_frz_set_temp).publish_state(data["frz_set_temp"].as<float>());
             if (data["frz_door_ajar"].is<bool>())
               id(${prefix}_frz_door_ajar).publish_state(data["frz_door_ajar"].as<bool>());
             if (data["ice_maker_on"].is<bool>())
               id(${prefix}_ice_maker).publish_state(data["ice_maker_on"].as<bool>());
             // --- Refrigerator drawer sensors ---
             if (data["ref2_set_temp"].is<float>())
-              id(${prefix}_ref2_temp).publish_state(data["ref2_set_temp"].as<float>());
+              id(${prefix}_ref2_set_temp).publish_state(data["ref2_set_temp"].as<float>());
             if (data["ref2_door_ajar"].is<bool>())
               id(${prefix}_ref2_door_ajar).publish_state(data["ref2_door_ajar"].as<bool>());
             // --- Wine sensors ---
             if (data["wine_door_ajar"].is<bool>())
               id(${prefix}_wine_door_ajar).publish_state(data["wine_door_ajar"].as<bool>());
             if (data["wine_set_temp"].is<float>())
-              id(${prefix}_wine_temp).publish_state(data["wine_set_temp"].as<float>());
+              id(${prefix}_wine_set_temp).publish_state(data["wine_set_temp"].as<float>());
             if (data["wine2_set_temp"].is<float>())
-              id(${prefix}_wine2_temp).publish_state(data["wine2_set_temp"].as<float>());
+              id(${prefix}_wine2_set_temp).publish_state(data["wine2_set_temp"].as<float>());
             if (data["wine_temp_alert_on"].is<bool>())
               id(${prefix}_wine_temp_alert).publish_state(data["wine_temp_alert_on"].as<bool>());
             // --- Crisper drawer sensors ---
             if (data["crisp_set_temp"].is<float>())
-              id(${prefix}_crisp_temp).publish_state(data["crisp_set_temp"].as<float>());
+              id(${prefix}_crisp_set_temp).publish_state(data["crisp_set_temp"].as<float>());
             // --- Filter sensors ---
             if (data["air_filter_on"].is<bool>())
               id(${prefix}_air_filter_on).publish_state(data["air_filter_on"].as<bool>());
@@ -338,6 +338,37 @@ script:
               id(${prefix}_model).publish_state(data["appliance_model"].as<std::string>());
             if (data["uptime"].is<const char*>())
               id(${prefix}_uptime).publish_state(data["uptime"].as<std::string>());
+            if (data["appliance_serial"].is<const char*>()) {
+              std::string s = data["appliance_serial"].as<std::string>();
+              size_t start = s.find_first_not_of(" \t");
+              size_t end = s.find_last_not_of(" \t");
+              if (start != std::string::npos)
+                id(${prefix}_serial).publish_state(s.substr(start, end - start + 1));
+            }
+            if (data["appliance_type"].is<const char*>())
+              id(${prefix}_appliance_type).publish_state(data["appliance_type"].as<std::string>());
+            if (data["diagnostic_status"].is<const char*>())
+              id(${prefix}_diag_status).publish_state(data["diagnostic_status"].as<std::string>());
+            if (data["version"].is<JsonObject>()) {
+              JsonObject v = data["version"].as<JsonObject>();
+              if (v["fw"].is<const char*>())
+                id(${prefix}_fw_version).publish_state(v["fw"].as<std::string>());
+              if (v["api"].is<const char*>())
+                id(${prefix}_api_version).publish_state(v["api"].as<std::string>());
+              if (v["bleapp"].is<const char*>())
+                id(${prefix}_bleapp_version).publish_state(v["bleapp"].as<std::string>());
+              if (v["os"].is<const char*>())
+                id(${prefix}_os_version).publish_state(v["os"].as<std::string>());
+              if (v["rtapp"].is<const char*>())
+                id(${prefix}_rtapp_version).publish_state(v["rtapp"].as<std::string>());
+              if (v["appliance"].is<const char*>())
+                id(${prefix}_board_version).publish_state(v["appliance"].as<std::string>());
+            }
+            if (data["build_info"].is<JsonObject>()) {
+              JsonObject b = data["build_info"].as<JsonObject>();
+              if (b["build_date"].is<const char*>())
+                id(${prefix}_build_date).publish_state(b["build_date"].as<std::string>());
+            }
             // Debug: log all keys in the response
             if (id(${prefix}_debug_mode)) {
               for (JsonPair kv : data) {

--- a/subzero_range.yaml
+++ b/subzero_range.yaml
@@ -453,6 +453,37 @@ script:
               id(${prefix}_model).publish_state(data["appliance_model"].as<std::string>());
             if (data["uptime"].is<const char*>())
               id(${prefix}_uptime).publish_state(data["uptime"].as<std::string>());
+            if (data["appliance_serial"].is<const char*>()) {
+              std::string s = data["appliance_serial"].as<std::string>();
+              size_t start = s.find_first_not_of(" \t");
+              size_t end = s.find_last_not_of(" \t");
+              if (start != std::string::npos)
+                id(${prefix}_serial).publish_state(s.substr(start, end - start + 1));
+            }
+            if (data["appliance_type"].is<const char*>())
+              id(${prefix}_appliance_type).publish_state(data["appliance_type"].as<std::string>());
+            if (data["diagnostic_status"].is<const char*>())
+              id(${prefix}_diag_status).publish_state(data["diagnostic_status"].as<std::string>());
+            if (data["version"].is<JsonObject>()) {
+              JsonObject v = data["version"].as<JsonObject>();
+              if (v["fw"].is<const char*>())
+                id(${prefix}_fw_version).publish_state(v["fw"].as<std::string>());
+              if (v["api"].is<const char*>())
+                id(${prefix}_api_version).publish_state(v["api"].as<std::string>());
+              if (v["bleapp"].is<const char*>())
+                id(${prefix}_bleapp_version).publish_state(v["bleapp"].as<std::string>());
+              if (v["os"].is<const char*>())
+                id(${prefix}_os_version).publish_state(v["os"].as<std::string>());
+              if (v["rtapp"].is<const char*>())
+                id(${prefix}_rtapp_version).publish_state(v["rtapp"].as<std::string>());
+              if (v["appliance"].is<const char*>())
+                id(${prefix}_board_version).publish_state(v["appliance"].as<std::string>());
+            }
+            if (data["build_info"].is<JsonObject>()) {
+              JsonObject b = data["build_info"].as<JsonObject>();
+              if (b["build_date"].is<const char*>())
+                id(${prefix}_build_date).publish_state(b["build_date"].as<std::string>());
+            }
             // Debug: log all keys in the response
             if (id(${prefix}_debug_mode)) {
               for (JsonPair kv : data) {


### PR DESCRIPTION
## Summary

- **BREAKING:** Rename fridge/wine/crisper/drawer temperature sensors (and their internal IDs) to include `set` — clarifies that Sub-Zero BLE firmware only exposes setpoints, not actual measured compartment temps. Wolf range `cav_temp`/`cav_probe_temp` remain unchanged (those are real measurements).
- Add 10 diagnostic text sensors exposed across all appliance types (fridge, range, dishwasher): Appliance Serial, Appliance Type, Diagnostic Status, Firmware/API/BLE App/OS/RTApp Versions, Appliance Board Version (raw composite), and Build Date. All tagged `entity_category: diagnostic`.
- Document the fridge actual-temp limitation in `docs/ble-protocol.adoc` and `README.adoc`, with evidence from an IW30R wine fridge (fw 2.27).

## Breaking changes

### HA entity IDs

| Old | New |
|---|---|
| `sensor.<name>_freezer_temperature` | `sensor.<name>_freezer_set_temperature` |
| `sensor.<name>_wine_zone_upper_temperature` | `sensor.<name>_wine_zone_upper_set_temperature` |
| `sensor.<name>_wine_zone_lower_temperature` | `sensor.<name>_wine_zone_lower_set_temperature` |
| `sensor.<name>_refrigerator_drawer_temperature` | `sensor.<name>_refrigerator_drawer_set_temperature` |
| `sensor.<name>_crisper_drawer_temperature` | `sensor.<name>_crisper_drawer_set_temperature` |

### ESPHome internal IDs (only affects users with custom lambdas referencing these)

| Old | New |
|---|---|
| `${prefix}_frz_temp` | `${prefix}_frz_set_temp` | | `${prefix}_wine_temp` | `${prefix}_wine_set_temp` |
| `${prefix}_wine2_temp` | `${prefix}_wine2_set_temp` | | `${prefix}_ref2_temp` | `${prefix}_ref2_set_temp` |
| `${prefix}_crisp_temp` | `${prefix}_crisp_set_temp` |

## Why

Empirical debug capture of an IW30R across a setpoint change that would drive the compressor showed zero `*_cur_temp` / `*_actual_temp` / plain `*_temp` keys in any response over 4+ minutes. The firmware tracks actual temps internally (it exposes `wine_temp_alert_on` as a derived boolean) but doesn't publish them over BLE. The old sensor names and internal IDs misleadingly implied real temperatures.

closes https://github.com/JonGilmore/esphome-subzero-ble/issues/53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diagnostic sensors exposing appliance metadata (serial number, appliance type, firmware/API/OS versions, board version, build date).

* **Documentation**
  * Clarified that Sub-Zero refrigerators expose setpoint temperatures only; measured compartment temperatures are not available (unlike Wolf ranges).

* **Bug Fixes**
  * Renamed refrigerator temperature sensors to accurately reflect they report setpoints rather than actual temperatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->