### PR TITLE
fix(log): sanitize raw-buf log lines + gate chunked payload on debug mode

### DIFF
--- a/docs/advanced.adoc
+++ b/docs/advanced.adoc
@@ -190,12 +190,15 @@ ctest --test-dir build --output-on-failure
 
 First run fetches ArduinoJson, GoogleTest, and nlohmann/json via CMake's `FetchContent` (~20 seconds). Subsequent runs compile in under a second and tests complete in milliseconds. The CI workflow runs the same commands on every push and PR (cached).
 
-To add a fixture for a new appliance variant: turn on *Debug Mode*, copy the raw JSON from the ESPHome logs into `tests/fixtures/<name>.json`, then record the expected parser output in `tests/fixtures/<name>.expected.json`. The test discovery picks up new pairs automatically.
+To add a fixture for a new appliance variant: turn on *Debug Mode*, concatenate the `Response[N/M]:` lines from the ESPHome logs (grep `Response\[` and stitch in order) into `tests/fixtures/<name>.json`, then record the expected parser output in `tests/fixtures/<name>.expected.json`. The test discovery picks up new pairs automatically.
 
 == Debug Mode
 
 Each appliance exposes a *Debug Mode* switch and a *Log Debug Info* button in Home Assistant (both under diagnostic entities).
-When debug mode is enabled, the full response payload is logged at `INFO` level on every poll or push notification, and all response keys are logged under the `szg-debug` tag - making it easy to identify what data an untested appliance sends.
+When debug mode is enabled, the full response payload is logged at `INFO` level in chunked `Response[N/M]:` lines (chunked at 400 bytes to fit the per-line log budget) and all top-level response keys are logged under the `szg-debug` tag - making it easy to identify what data an untested appliance sends.
+Grep for `Response\[` and concatenate the payloads in order to reassemble the full JSON.
+
+IMPORTANT: Debug-mode payload logging is intentionally gated behind the switch. Normal operation never logs raw BLE bytes, because any non-UTF-8 byte in a log message crashes Home Assistant's protobuf decoder (`LogEntryResponse` requires valid UTF-8) and HA caches the bad event into a restart loop. When debug mode IS on, bytes outside the printable-ASCII range are replaced with `?` as a safety net.
 
 The *Log Debug Info* button is a one-press shortcut: it turns on debug mode and immediately polls the appliance using the correct channel for that appliance type.
 
@@ -204,7 +207,7 @@ The *Log Debug Info* button is a one-press shortcut: it turns on debug mode and 
 Dishwashers and ranges respond to polls on the D5 (encrypted) channel with their full state - all sensor keys in a single response.
 
 . Press *Log Debug Info* (or turn on *Debug Mode* and press *Poll*).
-. The full JSON appears in the ESPHome logs and all keys are logged.
+. Grep `Response\[` in the ESPHome logs, concatenate the chunks in order to get the full JSON.
 . Turn *Debug Mode* off when done.
 
 === Refrigerators / Freezers

--- a/docs/ble-protocol.adoc
+++ b/docs/ble-protocol.adoc
@@ -149,6 +149,8 @@ The integration accepts that some payloads will be unreadable and relies on the 
 Earlier revisions tried to actively *detect* fragment drops by discarding the buffer whenever a new chunk's leading `{` appeared while brace depth was non-zero. That heuristic misfired whenever a short push notification arrived during a long poll response (common on fw 8.5 wall ovens whose full state is ~1.9 KB across 48 fragments), throwing away an almost-complete legitimate poll. The current code prefers the quieter v0.21.0-era behavior: let the buffer accumulate, and trust that the 60s periodic poll plus natural push traffic will produce a clean parse within a cycle or two.
 +
 On appliances whose full-state response reliably hits the ACL bug (wall ovens, 313 fridge), the "poll-only" sensors (model, uptime, serial, sabbath_on, version tree) may still take several cycles to populate, but they will eventually land whenever one full response arrives intact. Push-driven sensors (door, light, setpoint changes) work regardless.
++
+Any raw-buffer content that reaches ESPHome's logger (the debug-mode `Response[N/M]:` chunks, the `Parse failed...` preview) is pre-sanitized: bytes outside the printable-ASCII range `0x20..0x7E` are replaced with `?`. Non-UTF-8 bytes in an API log message crash Home Assistant's protobuf decoder the same way they used to crash it via the retired `Raw JSON` text sensor, and HA caches the bad event. Sanitization keeps the log channel safe without touching what the parser actually sees.
 
 == Command Reference
 

--- a/subzero_dishwasher.yaml
+++ b/subzero_dishwasher.yaml
@@ -157,21 +157,34 @@ script:
           if (start > 0) buf.erase(0, start);
           bool dbg = id(${prefix}_debug_mode);
           ESP_LOGI("szg", "[${appliance_name}] Parsing JSON (%d bytes)", (int)buf.size());
-          if (dbg || buf.size() >= 255) {
-            // Chunked so the full payload survives the 768-byte task log buffer.
-            // Grep `Response\[` and concatenate to reassemble - used by fixture capture.
-            const size_t CHUNK = 600;
+          // Raw buf may contain non-UTF-8 bytes from ACL fragment corruption.
+          // Anything we log from buf MUST be sanitized first: the log message
+          // is sent to HA as a protobuf `string` (UTF-8 required) and non-UTF-8
+          // bytes crash HA's protobuf decoder, which caches the bad event and
+          // loops. Replace non-printable-ASCII with '?'.
+          auto sanitize = [](const std::string &s, size_t off, size_t len) {
+            std::string out(s, off, len);
+            for (char &c : out) if ((unsigned char)c < 0x20 || (unsigned char)c > 0x7E) c = '?';
+            return out;
+          };
+          if (dbg) {
+            // Chunked so the full payload survives the per-line log budget.
+            // Grep `Response\[` and concatenate to reassemble - used for fixture
+            // capture. Gated on debug mode so normal operation never logs raw
+            // buf contents.
+            const size_t CHUNK = 400;
             size_t total = (buf.size() + CHUNK - 1) / CHUNK;
             for (size_t i = 0; i < total; i++) {
               size_t off = i * CHUNK;
               size_t len = std::min(CHUNK, buf.size() - off);
-              ESP_LOGI("szg", "[${appliance_name}] Response[%d/%d]: %.*s",
-                       (int)(i + 1), (int)total, (int)len, buf.c_str() + off);
+              ESP_LOGI("szg", "[${appliance_name}] Response[%d/%d]: %s",
+                       (int)(i + 1), (int)total, sanitize(buf, off, len).c_str());
             }
           }
           auto s = esphome::subzero_protocol::parse_dishwasher(buf);
           if (!s.valid) {
-            ESP_LOGW("szg", "[${appliance_name}] Parse failed or status!=0, skipping (%.80s...)", buf.c_str());
+            ESP_LOGW("szg", "[${appliance_name}] Parse failed or status!=0, skipping (%s...)",
+                     sanitize(buf, 0, std::min<size_t>(80, buf.size())).c_str());
             buf.clear();
             return;
           }

--- a/subzero_dishwasher.yaml
+++ b/subzero_dishwasher.yaml
@@ -159,12 +159,21 @@ script:
           ESP_LOGI("szg", "[${appliance_name}] Parsing JSON (%d bytes)", (int)buf.size());
           // Raw buf may contain non-UTF-8 bytes from ACL fragment corruption.
           // Anything we log from buf MUST be sanitized first: the log message
-          // is sent to HA as a protobuf `string` (UTF-8 required) and non-UTF-8
-          // bytes crash HA's protobuf decoder, which caches the bad event and
-          // loops. Replace non-printable-ASCII with '?'.
+          // is sent to HA as a protobuf `string` (UTF-8 required) and a
+          // high-bit byte (0x80-0xFF) that isn't part of a valid multi-byte
+          // sequence crashes HA's protobuf decoder, which caches the bad
+          // event and loops. Allow printable ASCII plus \t \n \r (all valid
+          // UTF-8 and harmless in protobuf); everything else becomes '?'.
+          // Keeping \n unsanitized means the normal protocol terminator at
+          // the end of every response no longer triggers a nuisance '?' -
+          // so any '?' that now appears is a real signal of corruption.
           auto sanitize = [](const std::string &s, size_t off, size_t len) {
             std::string out(s, off, len);
-            for (char &c : out) if ((unsigned char)c < 0x20 || (unsigned char)c > 0x7E) c = '?';
+            for (char &c : out) {
+              unsigned char u = c;
+              bool ok = (u >= 0x20 && u <= 0x7E) || u == 0x09 || u == 0x0A || u == 0x0D;
+              if (!ok) c = '?';
+            }
             return out;
           };
           if (dbg) {

--- a/subzero_fridge.yaml
+++ b/subzero_fridge.yaml
@@ -254,21 +254,34 @@ script:
           if (start > 0) buf.erase(0, start);
           bool dbg = id(${prefix}_debug_mode);
           ESP_LOGI("szg", "[${appliance_name}] Parsing JSON (%d bytes)", (int)buf.size());
-          if (dbg || buf.size() >= 255) {
-            // Chunked so the full payload survives the 768-byte task log buffer.
-            // Grep `Response\[` and concatenate to reassemble - used by fixture capture.
-            const size_t CHUNK = 600;
+          // Raw buf may contain non-UTF-8 bytes from ACL fragment corruption.
+          // Anything we log from buf MUST be sanitized first: the log message
+          // is sent to HA as a protobuf `string` (UTF-8 required) and non-UTF-8
+          // bytes crash HA's protobuf decoder, which caches the bad event and
+          // loops. Replace non-printable-ASCII with '?'.
+          auto sanitize = [](const std::string &s, size_t off, size_t len) {
+            std::string out(s, off, len);
+            for (char &c : out) if ((unsigned char)c < 0x20 || (unsigned char)c > 0x7E) c = '?';
+            return out;
+          };
+          if (dbg) {
+            // Chunked so the full payload survives the per-line log budget.
+            // Grep `Response\[` and concatenate to reassemble - used for fixture
+            // capture. Gated on debug mode so normal operation never logs raw
+            // buf contents.
+            const size_t CHUNK = 400;
             size_t total = (buf.size() + CHUNK - 1) / CHUNK;
             for (size_t i = 0; i < total; i++) {
               size_t off = i * CHUNK;
               size_t len = std::min(CHUNK, buf.size() - off);
-              ESP_LOGI("szg", "[${appliance_name}] Response[%d/%d]: %.*s",
-                       (int)(i + 1), (int)total, (int)len, buf.c_str() + off);
+              ESP_LOGI("szg", "[${appliance_name}] Response[%d/%d]: %s",
+                       (int)(i + 1), (int)total, sanitize(buf, off, len).c_str());
             }
           }
           auto s = esphome::subzero_protocol::parse_fridge(buf);
           if (!s.valid) {
-            ESP_LOGW("szg", "[${appliance_name}] Parse failed or status!=0, skipping (%.80s...)", buf.c_str());
+            ESP_LOGW("szg", "[${appliance_name}] Parse failed or status!=0, skipping (%s...)",
+                     sanitize(buf, 0, std::min<size_t>(80, buf.size())).c_str());
             buf.clear();
             return;
           }

--- a/subzero_fridge.yaml
+++ b/subzero_fridge.yaml
@@ -256,12 +256,21 @@ script:
           ESP_LOGI("szg", "[${appliance_name}] Parsing JSON (%d bytes)", (int)buf.size());
           // Raw buf may contain non-UTF-8 bytes from ACL fragment corruption.
           // Anything we log from buf MUST be sanitized first: the log message
-          // is sent to HA as a protobuf `string` (UTF-8 required) and non-UTF-8
-          // bytes crash HA's protobuf decoder, which caches the bad event and
-          // loops. Replace non-printable-ASCII with '?'.
+          // is sent to HA as a protobuf `string` (UTF-8 required) and a
+          // high-bit byte (0x80-0xFF) that isn't part of a valid multi-byte
+          // sequence crashes HA's protobuf decoder, which caches the bad
+          // event and loops. Allow printable ASCII plus \t \n \r (all valid
+          // UTF-8 and harmless in protobuf); everything else becomes '?'.
+          // Keeping \n unsanitized means the normal protocol terminator at
+          // the end of every response no longer triggers a nuisance '?' -
+          // so any '?' that now appears is a real signal of corruption.
           auto sanitize = [](const std::string &s, size_t off, size_t len) {
             std::string out(s, off, len);
-            for (char &c : out) if ((unsigned char)c < 0x20 || (unsigned char)c > 0x7E) c = '?';
+            for (char &c : out) {
+              unsigned char u = c;
+              bool ok = (u >= 0x20 && u <= 0x7E) || u == 0x09 || u == 0x0A || u == 0x0D;
+              if (!ok) c = '?';
+            }
             return out;
           };
           if (dbg) {

--- a/subzero_range.yaml
+++ b/subzero_range.yaml
@@ -325,21 +325,34 @@ script:
           if (start > 0) buf.erase(0, start);
           bool dbg = id(${prefix}_debug_mode);
           ESP_LOGI("szg", "[${appliance_name}] Parsing JSON (%d bytes)", (int)buf.size());
-          if (dbg || buf.size() >= 255) {
-            // Chunked so the full payload survives the 768-byte task log buffer.
-            // Grep `Response\[` and concatenate to reassemble - used by fixture capture.
-            const size_t CHUNK = 600;
+          // Raw buf may contain non-UTF-8 bytes from ACL fragment corruption.
+          // Anything we log from buf MUST be sanitized first: the log message
+          // is sent to HA as a protobuf `string` (UTF-8 required) and non-UTF-8
+          // bytes crash HA's protobuf decoder, which caches the bad event and
+          // loops. Replace non-printable-ASCII with '?'.
+          auto sanitize = [](const std::string &s, size_t off, size_t len) {
+            std::string out(s, off, len);
+            for (char &c : out) if ((unsigned char)c < 0x20 || (unsigned char)c > 0x7E) c = '?';
+            return out;
+          };
+          if (dbg) {
+            // Chunked so the full payload survives the per-line log budget.
+            // Grep `Response\[` and concatenate to reassemble - used for fixture
+            // capture. Gated on debug mode so normal operation never logs raw
+            // buf contents.
+            const size_t CHUNK = 400;
             size_t total = (buf.size() + CHUNK - 1) / CHUNK;
             for (size_t i = 0; i < total; i++) {
               size_t off = i * CHUNK;
               size_t len = std::min(CHUNK, buf.size() - off);
-              ESP_LOGI("szg", "[${appliance_name}] Response[%d/%d]: %.*s",
-                       (int)(i + 1), (int)total, (int)len, buf.c_str() + off);
+              ESP_LOGI("szg", "[${appliance_name}] Response[%d/%d]: %s",
+                       (int)(i + 1), (int)total, sanitize(buf, off, len).c_str());
             }
           }
           auto s = esphome::subzero_protocol::parse_range(buf);
           if (!s.valid) {
-            ESP_LOGW("szg", "[${appliance_name}] Parse failed or status!=0, skipping (%.80s...)", buf.c_str());
+            ESP_LOGW("szg", "[${appliance_name}] Parse failed or status!=0, skipping (%s...)",
+                     sanitize(buf, 0, std::min<size_t>(80, buf.size())).c_str());
             buf.clear();
             return;
           }

--- a/subzero_range.yaml
+++ b/subzero_range.yaml
@@ -327,12 +327,21 @@ script:
           ESP_LOGI("szg", "[${appliance_name}] Parsing JSON (%d bytes)", (int)buf.size());
           // Raw buf may contain non-UTF-8 bytes from ACL fragment corruption.
           // Anything we log from buf MUST be sanitized first: the log message
-          // is sent to HA as a protobuf `string` (UTF-8 required) and non-UTF-8
-          // bytes crash HA's protobuf decoder, which caches the bad event and
-          // loops. Replace non-printable-ASCII with '?'.
+          // is sent to HA as a protobuf `string` (UTF-8 required) and a
+          // high-bit byte (0x80-0xFF) that isn't part of a valid multi-byte
+          // sequence crashes HA's protobuf decoder, which caches the bad
+          // event and loops. Allow printable ASCII plus \t \n \r (all valid
+          // UTF-8 and harmless in protobuf); everything else becomes '?'.
+          // Keeping \n unsanitized means the normal protocol terminator at
+          // the end of every response no longer triggers a nuisance '?' -
+          // so any '?' that now appears is a real signal of corruption.
           auto sanitize = [](const std::string &s, size_t off, size_t len) {
             std::string out(s, off, len);
-            for (char &c : out) if ((unsigned char)c < 0x20 || (unsigned char)c > 0x7E) c = '?';
+            for (char &c : out) {
+              unsigned char u = c;
+              bool ok = (u >= 0x20 && u <= 0x7E) || u == 0x09 || u == 0x0A || u == 0x0D;
+              if (!ok) c = '?';
+            }
             return out;
           };
           if (dbg) {

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -2,7 +2,7 @@
 
 Captured from real appliances via debug-mode ESPHome logs. Each `*.json` is a raw BLE payload; the paired `*.expected.json` is the expected output of `subzero_protocol::parse_*` for that input.
 
-To regenerate an expected file: enable debug mode on the appliance, concatenate the `Response[N/M]:` lines from the ESPHome logs (the payload is chunked at ~600 bytes to fit the task log buffer), save the reassembled JSON here, and record the entity publish log lines that follow. Expected fields use the internal names used by the C++ parser (not the sensor display names).
+To regenerate an expected file: **turn on Debug Mode** on the appliance (the `*_debug_switch` in HA) — chunked payload logging is gated behind it so normal operation never logs raw BLE bytes. Then concatenate the `Response[N/M]:` lines from the ESPHome logs (the payload is chunked at 400 bytes to fit the per-line log budget) into `tests/fixtures/<name>.json` and record the entity publish log lines that follow into `<name>.expected.json`. Note that non-printable bytes in the log are replaced with `?` (anti-footgun against non-UTF-8 in HA's protobuf log channel); fixtures should be hand-edited to use the real bytes or captured from a clean poll with no ACL corruption.
 
 ## Layout
 


### PR DESCRIPTION
## Summary

HA crashes were still happening after #61 merged — same protobuf-decode-on-non-UTF-8 failure mode the retired \`raw_json\` text sensor used to cause, just reintroduced through the log channel.

The parse_json scripts were logging raw buf bytes in two places:

1. \`Response[N/M]: %.*s\` — fired on every poll (>= 255 bytes) AND every push via \`buf.size() >= 255\`, copying raw buf into the log message. Log messages go to HA as \`LogEntryResponse.message\` (protobuf \`string\`, UTF-8 required). A non-UTF-8 byte from ACL corruption crashes HA's decoder, HA caches the bad event, restart loop.
2. \`Parse failed ... (%.80s...)\` — 80-byte preview on parse failure, same failure mode on a smaller window.

Also discovered the chunked logging itself was silently dropping ~150 chars at each 600-byte boundary — ESPHome's per-line log budget after prefix + ANSI codes is actually ~450 chars, not the ~700 I'd calculated. User noticed this as \`\"mode\":0,\` in chunk 2 concatenated with \`e\":2,\` in chunk 3 producing obvious nonsense — the \`\"wash_mod\` between them was dropped.

## Fixes

- **Sanitize any buf content before logging**: bytes outside the printable-ASCII range \`0x20..0x7E\` replaced with \`?\`. Protobuf-safe regardless of what ACL garbage arrived. Applied to both \`Response[N/M]\` chunks and the \`Parse failed\` 80-byte preview.
- **Gate chunked \`Response[N/M]\` output behind debug mode.** Normal operation never logs raw buf content, period. The old \`dbg || buf.size() >= 255\` condition meant every poll response chunked automatically; now it's \`if (dbg)\` only. Fixture-capture workflow explicitly requires turning on Debug Mode.
- **Reduce \`CHUNK\` from 600 to 400** so chunks actually fit the per-line log budget when debug mode IS on — no more silent char drops at boundaries.

## Files

- \`subzero_base.yaml\` / \`subzero_fridge.yaml\` / \`subzero_dishwasher.yaml\` / \`subzero_range.yaml\` — apply the sanitization + debug-gating in each parse_json script
- \`docs/advanced.adoc\` — Debug Mode section documents the chunked workflow + UTF-8 safety net; fixture-capture workflow updated
- \`docs/ble-protocol.adoc\` — ACL Fragment Drops section adds a paragraph on log-channel sanitization
- \`tests/fixtures/README.md\` — fixture regeneration workflow updated to note Debug Mode is required

## Test plan

- [x] \`esphome config\` validates all three minimal configs
- [x] \`esphome compile wolf-minimal-range.yaml\` succeeds after forced rebuild (\`rm -rf .esphome/build/wolf-range/src\` — see AGENTS.md, config_hash doesn't include lambda bodies)
- [x] C++ parser unit tests: 37/37 pass
- [ ] Flash to szg-kitchen02 and verify:
  - Normal operation logs \`Parsing JSON (N bytes)\` but NOT \`Response[N/M]\` lines
  - Enabling Debug Mode produces \`Response[1/6]\` through \`Response[6/6]\` lines (assuming 2160-byte Wall Oven response → 6 chunks at 400 bytes each)
  - Boundaries concatenate cleanly with no missing chars
  - HA stops crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log safety to prevent Home Assistant crashes caused by invalid UTF-8 bytes in debug output.
  * Non-printable bytes in logs are now replaced with `?` to ensure system stability.

* **Documentation**
  * Updated debug mode guides with clearer instructions for reconstructing device responses from chunked log entries.
  * Updated test fixture creation procedures to reflect new logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->