### PR TITLE
fix: stagger bonding + per-cycle subscribe-retry on stale unlock

### DIFF
--- a/docs/advanced.adoc
+++ b/docs/advanced.adoc
@@ -150,6 +150,38 @@ The `Log Debug Info` button on each appliance also calls `_subscribe.execute()` 
 
 `poll_offset` (substitution, default `0s`) is applied at the top of `periodic_poll`, `post_bond`, and `fast_reconnect`. Setting per-appliance values like `0s / 5s / 10s` on a multi-appliance ESP32 spreads the bonding chains in time so the concurrent-bonding race doesn't trigger in the first place. The subscribe-retry path above remains as a safety net.
 
+=== Push-Only Mode for fw 8.5 Appliances
+
+`push_only_after_first_poll` (substitution, default `"false"`) opts out of periodic polling after the first successful response. Recommended for Sub-Zero 313 fridges, Wolf SO3050PESP wall ovens, and any other fw 8.5 / API 5.4 appliance whose unlock session expires within ~1 minute.
+
+When set to `"true"`:
+
+* `periodic_poll` fires once after each (re)connect to land an initial full state, then sets `first_poll_done`.
+* On every subsequent tick, `periodic_poll` returns early without writing `get_async`.
+* The connection stays alive via push notifications (CCCD-based, not session-based), which keep `poll_ok` set so zombie detection doesn't fire spuriously.
+* If 15 minutes of total silence (no polls AND no pushes) ever happens, zombie detection still triggers a reconnect, which lands a fresh poll.
+
+This matches the strategy of the official Sub-Zero Android app (poll briefly, stop polling once async indications flow, rely on pushes thereafter - see link:ble-protocol.adoc#_unlock_session_research_fw_8_5[Unlock Session Research]).
+
+The trade-off: poll-only sensors (model, uptime, version tree, sabbath_on, setpoints) refresh only when a fresh connect happens. They don't drift because they don't change much - the appliance model never changes, the version doesn't change without a firmware update. Setpoints and live state changes arrive via pushes (`cav_temp`, `cav_door_ajar`, `cav_light_on`, `cav_set_temp`, etc.).
+
+For fw 2.27 / API 5.5 appliances (most dishwashers, most ranges, most wine fridges), keep the default `"false"` - their unlock session lasts long enough for the standard 60s polling cadence to work. Likewise keep the default for fridge configurations using `poll_via_d4: "true"` since D4 polls don't need an unlock at all.
+
+Per-appliance configuration in your entry-point YAML:
+
+[source,yaml]
+----
+packages:
+  main_fridge: !include
+    file: subzero_fridge.yaml
+    vars:
+      prefix: "szg"
+      appliance_name: "Main Fridge"
+      appliance_mac: !secret main_fridge_mac
+      appliance_pin: !secret main_fridge_pin
+      push_only_after_first_poll: "true"   # fw 8.5 fridge
+----
+
 === Log Format
 
 [source]

--- a/docs/advanced.adoc
+++ b/docs/advanced.adoc
@@ -140,7 +140,9 @@ Two distinct conditions land the same appliance in the same state - bonded and c
 
 When `periodic_poll` fires and finds `poll_in_flight` still `true` from the previous tick, the previous poll went unanswered. Instead of writing another bare `get_async` into the void, it runs `_subscribe.execute()` - which re-writes CCCDs (idempotent), re-issues `unlock_channel`, and writes `get_async` again. The `unlock_channel` response is small (40 bytes, single fragment, not vulnerable to ACL drops) so it parses cleanly and clears `poll_in_flight`. Next tick takes the bare-poll path again.
 
-For the false-positive scenario the prior unlock-expiry detector hit (a push interleaving with a poll on fw 8.5 makes the poll's brace-balance never reach zero, so we never get an `is_poll=true` parse): re-running subscribe is the right response anyway. It refreshes the session and the next attempt either succeeds or repeats the cycle - no reconnect loop, no false positives.
+`unanswered_polls` is a small int counter that increments each time the subscribe-retry branch fires. It resets to 0 on any valid `is_poll` parse and on disconnect. When it reaches 3 (= 3 minutes of subscribe-retries that produced no poll response - not even an `unlock_channel` reply), the session is wedged at a level even subscribe can't unstick (we never even saw the unlock response come back). At that point the script calls `client->disconnect()` and `auto_connect: true` brings the connection back from scratch. This is intentionally faster than zombie detection (15 min) because zombie won't fire as long as pushes keep flowing.
+
+For the false-positive scenario the prior unlock-expiry detector hit (a push interleaving with a poll on fw 8.5 makes the poll's brace-balance never reach zero, so we never get an `is_poll=true` parse): re-running subscribe is the right response anyway. The unlock response on retry parses cleanly and clears the counter. We only escalate to reconnect if even unlock_channel goes silent - which is the genuinely-stuck case where reconnecting is correct.
 
 The `Log Debug Info` button on each appliance also calls `_subscribe.execute()` for the same reason: a bare `get_async` from the button doesn't work on a stale-unlock fw 8.5 appliance. Going through subscribe refreshes the session first.
 
@@ -153,12 +155,14 @@ The `Log Debug Info` button on each appliance also calls `_subscribe.execute()` 
 [source]
 ----
 [I][szg:XXX]: [Left Dishwasher] Periodic poll (miss=2, retries=0)
-[W][szg:XXX]: [Wall Oven] Previous poll unanswered - re-running subscribe to refresh session
+[W][szg:XXX]: [Wall Oven] Previous poll unanswered (1/3) - re-running subscribe to refresh session
+[W][szg:XXX]: [Wall Oven] 3 subscribe retries unanswered - session wedged, forcing reconnect
 ----
 
 * `miss` - zombie counter (0-15, reconnect at 15 = 15 min of total silence)
 * `retries` - fast-reconnect retry counter (0-3, bond clear at 3; see below)
-* `Previous poll unanswered` - subscribe-retry path firing (poll_in_flight stayed `true` across a tick); on fw 8.5 appliances this is normal once per ~minute as the unlock session refreshes
+* `Previous poll unanswered (N/3)` - subscribe-retry path firing (poll_in_flight stayed `true` across a tick); on fw 8.5 appliances this is normal once per ~minute as the unlock session refreshes
+* `subscribe retries unanswered - session wedged` - escalation to reconnect after 3 subscribe-retries with no poll response
 
 === Fast Reconnect + Bond Clear
 

--- a/docs/advanced.adoc
+++ b/docs/advanced.adoc
@@ -120,7 +120,7 @@ If you experience crashes (typically `__cxa_allocate_exception` -> `operator new
 [[reconnect-logic]]
 == Reconnect Logic
 
-The integration runs a periodic poll every 60 seconds against each bonded appliance, and uses one signal - total BLE silence - to decide when to force a reconnect.
+The integration runs a periodic poll every 60 seconds against each bonded appliance and uses two complementary mechanisms to keep things alive: zombie detection (catches a fully dead link) and a subscribe-retry safety net (catches a half-initialized session where the unlock_channel got dropped).
 
 === Zombie Detection
 
@@ -128,15 +128,29 @@ The integration runs a periodic poll every 60 seconds against each bonded applia
 
 This catches cases where the BLE link has died entirely. It intentionally does *not* try to distinguish "poll silently unanswered" from "appliance is quiet" - past attempts at a tighter signal caused pointless reconnect loops on fw 8.5 appliances whose polls sometimes fail to reassemble (see link:ble-protocol.adoc#_key_protocol_details[ACL Fragment Drops]) while pushes keep flowing.
 
+=== Subscribe Retry on Stuck Connection
+
+When multiple appliances all reconnect simultaneously at boot, the ESP-IDF Bluedroid stack occasionally drops one peer's `unlock_channel` write under the concurrent traffic. That appliance ends up bonded, with CCCDs subscribed and the `get_async` written successfully at the BLE layer (status 0), but the appliance never responds because its session was never unlocked. The connection looks alive at every layer below the protocol.
+
+`first_poll_seen` is a per-appliance bool, cleared on disconnect, set to `true` whenever any parse succeeds (poll OR push). When `periodic_poll` fires and finds it still `false`, instead of writing a bare `get_async` it re-runs the full `_subscribe` script - which re-writes the CCCDs and re-issues `unlock_channel` followed by `get_async`. CCCD writes are idempotent and `unlock_channel` is re-doable, so this is safe to repeat. As soon as one parse lands, `first_poll_seen` flips and the periodic poll resumes its normal write cadence.
+
+This is bounded retry, not a reconnect loop: it keeps the connection (the underlying GATT bond is fine), it just nudges the protocol-layer handshake until the appliance responds. Worst case it runs once every 60s on a permanently-stuck appliance until the 15-minute zombie threshold gives up and forces a full reconnect.
+
+=== Boot Stagger via `poll_offset`
+
+`poll_offset` (substitution, default `0s`) is applied at the top of `periodic_poll`, `post_bond`, and `fast_reconnect`. Setting per-appliance values like `0s / 5s / 10s` on a multi-appliance ESP32 spreads the bonding chains in time so the concurrent-bonding race doesn't trigger in the first place. The subscribe-retry path above remains as a safety net.
+
 === Log Format
 
 [source]
 ----
 [I][szg:XXX]: [Left Dishwasher] Periodic poll (miss=2, retries=0)
+[W][szg:XXX]: [Kitchen Range] No parse since connect - re-running subscribe
 ----
 
 * `miss` - zombie counter (0-15, reconnect at 15 = 15 min of total silence)
 * `retries` - fast-reconnect retry counter (0-3, bond clear at 3; see below)
+* `No parse since connect` - subscribe-retry path firing (Option B); will keep firing once per poll until the appliance responds or zombie kicks in
 
 === Fast Reconnect + Bond Clear
 
@@ -144,10 +158,9 @@ Separately, when the BLE connection drops and `auto_connect: true` reconnects, t
 
 === Tuning
 
-Both knobs are in `subzero_base.yaml`:
-
-* `interval: 60s` (line with `interval:`) - poll cadence. Shortening to 30s halves detection time and doubles radio utilization (still single-digit percent for typical configs).
+* `interval: 60s` in `subzero_base.yaml` - poll cadence. Shortening to 30s halves detection time and doubles radio utilization (still single-digit percent for typical configs).
 * `poll_miss >= 15` - zombie threshold. Scales with the interval: at 60s that's 15 min.
+* `poll_offset` substitution per-appliance - boot stagger. `0s` for first, `5s` or `10s` for subsequent appliances on the same ESP32.
 
 [[parser-component]]
 == Parser Component

--- a/docs/advanced.adoc
+++ b/docs/advanced.adoc
@@ -128,13 +128,21 @@ The integration runs a periodic poll every 60 seconds against each bonded applia
 
 This catches cases where the BLE link has died entirely. It intentionally does *not* try to distinguish "poll silently unanswered" from "appliance is quiet" - past attempts at a tighter signal caused pointless reconnect loops on fw 8.5 appliances whose polls sometimes fail to reassemble (see link:ble-protocol.adoc#_key_protocol_details[ACL Fragment Drops]) while pushes keep flowing.
 
-=== Subscribe Retry on Stuck Connection
+=== Subscribe Retry on Stale Unlock or Stuck Boot
 
-When multiple appliances all reconnect simultaneously at boot, the ESP-IDF Bluedroid stack occasionally drops one peer's `unlock_channel` write under the concurrent traffic. That appliance ends up bonded, with CCCDs subscribed and the `get_async` written successfully at the BLE layer (status 0), but the appliance never responds because its session was never unlocked. The connection looks alive at every layer below the protocol.
+Two distinct conditions land the same appliance in the same state - bonded and connected at the GATT layer, but the command channel goes silent:
 
-`first_poll_seen` is a per-appliance bool, cleared on disconnect, set to `true` whenever any parse succeeds (poll OR push). When `periodic_poll` fires and finds it still `false`, instead of writing a bare `get_async` it re-runs the full `_subscribe` script - which re-writes the CCCDs and re-issues `unlock_channel` followed by `get_async`. CCCD writes are idempotent and `unlock_channel` is re-doable, so this is safe to repeat. As soon as one parse lands, `first_poll_seen` flips and the periodic poll resumes its normal write cadence.
+1. **Cold-boot race.** When multiple appliances reconnect simultaneously at boot, the ESP-IDF Bluedroid stack occasionally drops one peer's `unlock_channel` write under the concurrent traffic. That appliance ends up subscribed and `get_async`-written at the BLE layer (status 0), but never responds because its session was never unlocked.
 
-This is bounded retry, not a reconnect loop: it keeps the connection (the underlying GATT bond is fine), it just nudges the protocol-layer handshake until the appliance responds. Worst case it runs once every 60s on a permanently-stuck appliance until the 15-minute zombie threshold gives up and forces a full reconnect.
+2. **fw 8.5 unlock-session expiry.** Sub-Zero fridges and wall ovens running fw 8.5 / API 5.4 silently invalidate the unlock session within ~1 minute (much shorter than the 20-25 minute window observed on other firmware). After that, `get_async` writes on D5 are accepted at the BLE layer but produce no indication response, even though push notifications keep flowing.
+
+`poll_in_flight` is a per-appliance bool, cleared on disconnect, set to `true` whenever a `get_async` is written (in `subscribe` or `periodic_poll`), and cleared only by a valid poll response (`{"status":0,"resp":...}`, parser sets `is_poll=true`). Push notifications do **not** clear it - they prove the connection is alive but don't prove the command channel is responding.
+
+When `periodic_poll` fires and finds `poll_in_flight` still `true` from the previous tick, the previous poll went unanswered. Instead of writing another bare `get_async` into the void, it runs `_subscribe.execute()` - which re-writes CCCDs (idempotent), re-issues `unlock_channel`, and writes `get_async` again. The `unlock_channel` response is small (40 bytes, single fragment, not vulnerable to ACL drops) so it parses cleanly and clears `poll_in_flight`. Next tick takes the bare-poll path again.
+
+For the false-positive scenario the prior unlock-expiry detector hit (a push interleaving with a poll on fw 8.5 makes the poll's brace-balance never reach zero, so we never get an `is_poll=true` parse): re-running subscribe is the right response anyway. It refreshes the session and the next attempt either succeeds or repeats the cycle - no reconnect loop, no false positives.
+
+The `Log Debug Info` button on each appliance also calls `_subscribe.execute()` for the same reason: a bare `get_async` from the button doesn't work on a stale-unlock fw 8.5 appliance. Going through subscribe refreshes the session first.
 
 === Boot Stagger via `poll_offset`
 
@@ -145,12 +153,12 @@ This is bounded retry, not a reconnect loop: it keeps the connection (the underl
 [source]
 ----
 [I][szg:XXX]: [Left Dishwasher] Periodic poll (miss=2, retries=0)
-[W][szg:XXX]: [Kitchen Range] No parse since connect - re-running subscribe
+[W][szg:XXX]: [Wall Oven] Previous poll unanswered - re-running subscribe to refresh session
 ----
 
 * `miss` - zombie counter (0-15, reconnect at 15 = 15 min of total silence)
 * `retries` - fast-reconnect retry counter (0-3, bond clear at 3; see below)
-* `No parse since connect` - subscribe-retry path firing (Option B); will keep firing once per poll until the appliance responds or zombie kicks in
+* `Previous poll unanswered` - subscribe-retry path firing (poll_in_flight stayed `true` across a tick); on fw 8.5 appliances this is normal once per ~minute as the unlock session refreshes
 
 === Fast Reconnect + Bond Clear
 

--- a/docs/advanced.adoc
+++ b/docs/advanced.adoc
@@ -152,22 +152,25 @@ The `Log Debug Info` button on each appliance also calls `_subscribe.execute()` 
 
 === Push-Only Mode for fw 8.5 Appliances
 
-`push_only_after_first_poll` (substitution, default `"false"`) opts out of periodic polling after the first successful response. Recommended for Sub-Zero 313 fridges, Wolf SO3050PESP wall ovens, and any other fw 8.5 / API 5.4 appliance whose unlock session expires within ~1 minute.
+`push_only_after_first_poll` (substitution) controls whether the integration stops polling after the first successful response on each connect, relying on push notifications for live state. Three values:
 
-When set to `"true"`:
+* `"auto"` *(default)* - decide at runtime from the firmware version reported in the first poll response. If the appliance reports `version.fw == "8.5"` (API 5.4), enable push-only mode for that connection. Otherwise leave it off. Sub-Zero 313 fridges, Wolf SO3050PESP wall ovens, and similar fw 8.5 / API 5.4 appliances are auto-detected and run in push-only mode without any per-appliance config. fw 2.27 / API 5.5 appliances stay on the standard 60s polling cadence.
+* `"true"` - always enable push-only after the first successful poll, regardless of detected firmware. Useful if you want the behavior on a fw 2.27 appliance to minimize BLE airtime.
+* `"false"` - never enable push-only. Use this to override the auto detection on a fw 8.5 appliance where you really want fresh `uptime` and `diagnostic_status` at the cost of the ~4 minute reconnect cycle the recovery ladder produces.
 
-* `periodic_poll` fires once after each (re)connect to land an initial full state, then sets `first_poll_done`.
-* On every subsequent tick, `periodic_poll` returns early without writing `get_async`.
-* The connection stays alive via push notifications (CCCD-based, not session-based), which keep `poll_ok` set so zombie detection doesn't fire spuriously.
-* If 15 minutes of total silence (no polls AND no pushes) ever happens, zombie detection still triggers a reconnect, which lands a fresh poll.
+When push-only is active, `periodic_poll` fires exactly once after each (re)connect to land an initial full state (sets `first_poll_done`), then returns early on every subsequent tick - no `get_async` writes, no subscribe-retry ladder. Push notifications carry live state and keep `poll_ok` set in the notify handler so zombie detection stays at zero unless 15 min of total silence happens. Poll-only fields (`appliance_model`, `appliance_serial`, version tree, `uptime`, `diagnostic_status`) refresh only on the next reconnect.
 
 This matches the strategy of the official Sub-Zero Android app (poll briefly, stop polling once async indications flow, rely on pushes thereafter - see link:ble-protocol.adoc#_unlock_session_research_fw_8_5[Unlock Session Research]).
 
-The trade-off: poll-only sensors (model, uptime, version tree, sabbath_on, setpoints) refresh only when a fresh connect happens. They don't drift because they don't change much - the appliance model never changes, the version doesn't change without a firmware update. Setpoints and live state changes arrive via pushes (`cav_temp`, `cav_door_ajar`, `cav_light_on`, `cav_set_temp`, etc.).
+==== Trade-offs
 
-For fw 2.27 / API 5.5 appliances (most dishwashers, most ranges, most wine fridges), keep the default `"false"` - their unlock session lasts long enough for the standard 60s polling cadence to work. Likewise keep the default for fridge configurations using `poll_via_d4: "true"` since D4 polls don't need an unlock at all.
+* **fw 8.5 with default `"auto"`**: connection stays up indefinitely if pushes are flowing (door opens, setpoint changes, light toggles, etc.), or until 15 min of total silence triggers zombie reconnect. No 4-min reconnect cycle. `uptime` only updates on reconnects - could be hours if the appliance is busy.
+* **fw 8.5 with `"false"`**: the recovery ladder kicks in (subscribe-retry × 3 → forced reconnect after 3 unanswered polls), so reconnects fire roughly every 4 minutes regardless of activity. `uptime` and `diagnostic_status` refresh on every cycle.
+* **fw 2.27 with default `"auto"`**: stays on the bare-poll fast path forever, just like before. Polls land every 60s, all sensors refresh every cycle.
 
-Per-appliance configuration in your entry-point YAML:
+For fridge configurations using `poll_via_d4: "true"`, push-only is mostly moot since D4 polls don't need an unlock at all and never fail with the unlock-expiry symptom.
+
+Per-appliance override in your entry-point YAML:
 
 [source,yaml]
 ----
@@ -179,7 +182,7 @@ packages:
       appliance_name: "Main Fridge"
       appliance_mac: !secret main_fridge_mac
       appliance_pin: !secret main_fridge_pin
-      push_only_after_first_poll: "true"   # fw 8.5 fridge
+      push_only_after_first_poll: "false"   # override auto, keep polling
 ----
 
 === Log Format

--- a/docs/advanced.adoc
+++ b/docs/advanced.adoc
@@ -260,30 +260,37 @@ Grep for `Response\[` and concatenate the payloads in order to reassemble the fu
 
 IMPORTANT: Debug-mode payload logging is intentionally gated behind the switch. Normal operation never logs raw BLE bytes, because any non-UTF-8 byte in a log message crashes Home Assistant's protobuf decoder (`LogEntryResponse` requires valid UTF-8) and HA caches the bad event into a restart loop. When debug mode IS on, bytes outside the printable-ASCII range are replaced with `?` as a safety net.
 
-The *Log Debug Info* button is a one-press shortcut: it turns on debug mode and immediately polls the appliance using the correct channel for that appliance type.
+The *Log Debug Info* button is a one-press shortcut: it turns on debug mode and lands a fresh poll. The path it takes depends on detected firmware:
+
+* **fw 2.27 / API 5.5**: re-runs the subscribe chain (CCCDs + `unlock_channel` + `get_async`) on the existing connection. Debug logs land in ~1.5 seconds.
+* **fw 8.5 / API 5.4**: forces a BLE disconnect. `auto_connect: true` brings the connection back via `post_bond` which naturally runs subscribe with a fresh unlock window. Debug logs land in ~10-15 seconds. Required because the fw 8.5 unlock session expires within ~1 minute and re-issuing `unlock_channel` on the existing connection produces no response (see link:ble-protocol.adoc#_unlock_session_research_fw_8_5[Unlock Session Research]).
+
+Either way the user-visible workflow is the same: press the button, wait, grep `Response\[` in the logs.
 
 === Dishwashers & Ranges
 
 Dishwashers and ranges respond to polls on the D5 (encrypted) channel with their full state - all sensor keys in a single response.
 
 . Press *Log Debug Info* (or turn on *Debug Mode* and press *Poll*).
+. Wait ~1.5s on fw 2.27 or ~10-15s on fw 8.5 for the poll to land.
 . Grep `Response\[` in the ESPHome logs, concatenate the chunks in order to get the full JSON.
 . Turn *Debug Mode* off when done.
 
 === Refrigerators / Freezers
 
-Fridges behave differently from dishwashers and ranges. They have 5 BLE characteristics (D4-D8) instead of 2 (D4-D5), and the command routing is different:
+Fridges have 5 BLE characteristics (D4-D8) instead of 2 (D4-D5):
 
-* *D4* (open channel) - responds to `get_async` with basic diagnostic data (model, doors, uptime), no unlock needed
-* *D5* (encrypted channel) - responds to `get_async` with the full appliance state after a fresh `unlock_channel`, but the unlock session expires after some time (possibly hours); push notifications continue regardless of session state
+* *D4* (open channel) - responds to `get_async` with basic diagnostic data (model, doors, uptime), no unlock needed; mirrors D5 push notifications with `msg_types: 8`
+* *D5* (encrypted channel) - responds to `get_async` with the full appliance state after a fresh `unlock_channel`; push notifications continue regardless of session state
 * *D6-D8* - accept writes but do not respond
 
-The *Log Debug Info* button polls D4, which always works without an unlock session. To capture the full set of keys from a fridge:
+The *Log Debug Info* button now uses the same path as ranges and dishwashers: subscribe-refresh on fw 2.27 (~1.5s), or force-reconnect on fw 8.5 (~10-15s). Either way you get a full D5 poll response logged as `Response[N/M]:` chunks. To capture the full set of keys including the live state changes:
 
-. Press *Log Debug Info* - this polls D4 and logs the basic diagnostic keys.
-. *Interact with the appliance* - open/close doors, change the set temperature on the panel, toggle the ice maker, etc. Each change triggers a push notification on D5 with the relevant keys, which debug mode captures and logs.
+. Press *Log Debug Info*.
+. Wait for the `Response[N/M]:` chunks - that's the full poll snapshot.
+. Optionally *interact with the appliance* (open/close doors, change set temp, toggle ice maker) to capture push notifications too. Each change triggers a small push on D5 with just the changed field.
 
-Between the D4 poll and D5 push notifications, you can map out every key your fridge exposes.
+Between the full D5 poll and D5 push notifications, you can map out every key your fridge exposes.
 
 === Reading the Logs
 

--- a/docs/ble-protocol.adoc
+++ b/docs/ble-protocol.adoc
@@ -99,7 +99,7 @@ The full handshake follows these steps (shown for dishwashers/ranges where D5 is
 Fridges follow the same connection and bonding flow, but command/response routing differs:
 
 * *D4 polling:* `get_async` on *D4* works without an unlock and returns basic diagnostic data (model, door status, uptime) but not the full sensor state.
-* *D5 polling:* `get_async` on *D5* returns the full sensor state (set temperatures, ice maker status, sabbath mode, wine zones, etc.) *after a successful `unlock_channel`*. However, the unlock session expires roughly 20-25 minutes after unlock. After expiry, writes to D5 are still accepted (GATT write status 0) but produce no indication response. Re-sending `unlock_channel` does *not* restore the session on some appliances (wall ovens, fridges with fw 8.5) - a full BLE reconnect is required. The integration detects this by tracking poll-response timeouts independently from push activity; see link:advanced.adoc#reconnect-logic[Reconnect Logic] for details.
+* *D5 polling:* `get_async` on *D5* returns the full sensor state (set temperatures, ice maker status, sabbath mode, wine zones, etc.) *after a successful `unlock_channel`*. The unlock session expires after some time. On fw 2.27 / API 5.5 appliances the window is roughly 20-25 minutes; on fw 8.5 / API 5.4 appliances (Sub-Zero 313 fridge, Wolf SO3050PESP wall oven, etc.) it expires within ~1 minute. After expiry, writes to D5 are still accepted (GATT write status 0) but produce no indication response. Re-sending `unlock_channel` does *not* restore the session on fw 8.5 - a full BLE reconnect is required. The integration detects this by tracking poll-response timeouts independently from push activity; see link:advanced.adoc#reconnect-logic[Reconnect Logic] for details.
 * *Push notifications:* Full sensor data also arrives via *D5 push notifications* triggered by state changes on the appliance. Push notifications continue even after the unlock session expires (they are CCCD-based, not session-based).
 * *Push mirroring:* Fridges send each push notification on *both* D4 (`msg_types: 8`) and D5 (`msg_types: 2`) simultaneously with identical `props` content.
 
@@ -151,6 +151,18 @@ Earlier revisions tried to actively *detect* fragment drops by discarding the bu
 On appliances whose full-state response reliably hits the ACL bug (wall ovens, 313 fridge), the "poll-only" sensors (model, uptime, serial, sabbath_on, version tree) may still take several cycles to populate, but they will eventually land whenever one full response arrives intact. Push-driven sensors (door, light, setpoint changes) work regardless.
 +
 Any raw-buffer content that reaches ESPHome's logger (the debug-mode `Response[N/M]:` chunks, the `Parse failed...` preview) is pre-sanitized: bytes outside the printable-ASCII range `0x20..0x7E` are replaced with `?`. Non-UTF-8 bytes in an API log message crash Home Assistant's protobuf decoder the same way they used to crash it via the retired `Raw JSON` text sensor, and HA caches the bad event. Sanitization keeps the log channel safe without touching what the parser actually sees.
+
+== Unlock Session Research (fw 8.5)
+
+The unlock session expiry on fw 8.5 appliances is short (~1 minute, vs. ~20 minutes on fw 2.27) and the only recovery is a full BLE reconnect. Re-sending `unlock_channel` on the existing connection produces no response. We investigated the official Sub-Zero Android app (v4.5.1, decompiled APK) to see if it solves this differently.
+
+**Findings from the APK** (`apk-subzero-4.5.1/lib/arm64-v8a/libapp.so`):
+
+* **No keepalive/ping command exists.** Initial Smali references to `PingMessage` / `_WebSocketPing` / `_cleanupPingTimer` turned out to be Dart's `dart:io` WebSocket framework boilerplate (used for cloud/MQTT comms, not BLE). The compiled Dart binary contains no `{"cmd":"ping"}`-style verb. The `keepAliveIntervalInMilliseconds` field in the per-appliance metadata is the BLE *connection interval* (link-layer parameter), not a JSON command.
+* **The full BLE command set is exactly six verbs.** `unlock_channel`, `get_async`, `display_pin`, `set` (write properties), `scan` (Wi-Fi scan), `reset_air_filter`. No hidden seventh command refreshes the session.
+* **The Android app's strategy is push-driven, not poll-driven.** Strings in the binary include `_startPropertyPolling` / `_stopPropertyPolling` and the message *"Async channel is open, stopping property polling"*. The app polls briefly on connect until indications start flowing, then *stops polling* and relies on push notifications (CCCD-based, not session-based) for live state changes thereafter. Mobile apps then naturally get a fresh unlock window each time the user re-opens the app, because the connection is torn down and remade.
+
+**Implication for an always-on integration:** there is no protocol-level fix. fw 8.5 unlock-session expiry is a hard constraint enforced by the appliance firmware. The integration matches the official app's strategy via the optional `push_only_after_first_poll` substitution (see link:advanced.adoc#reconnect-logic[Reconnect Logic]) - poll once on connect, then stop, rely on pushes. This trades stale poll-only sensors (model, uptime, version, sabbath_on) for zero BLE churn.
 
 == Command Reference
 

--- a/subzero_base.yaml
+++ b/subzero_base.yaml
@@ -77,6 +77,15 @@ globals:
   - id: ${prefix}_poll_in_flight
     type: bool
     initial_value: "false"
+  # Counts consecutive periodic_poll cycles that took the subscribe-retry
+  # branch (poll_in_flight stayed true). Reset on any valid is_poll parse
+  # and on disconnect. When >= 3, the session is wedged at a level even
+  # subscribe (unlock_channel) can't unstick - force a reconnect via
+  # client->disconnect(). auto_connect: true brings the connection back
+  # from scratch.
+  - id: ${prefix}_unanswered_polls
+    type: int
+    initial_value: "0"
   - id: ${prefix}_debug_mode
     type: bool
     initial_value: "false"
@@ -141,6 +150,7 @@ ble_client:
         - lambda: |-
             id(${prefix}_json_buf).clear();
             id(${prefix}_poll_in_flight) = false;
+            id(${prefix}_unanswered_polls) = 0;
             id(${prefix}_post_bond).stop();
             id(${prefix}_subscribe).stop();
             id(${prefix}_fast_reconnect).stop();
@@ -500,21 +510,34 @@ script:
           id(${prefix}_poll_ok) = false;
           // Clear any stale partial JSON from interrupted previous transfer
           id(${prefix}_json_buf).clear();
-          // Recovery path: if poll_in_flight is still set from the previous
-          // tick, the previous get_async went unanswered. Either:
-          //  - cold-boot race: subscribe ran but unlock_channel got lost
-          //    under concurrent BLE traffic, leaving the session
-          //    half-initialized (the appliance never produces ANYTHING)
-          //  - fw 8.5 unlock-session expired (session-based; pushes keep
-          //    flowing but command channel goes silent within ~1 minute)
-          // Re-run subscribe (CCCD writes are idempotent, unlock is
-          // re-doable, get_async will be re-issued at the end). The
-          // unlock_channel response is small (40 bytes, single fragment,
-          // not vulnerable to ACL drops) so it parses cleanly as
-          // is_poll=true and clears poll_in_flight. Once the session is
-          // refreshed, the next periodic tick takes the bare-poll path.
+          // Recovery ladder when poll_in_flight is still set from the
+          // previous tick (the previous get_async went unanswered):
+          //
+          //   Tick 1: run subscribe to re-issue unlock_channel + get_async.
+          //           Handles cold-boot races and most fw 8.5 unlock-expiry
+          //           cases - the unlock response is small (single fragment,
+          //           not ACL-vulnerable) so it parses cleanly as is_poll
+          //           and clears poll_in_flight + unanswered_polls.
+          //   Tick 2-3: same. Some sessions take a couple of refreshes.
+          //   Tick 4 (unanswered_polls >= 3): escalate to a full reconnect.
+          //           At this point the session is wedged at a level even
+          //           unlock_channel can't unstick - we never even saw the
+          //           unlock response come back across multiple retries.
+          //           auto_connect: true brings the connection back from
+          //           scratch. Counter resets on any valid is_poll parse.
           if (id(${prefix}_poll_in_flight)) {
-            ESP_LOGW("szg", "[${appliance_name}] Previous poll unanswered - re-running subscribe to refresh session");
+            id(${prefix}_unanswered_polls) += 1;
+            if (id(${prefix}_unanswered_polls) >= 3) {
+              ESP_LOGW("szg", "[${appliance_name}] %d subscribe retries unanswered - session wedged, forcing reconnect",
+                id(${prefix}_unanswered_polls));
+              id(${prefix}_unanswered_polls) = 0;
+              id(${prefix}_poll_in_flight) = false;
+              id(${prefix}_debug).publish_state("Session wedged, reconnecting...");
+              client->disconnect();
+              return;
+            }
+            ESP_LOGW("szg", "[${appliance_name}] Previous poll unanswered (%d/3) - re-running subscribe to refresh session",
+              id(${prefix}_unanswered_polls));
             id(${prefix}_subscribe).execute();
             return;
           }

--- a/subzero_base.yaml
+++ b/subzero_base.yaml
@@ -7,6 +7,23 @@
 substitutions:
   poll_offset: "0s"
   poll_via_d4: "false"
+  # Set to "true" for fw 8.5 / API 5.4 appliances (Sub-Zero 313 fridge,
+  # Wolf SO3050PESP wall oven, etc.) where the unlock session expires within
+  # ~1 minute. With this on, periodic_poll fires exactly once after each
+  # (re)connect and then goes silent - the integration relies entirely on
+  # push notifications for live state. Push-driven sensors (door, light,
+  # setpoints, cook mode) keep updating; poll-only sensors (model, uptime,
+  # version, sabbath_on) refresh only on the next zombie reconnect (15 min
+  # of total silence).
+  #
+  # This matches what the official Sub-Zero Android app does: poll briefly
+  # on connect until indications start flowing, then stop polling and rely
+  # on pushes. See docs/ble-protocol.adoc "Unlock Session Research".
+  #
+  # Default "false" keeps the standard 60s polling cadence with subscribe-
+  # retry escalation, appropriate for fw 2.27 / API 5.5 appliances and
+  # fridge configurations using poll_via_d4.
+  push_only_after_first_poll: "false"
 
 # NOTE: external_components is declared by the entry-point yaml, not here.
 # Minimal examples use `type: git` with a released ref; personal dev yamls
@@ -86,6 +103,13 @@ globals:
   - id: ${prefix}_unanswered_polls
     type: int
     initial_value: "0"
+  # One-shot: set true on first valid is_poll parse after (re)connect.
+  # Reset on disconnect. Only used when push_only_after_first_poll is "true"
+  # to gate the periodic_poll write path - once the initial poll has
+  # completed we stop polling entirely and rely on pushes.
+  - id: ${prefix}_first_poll_done
+    type: bool
+    initial_value: "false"
   - id: ${prefix}_debug_mode
     type: bool
     initial_value: "false"
@@ -151,6 +175,7 @@ ble_client:
             id(${prefix}_json_buf).clear();
             id(${prefix}_poll_in_flight) = false;
             id(${prefix}_unanswered_polls) = 0;
+            id(${prefix}_first_poll_done) = false;
             id(${prefix}_post_bond).stop();
             id(${prefix}_subscribe).stop();
             id(${prefix}_fast_reconnect).stop();
@@ -510,6 +535,17 @@ script:
           id(${prefix}_poll_ok) = false;
           // Clear any stale partial JSON from interrupted previous transfer
           id(${prefix}_json_buf).clear();
+          // Push-only mode: after the first successful poll, stop polling
+          // entirely and rely on push notifications for live state. Matches
+          // what the official Sub-Zero Android app does on fw 8.5 (where
+          // the unlock session expires within ~1 minute and re-issuing
+          // unlock_channel doesn't refresh it - see APK research in
+          // docs/ble-protocol.adoc). Pushes still set poll_ok in the notify
+          // handler so zombie detection above keeps working; if 15 min of
+          // total silence ever happens, we'll reconnect normally.
+          if (${push_only_after_first_poll} && id(${prefix}_first_poll_done)) {
+            return;
+          }
           // Recovery ladder when poll_in_flight is still set from the
           // previous tick (the previous get_async went unanswered):
           //

--- a/subzero_base.yaml
+++ b/subzero_base.yaml
@@ -65,12 +65,16 @@ globals:
   - id: ${prefix}_poll_miss
     type: int
     initial_value: "0"
-  # Set to true the first time a parse succeeds on the current connection
-  # cycle (poll response OR push notification). Cleared on disconnect.
-  # When false, periodic_poll re-runs the full _subscribe chain instead of
-  # just writing get_async, which recovers from boot-time races where the
-  # initial unlock_channel write got dropped under concurrent BLE traffic.
-  - id: ${prefix}_first_poll_seen
+  # Set to true when we write a get_async; cleared when a valid poll
+  # response (`{"status":0,"resp":...}`, parser sets is_poll=true) arrives.
+  # Push notifications do NOT clear it - they're not a response to our
+  # poll. Cleared on disconnect. When still true at the next periodic_poll
+  # tick, the previous poll went unanswered (cold-boot race left the
+  # subscribe chain half-initialized, OR fw 8.5 unlock session expired
+  # silently) and periodic_poll re-runs the full _subscribe chain to
+  # refresh CCCDs + unlock_channel + get_async instead of writing a bare
+  # get_async into the void.
+  - id: ${prefix}_poll_in_flight
     type: bool
     initial_value: "false"
   - id: ${prefix}_debug_mode
@@ -136,7 +140,7 @@ ble_client:
       then:
         - lambda: |-
             id(${prefix}_json_buf).clear();
-            id(${prefix}_first_poll_seen) = false;
+            id(${prefix}_poll_in_flight) = false;
             id(${prefix}_post_bond).stop();
             id(${prefix}_subscribe).stop();
             id(${prefix}_fast_reconnect).stop();
@@ -496,14 +500,21 @@ script:
           id(${prefix}_poll_ok) = false;
           // Clear any stale partial JSON from interrupted previous transfer
           id(${prefix}_json_buf).clear();
-          // Recovery path: if we've never seen a parse on this connection
-          // cycle, the initial subscribe chain probably lost its
-          // unlock_channel write to a concurrent-bonding race at boot.
+          // Recovery path: if poll_in_flight is still set from the previous
+          // tick, the previous get_async went unanswered. Either:
+          //  - cold-boot race: subscribe ran but unlock_channel got lost
+          //    under concurrent BLE traffic, leaving the session
+          //    half-initialized (the appliance never produces ANYTHING)
+          //  - fw 8.5 unlock-session expired (session-based; pushes keep
+          //    flowing but command channel goes silent within ~1 minute)
           // Re-run subscribe (CCCD writes are idempotent, unlock is
-          // re-doable). Once any parse lands, first_poll_seen flips and
-          // we resume normal get_async writes.
-          if (!id(${prefix}_first_poll_seen)) {
-            ESP_LOGW("szg", "[${appliance_name}] No parse since connect - re-running subscribe");
+          // re-doable, get_async will be re-issued at the end). The
+          // unlock_channel response is small (40 bytes, single fragment,
+          // not vulnerable to ACL drops) so it parses cleanly as
+          // is_poll=true and clears poll_in_flight. Once the session is
+          // refreshed, the next periodic tick takes the bare-poll path.
+          if (id(${prefix}_poll_in_flight)) {
+            ESP_LOGW("szg", "[${appliance_name}] Previous poll unanswered - re-running subscribe to refresh session");
             id(${prefix}_subscribe).execute();
             return;
           }
@@ -518,6 +529,7 @@ script:
             client->disconnect();
             return;
           }
+          id(${prefix}_poll_in_flight) = true;
           ESP_LOGI("szg", "[${appliance_name}] Periodic poll (miss=%d, retries=%d)",
             id(${prefix}_poll_miss), id(${prefix}_fast_retries));
 
@@ -778,4 +790,5 @@ script:
             d5, cmd.size(), (uint8_t*)cmd.data(),
             ESP_GATT_WRITE_TYPE_RSP, ESP_GATT_AUTH_REQ_NONE);
           ESP_LOGI("ble", "[${appliance_name}] get_async err=%d", err);
+          if (err == ESP_OK) id(${prefix}_poll_in_flight) = true;
           id(${prefix}_debug).publish_state("Connected and polling.");

--- a/subzero_base.yaml
+++ b/subzero_base.yaml
@@ -7,23 +7,40 @@
 substitutions:
   poll_offset: "0s"
   poll_via_d4: "false"
-  # Set to "true" for fw 8.5 / API 5.4 appliances (Sub-Zero 313 fridge,
-  # Wolf SO3050PESP wall oven, etc.) where the unlock session expires within
-  # ~1 minute. With this on, periodic_poll fires exactly once after each
-  # (re)connect and then goes silent - the integration relies entirely on
-  # push notifications for live state. Push-driven sensors (door, light,
-  # setpoints, cook mode) keep updating; poll-only sensors (model, uptime,
-  # version, sabbath_on) refresh only on the next zombie reconnect (15 min
-  # of total silence).
+  # Three values:
+  #   "auto"  (default) - decide at runtime based on the firmware version
+  #                       reported in the first poll response. If the
+  #                       appliance reports `fw: 8.5` (API 5.4), enable
+  #                       push-only mode for this connection. Otherwise
+  #                       leave it off. Reverts to off on disconnect, so
+  #                       the next connect re-evaluates from the fresh
+  #                       version response.
+  #   "true"  - always enable push-only after the first successful poll,
+  #             regardless of detected firmware. Use this if you want the
+  #             behavior on a fw 2.27 appliance for some reason.
+  #   "false" - never enable push-only. Use this to override the auto
+  #             detection (e.g. on a fw 8.5 appliance where you really
+  #             want fresh uptime/diagnostic_status at the cost of the
+  #             ~4 minute reconnect cycle).
   #
-  # This matches what the official Sub-Zero Android app does: poll briefly
-  # on connect until indications start flowing, then stop polling and rely
-  # on pushes. See docs/ble-protocol.adoc "Unlock Session Research".
+  # When push-only is active, periodic_poll fires exactly once after each
+  # (re)connect (to land an initial full state) and then returns early
+  # on every subsequent tick - no get_async writes, no subscribe-retry
+  # ladder. Push notifications carry live state (door, light, setpoints,
+  # cook mode, etc.) and keep poll_ok set so zombie detection stays at
+  # zero unless 15 min of total silence happens. Poll-only fields
+  # (model, serial, version, uptime, diagnostic_status) refresh only on
+  # the next reconnect.
   #
-  # Default "false" keeps the standard 60s polling cadence with subscribe-
-  # retry escalation, appropriate for fw 2.27 / API 5.5 appliances and
-  # fridge configurations using poll_via_d4.
-  push_only_after_first_poll: "false"
+  # Why this exists: fw 8.5 / API 5.4 appliances (Sub-Zero 313 fridge,
+  # Wolf SO3050PESP wall oven) silently invalidate the unlock session
+  # within ~1 minute. Without push-only mode, the periodic_poll write
+  # gets no response, the subscribe-retry ladder fires, and the session
+  # eventually escalates to a forced reconnect every ~4 min. Push-only
+  # avoids that churn entirely. Matches what the official Sub-Zero
+  # Android app does - see docs/ble-protocol.adoc "Unlock Session
+  # Research".
+  push_only_after_first_poll: "auto"
 
 # NOTE: external_components is declared by the entry-point yaml, not here.
 # Minimal examples use `type: git` with a released ref; personal dev yamls
@@ -104,10 +121,18 @@ globals:
     type: int
     initial_value: "0"
   # One-shot: set true on first valid is_poll parse after (re)connect.
-  # Reset on disconnect. Only used when push_only_after_first_poll is "true"
-  # to gate the periodic_poll write path - once the initial poll has
-  # completed we stop polling entirely and rely on pushes.
+  # Reset on disconnect. Only used when push_only_after_first_poll is
+  # "true" or "auto" (with fw_85_detected) to gate the periodic_poll
+  # write path - once the initial poll has completed we stop polling
+  # entirely and rely on pushes.
   - id: ${prefix}_first_poll_done
+    type: bool
+    initial_value: "false"
+  # Set true when parse_json sees `version.fw == "8.5"` in a poll response.
+  # Reset on disconnect. Used by `push_only_after_first_poll: "auto"` to
+  # auto-enable push-only mode on appliances whose unlock session expires
+  # within ~1 minute, without requiring per-appliance configuration.
+  - id: ${prefix}_fw_85_detected
     type: bool
     initial_value: "false"
   - id: ${prefix}_debug_mode
@@ -176,6 +201,7 @@ ble_client:
             id(${prefix}_poll_in_flight) = false;
             id(${prefix}_unanswered_polls) = 0;
             id(${prefix}_first_poll_done) = false;
+            id(${prefix}_fw_85_detected) = false;
             id(${prefix}_post_bond).stop();
             id(${prefix}_subscribe).stop();
             id(${prefix}_fast_reconnect).stop();
@@ -543,8 +569,18 @@ script:
           // docs/ble-protocol.adoc). Pushes still set poll_ok in the notify
           // handler so zombie detection above keeps working; if 15 min of
           // total silence ever happens, we'll reconnect normally.
-          if (${push_only_after_first_poll} && id(${prefix}_first_poll_done)) {
-            return;
+          //
+          // Three modes: "true" forces it on, "false" forces it off,
+          // "auto" (default) enables it whenever the parser sees
+          // `version.fw == "8.5"` in the first poll response.
+          {
+            const char *mode = "${push_only_after_first_poll}";
+            bool push_only =
+              (mode[0] == 't') ||  // "true"
+              (mode[0] == 'a' && id(${prefix}_fw_85_detected));  // "auto" + fw 8.5
+            if (push_only && id(${prefix}_first_poll_done)) {
+              return;
+            }
           }
           // Recovery ladder when poll_in_flight is still set from the
           // previous tick (the previous get_async went unanswered):

--- a/subzero_base.yaml
+++ b/subzero_base.yaml
@@ -65,6 +65,14 @@ globals:
   - id: ${prefix}_poll_miss
     type: int
     initial_value: "0"
+  # Set to true the first time a parse succeeds on the current connection
+  # cycle (poll response OR push notification). Cleared on disconnect.
+  # When false, periodic_poll re-runs the full _subscribe chain instead of
+  # just writing get_async, which recovers from boot-time races where the
+  # initial unlock_channel write got dropped under concurrent BLE traffic.
+  - id: ${prefix}_first_poll_seen
+    type: bool
+    initial_value: "false"
   - id: ${prefix}_debug_mode
     type: bool
     initial_value: "false"
@@ -128,6 +136,7 @@ ble_client:
       then:
         - lambda: |-
             id(${prefix}_json_buf).clear();
+            id(${prefix}_first_poll_seen) = false;
             id(${prefix}_post_bond).stop();
             id(${prefix}_subscribe).stop();
             id(${prefix}_fast_reconnect).stop();
@@ -487,6 +496,17 @@ script:
           id(${prefix}_poll_ok) = false;
           // Clear any stale partial JSON from interrupted previous transfer
           id(${prefix}_json_buf).clear();
+          // Recovery path: if we've never seen a parse on this connection
+          // cycle, the initial subscribe chain probably lost its
+          // unlock_channel write to a concurrent-bonding race at boot.
+          // Re-run subscribe (CCCD writes are idempotent, unlock is
+          // re-doable). Once any parse lands, first_poll_seen flips and
+          // we resume normal get_async writes.
+          if (!id(${prefix}_first_poll_seen)) {
+            ESP_LOGW("szg", "[${appliance_name}] No parse since connect - re-running subscribe");
+            id(${prefix}_subscribe).execute();
+            return;
+          }
           std::string cmd = "{\"cmd\":\"get_async\"}\n";
           esp_err_t err = esp_ble_gattc_write_char(
             client->get_gattc_if(), client->get_conn_id(),
@@ -506,9 +526,19 @@ script:
   #    ESPHome's ble_client performs discovery once at connect and doesn't re-run it.
   # 2. We need to match D4/D5/D6/D7/D8 by UUID suffix and cache handles for fast reconnect.
   # 3. ESPHome does not expose GATT cache management (cache_refresh, cache_clean).
+  #
+  # The leading poll_offset delay staggers the bonding chain across multiple
+  # appliances on the same ESP32. Without it, three concurrent unlock_channel
+  # writes through the ESP-IDF Bluedroid stack at boot occasionally drop one,
+  # leaving that appliance with an unconfirmed unlock and silent get_async
+  # responses. Setting per-appliance poll_offset values like 0s/5s/10s
+  # serializes the bonding chains. periodic_poll has the same delay applied
+  # at its top, so the same stagger keeps the periodic polls themselves from
+  # colliding too.
   - id: ${prefix}_post_bond
     mode: restart
     then:
+      - delay: ${poll_offset}
       - delay: 500ms
       - lambda: |-
           auto *client = id(${prefix}_appliance);
@@ -660,6 +690,9 @@ script:
     mode: restart
     then:
       # Fast path: skip GATT dump, just encrypt + subscribe + unlock (no auto-poll)
+      # poll_offset stagger applies here too - simultaneous reconnects after a
+      # transient drop run into the same Bluedroid race as a fresh bond.
+      - delay: ${poll_offset}
       - lambda: |-
           auto *client = id(${prefix}_appliance);
           uint8_t addr[6];

--- a/subzero_dishwasher.yaml
+++ b/subzero_dishwasher.yaml
@@ -253,9 +253,12 @@ script:
           // Clear poll_in_flight + reset unanswered_polls only on a real
           // poll response, not on pushes. Pushes prove the connection is
           // alive but don't prove the command channel is responding.
+          // first_poll_done is the one-shot used by push_only_after_first_poll
+          // to gate further periodic_poll writes; once any poll lands we stop.
           if (s.is_poll) {
             id(${prefix}_poll_in_flight) = false;
             id(${prefix}_unanswered_polls) = 0;
+            id(${prefix}_first_poll_done) = true;
           }
           id(${prefix}_fast_retries) = 0;
           buf.clear();

--- a/subzero_dishwasher.yaml
+++ b/subzero_dishwasher.yaml
@@ -250,9 +250,12 @@ script:
           if (s.common.version.rtapp)     id(${prefix}_rtapp_version).publish_state(*s.common.version.rtapp);
           if (s.common.version.appliance) id(${prefix}_board_version).publish_state(*s.common.version.appliance);
           id(${prefix}_poll_ok) = true;
-          // Clear poll_in_flight only on a real poll response, not on pushes.
-          // Pushes prove the connection is alive but don't prove the poll
-          // command channel is responding.
-          if (s.is_poll) id(${prefix}_poll_in_flight) = false;
+          // Clear poll_in_flight + reset unanswered_polls only on a real
+          // poll response, not on pushes. Pushes prove the connection is
+          // alive but don't prove the command channel is responding.
+          if (s.is_poll) {
+            id(${prefix}_poll_in_flight) = false;
+            id(${prefix}_unanswered_polls) = 0;
+          }
           id(${prefix}_fast_retries) = 0;
           buf.clear();

--- a/subzero_dishwasher.yaml
+++ b/subzero_dishwasher.yaml
@@ -254,5 +254,6 @@ script:
           if (s.common.version.rtapp)     id(${prefix}_rtapp_version).publish_state(*s.common.version.rtapp);
           if (s.common.version.appliance) id(${prefix}_board_version).publish_state(*s.common.version.appliance);
           id(${prefix}_poll_ok) = true;
+          id(${prefix}_first_poll_seen) = true;
           id(${prefix}_fast_retries) = 0;
           buf.clear();

--- a/subzero_dishwasher.yaml
+++ b/subzero_dishwasher.yaml
@@ -253,12 +253,16 @@ script:
           // Clear poll_in_flight + reset unanswered_polls only on a real
           // poll response, not on pushes. Pushes prove the connection is
           // alive but don't prove the command channel is responding.
-          // first_poll_done is the one-shot used by push_only_after_first_poll
-          // to gate further periodic_poll writes; once any poll lands we stop.
+          // first_poll_done gates push_only_after_first_poll's early-return.
+          // fw_85_detected drives "auto" mode (rare on dishwashers but
+          // included for parity).
           if (s.is_poll) {
             id(${prefix}_poll_in_flight) = false;
             id(${prefix}_unanswered_polls) = 0;
             id(${prefix}_first_poll_done) = true;
+            if (s.common.version.fw && *s.common.version.fw == "8.5") {
+              id(${prefix}_fw_85_detected) = true;
+            }
           }
           id(${prefix}_fast_retries) = 0;
           buf.clear();

--- a/subzero_dishwasher.yaml
+++ b/subzero_dishwasher.yaml
@@ -128,9 +128,10 @@ button:
     icon: "mdi:bug-play"
     entity_category: diagnostic
     on_press:
-      # Run the full subscribe chain (CCCD + unlock + get_async) so debug
-      # works regardless of unlock-session state. See subzero_range.yaml's
-      # equivalent button for rationale.
+      # Branch on detected firmware - see subzero_range.yaml's equivalent
+      # button for rationale. Dishwashers are predominantly fw 2.27 so the
+      # subscribe path is the common case, but we still branch in case a
+      # future model lands on fw 8.5.
       - lambda: |-
           if (id(${prefix}_d5_handle) == 0) {
             id(${prefix}_debug).publish_state("ERROR: Not connected");
@@ -138,9 +139,15 @@ button:
           }
           id(${prefix}_debug_mode) = true;
           id(${prefix}_debug_switch).publish_state(true);
-          ESP_LOGI("ble", "[${appliance_name}] Debug poll: re-running subscribe");
-          id(${prefix}_debug).publish_state("Debug mode ON - refreshing session...");
-      - script.execute: ${prefix}_subscribe
+          if (id(${prefix}_fw_85_detected)) {
+            ESP_LOGI("ble", "[${appliance_name}] Debug poll: forcing reconnect for fresh unlock");
+            id(${prefix}_debug).publish_state("Debug mode ON - reconnecting for fresh poll...");
+            id(${prefix}_appliance)->disconnect();
+          } else {
+            ESP_LOGI("ble", "[${appliance_name}] Debug poll: re-running subscribe");
+            id(${prefix}_debug).publish_state("Debug mode ON - refreshing session...");
+            id(${prefix}_subscribe).execute();
+          }
 
 script:
   - id: ${prefix}_parse_json

--- a/subzero_dishwasher.yaml
+++ b/subzero_dishwasher.yaml
@@ -128,23 +128,19 @@ button:
     icon: "mdi:bug-play"
     entity_category: diagnostic
     on_press:
-      # Dishwashers respond to get_async on D5 with the full state.
+      # Run the full subscribe chain (CCCD + unlock + get_async) so debug
+      # works regardless of unlock-session state. See subzero_range.yaml's
+      # equivalent button for rationale.
       - lambda: |-
-          uint16_t d5 = id(${prefix}_d5_handle);
-          if (d5 == 0) {
+          if (id(${prefix}_d5_handle) == 0) {
             id(${prefix}_debug).publish_state("ERROR: Not connected");
             return;
           }
           id(${prefix}_debug_mode) = true;
           id(${prefix}_debug_switch).publish_state(true);
-          auto *client = id(${prefix}_appliance);
-          std::string cmd = "{\"cmd\":\"get_async\"}\n";
-          esp_err_t err = esp_ble_gattc_write_char(
-            client->get_gattc_if(), client->get_conn_id(),
-            d5, cmd.size(), (uint8_t*)cmd.data(),
-            ESP_GATT_WRITE_TYPE_RSP, ESP_GATT_AUTH_REQ_NONE);
-          ESP_LOGI("ble", "[${appliance_name}] Debug poll via D5 (h=%d) err=%d", d5, err);
-          id(${prefix}_debug).publish_state("Debug mode ON - full state logged");
+          ESP_LOGI("ble", "[${appliance_name}] Debug poll: re-running subscribe");
+          id(${prefix}_debug).publish_state("Debug mode ON - refreshing session...");
+      - script.execute: ${prefix}_subscribe
 
 script:
   - id: ${prefix}_parse_json
@@ -254,6 +250,9 @@ script:
           if (s.common.version.rtapp)     id(${prefix}_rtapp_version).publish_state(*s.common.version.rtapp);
           if (s.common.version.appliance) id(${prefix}_board_version).publish_state(*s.common.version.appliance);
           id(${prefix}_poll_ok) = true;
-          id(${prefix}_first_poll_seen) = true;
+          // Clear poll_in_flight only on a real poll response, not on pushes.
+          // Pushes prove the connection is alive but don't prove the poll
+          // command channel is responding.
+          if (s.is_poll) id(${prefix}_poll_in_flight) = false;
           id(${prefix}_fast_retries) = 0;
           buf.clear();

--- a/subzero_fridge.yaml
+++ b/subzero_fridge.yaml
@@ -223,25 +223,23 @@ button:
     icon: "mdi:bug-play"
     entity_category: diagnostic
     on_press:
-      # Fridges respond to get_async on D4 (open channel).
-      # Full sensor data comes via D5 push notifications - interact with the
-      # appliance (open door, change temp, toggle ice maker) with debug mode on.
+      # Run the full subscribe chain (CCCD on D4 AND D5, unlock on D5,
+      # then get_async on D5). On fw 8.5 fridges the unlock session
+      # silently expires within ~1 minute, so a bare get_async after that
+      # produces no response on EITHER channel - subscribe re-issues
+      # unlock_channel which refreshes the session. Push notifications
+      # via D5 still work after this for live state changes (open door,
+      # change temp, toggle ice maker).
       - lambda: |-
-          uint16_t d4 = id(${prefix}_d4_handle);
-          if (d4 == 0) {
+          if (id(${prefix}_d5_handle) == 0) {
             id(${prefix}_debug).publish_state("ERROR: Not connected");
             return;
           }
           id(${prefix}_debug_mode) = true;
           id(${prefix}_debug_switch).publish_state(true);
-          auto *client = id(${prefix}_appliance);
-          std::string cmd = "{\"cmd\":\"get_async\"}\n";
-          esp_err_t err = esp_ble_gattc_write_char(
-            client->get_gattc_if(), client->get_conn_id(),
-            d4, cmd.size(), (uint8_t*)cmd.data(),
-            ESP_GATT_WRITE_TYPE_RSP, ESP_GATT_AUTH_REQ_NONE);
-          ESP_LOGI("ble", "[${appliance_name}] Debug poll via D4 (h=%d) err=%d", d4, err);
-          id(${prefix}_debug).publish_state("Debug mode ON - polling D4, interact with appliance for full data");
+          ESP_LOGI("ble", "[${appliance_name}] Debug poll: re-running subscribe");
+          id(${prefix}_debug).publish_state("Debug mode ON - refreshing session...");
+      - script.execute: ${prefix}_subscribe
 
 script:
   - id: ${prefix}_parse_json
@@ -344,6 +342,9 @@ script:
           if (s.common.version.rtapp)     id(${prefix}_rtapp_version).publish_state(*s.common.version.rtapp);
           if (s.common.version.appliance) id(${prefix}_board_version).publish_state(*s.common.version.appliance);
           id(${prefix}_poll_ok) = true;
-          id(${prefix}_first_poll_seen) = true;
+          // Clear poll_in_flight only on a real poll response, not on pushes.
+          // Pushes prove the connection is alive but don't prove the poll
+          // command channel is responding.
+          if (s.is_poll) id(${prefix}_poll_in_flight) = false;
           id(${prefix}_fast_retries) = 0;
           buf.clear();

--- a/subzero_fridge.yaml
+++ b/subzero_fridge.yaml
@@ -223,13 +223,19 @@ button:
     icon: "mdi:bug-play"
     entity_category: diagnostic
     on_press:
-      # Run the full subscribe chain (CCCD on D4 AND D5, unlock on D5,
-      # then get_async on D5). On fw 8.5 fridges the unlock session
-      # silently expires within ~1 minute, so a bare get_async after that
-      # produces no response on EITHER channel - subscribe re-issues
-      # unlock_channel which refreshes the session. Push notifications
-      # via D5 still work after this for live state changes (open door,
-      # change temp, toggle ice maker).
+      # Branch on detected firmware to land debug data quickly:
+      #
+      #   fw 2.27: unlock window is long, so just re-run subscribe
+      #            (CCCDs on D4 AND D5, unlock on D5, get_async on D5).
+      #            ~1.5s to a full debug log.
+      #   fw 8.5:  unlock session expires within ~1 min and re-issuing
+      #            unlock_channel doesn't refresh it (see APK research
+      #            in docs/ble-protocol.adoc). Force a reconnect -
+      #            auto_connect brings it back via post_bond which
+      #            naturally runs subscribe with a fresh unlock window.
+      #            Takes ~10-15s to a full debug log. Push notifications
+      #            for live state (door, temp, ice maker) keep flowing
+      #            normally after the reconnect.
       - lambda: |-
           if (id(${prefix}_d5_handle) == 0) {
             id(${prefix}_debug).publish_state("ERROR: Not connected");
@@ -237,9 +243,15 @@ button:
           }
           id(${prefix}_debug_mode) = true;
           id(${prefix}_debug_switch).publish_state(true);
-          ESP_LOGI("ble", "[${appliance_name}] Debug poll: re-running subscribe");
-          id(${prefix}_debug).publish_state("Debug mode ON - refreshing session...");
-      - script.execute: ${prefix}_subscribe
+          if (id(${prefix}_fw_85_detected)) {
+            ESP_LOGI("ble", "[${appliance_name}] Debug poll: forcing reconnect for fresh unlock");
+            id(${prefix}_debug).publish_state("Debug mode ON - reconnecting for fresh poll...");
+            id(${prefix}_appliance)->disconnect();
+          } else {
+            ESP_LOGI("ble", "[${appliance_name}] Debug poll: re-running subscribe");
+            id(${prefix}_debug).publish_state("Debug mode ON - refreshing session...");
+            id(${prefix}_subscribe).execute();
+          }
 
 script:
   - id: ${prefix}_parse_json

--- a/subzero_fridge.yaml
+++ b/subzero_fridge.yaml
@@ -342,9 +342,12 @@ script:
           if (s.common.version.rtapp)     id(${prefix}_rtapp_version).publish_state(*s.common.version.rtapp);
           if (s.common.version.appliance) id(${prefix}_board_version).publish_state(*s.common.version.appliance);
           id(${prefix}_poll_ok) = true;
-          // Clear poll_in_flight only on a real poll response, not on pushes.
-          // Pushes prove the connection is alive but don't prove the poll
-          // command channel is responding.
-          if (s.is_poll) id(${prefix}_poll_in_flight) = false;
+          // Clear poll_in_flight + reset unanswered_polls only on a real
+          // poll response, not on pushes. Pushes prove the connection is
+          // alive but don't prove the command channel is responding.
+          if (s.is_poll) {
+            id(${prefix}_poll_in_flight) = false;
+            id(${prefix}_unanswered_polls) = 0;
+          }
           id(${prefix}_fast_retries) = 0;
           buf.clear();

--- a/subzero_fridge.yaml
+++ b/subzero_fridge.yaml
@@ -345,9 +345,12 @@ script:
           // Clear poll_in_flight + reset unanswered_polls only on a real
           // poll response, not on pushes. Pushes prove the connection is
           // alive but don't prove the command channel is responding.
+          // first_poll_done is the one-shot used by push_only_after_first_poll
+          // to gate further periodic_poll writes; once any poll lands we stop.
           if (s.is_poll) {
             id(${prefix}_poll_in_flight) = false;
             id(${prefix}_unanswered_polls) = 0;
+            id(${prefix}_first_poll_done) = true;
           }
           id(${prefix}_fast_retries) = 0;
           buf.clear();

--- a/subzero_fridge.yaml
+++ b/subzero_fridge.yaml
@@ -344,5 +344,6 @@ script:
           if (s.common.version.rtapp)     id(${prefix}_rtapp_version).publish_state(*s.common.version.rtapp);
           if (s.common.version.appliance) id(${prefix}_board_version).publish_state(*s.common.version.appliance);
           id(${prefix}_poll_ok) = true;
+          id(${prefix}_first_poll_seen) = true;
           id(${prefix}_fast_retries) = 0;
           buf.clear();

--- a/subzero_fridge.yaml
+++ b/subzero_fridge.yaml
@@ -345,12 +345,17 @@ script:
           // Clear poll_in_flight + reset unanswered_polls only on a real
           // poll response, not on pushes. Pushes prove the connection is
           // alive but don't prove the command channel is responding.
-          // first_poll_done is the one-shot used by push_only_after_first_poll
-          // to gate further periodic_poll writes; once any poll lands we stop.
+          // first_poll_done gates push_only_after_first_poll's early-return.
+          // fw_85_detected drives "auto" mode - lets push-only enable
+          // itself on Sub-Zero 313, Wolf SO3050PESP, etc. without
+          // per-appliance config.
           if (s.is_poll) {
             id(${prefix}_poll_in_flight) = false;
             id(${prefix}_unanswered_polls) = 0;
             id(${prefix}_first_poll_done) = true;
+            if (s.common.version.fw && *s.common.version.fw == "8.5") {
+              id(${prefix}_fw_85_detected) = true;
+            }
           }
           id(${prefix}_fast_retries) = 0;
           buf.clear();

--- a/subzero_range.yaml
+++ b/subzero_range.yaml
@@ -434,9 +434,12 @@ script:
           if (s.common.version.rtapp)     id(${prefix}_rtapp_version).publish_state(*s.common.version.rtapp);
           if (s.common.version.appliance) id(${prefix}_board_version).publish_state(*s.common.version.appliance);
           id(${prefix}_poll_ok) = true;
-          // Clear poll_in_flight only on a real poll response, not on pushes.
-          // Pushes prove the connection is alive but don't prove the poll
-          // command channel is responding.
-          if (s.is_poll) id(${prefix}_poll_in_flight) = false;
+          // Clear poll_in_flight + reset unanswered_polls only on a real
+          // poll response, not on pushes. Pushes prove the connection is
+          // alive but don't prove the command channel is responding.
+          if (s.is_poll) {
+            id(${prefix}_poll_in_flight) = false;
+            id(${prefix}_unanswered_polls) = 0;
+          }
           id(${prefix}_fast_retries) = 0;
           buf.clear();

--- a/subzero_range.yaml
+++ b/subzero_range.yaml
@@ -437,9 +437,12 @@ script:
           // Clear poll_in_flight + reset unanswered_polls only on a real
           // poll response, not on pushes. Pushes prove the connection is
           // alive but don't prove the command channel is responding.
+          // first_poll_done is the one-shot used by push_only_after_first_poll
+          // to gate further periodic_poll writes; once any poll lands we stop.
           if (s.is_poll) {
             id(${prefix}_poll_in_flight) = false;
             id(${prefix}_unanswered_polls) = 0;
+            id(${prefix}_first_poll_done) = true;
           }
           id(${prefix}_fast_retries) = 0;
           buf.clear();

--- a/subzero_range.yaml
+++ b/subzero_range.yaml
@@ -437,12 +437,17 @@ script:
           // Clear poll_in_flight + reset unanswered_polls only on a real
           // poll response, not on pushes. Pushes prove the connection is
           // alive but don't prove the command channel is responding.
-          // first_poll_done is the one-shot used by push_only_after_first_poll
-          // to gate further periodic_poll writes; once any poll lands we stop.
+          // first_poll_done gates push_only_after_first_poll's early-return.
+          // fw_85_detected drives "auto" mode - lets push-only enable
+          // itself on Sub-Zero 313, Wolf SO3050PESP, etc. without
+          // per-appliance config.
           if (s.is_poll) {
             id(${prefix}_poll_in_flight) = false;
             id(${prefix}_unanswered_polls) = 0;
             id(${prefix}_first_poll_done) = true;
+            if (s.common.version.fw && *s.common.version.fw == "8.5") {
+              id(${prefix}_fw_85_detected) = true;
+            }
           }
           id(${prefix}_fast_retries) = 0;
           buf.clear();

--- a/subzero_range.yaml
+++ b/subzero_range.yaml
@@ -296,11 +296,17 @@ button:
     icon: "mdi:bug-play"
     entity_category: diagnostic
     on_press:
-      # Run the full subscribe chain (CCCD + unlock + get_async) instead of
-      # writing get_async directly. On fw 8.5 appliances the unlock session
-      # silently expires within ~1 minute, so a bare get_async after that
-      # gets no response. subscribe re-issues unlock_channel which refreshes
-      # the session, then writes get_async, all in ~1.5s.
+      # Branch on detected firmware to land debug data quickly:
+      #
+      #   fw 2.27: unlock window is long (~20+ min), so just re-run
+      #            subscribe - CCCDs + unlock + get_async, ~1.5s to a
+      #            full debug log.
+      #   fw 8.5:  unlock session expires within ~1 min and re-issuing
+      #            unlock_channel doesn't refresh it (see APK research
+      #            in docs/ble-protocol.adoc). Force a reconnect -
+      #            auto_connect brings it back via post_bond which
+      #            naturally runs subscribe with a fresh unlock window.
+      #            Takes ~10-15s to a full debug log.
       - lambda: |-
           if (id(${prefix}_d5_handle) == 0) {
             id(${prefix}_debug).publish_state("ERROR: Not connected");
@@ -308,9 +314,15 @@ button:
           }
           id(${prefix}_debug_mode) = true;
           id(${prefix}_debug_switch).publish_state(true);
-          ESP_LOGI("ble", "[${appliance_name}] Debug poll: re-running subscribe");
-          id(${prefix}_debug).publish_state("Debug mode ON - refreshing session...");
-      - script.execute: ${prefix}_subscribe
+          if (id(${prefix}_fw_85_detected)) {
+            ESP_LOGI("ble", "[${appliance_name}] Debug poll: forcing reconnect for fresh unlock");
+            id(${prefix}_debug).publish_state("Debug mode ON - reconnecting for fresh poll...");
+            id(${prefix}_appliance)->disconnect();
+          } else {
+            ESP_LOGI("ble", "[${appliance_name}] Debug poll: re-running subscribe");
+            id(${prefix}_debug).publish_state("Debug mode ON - refreshing session...");
+            id(${prefix}_subscribe).execute();
+          }
 
 script:
   - id: ${prefix}_parse_json

--- a/subzero_range.yaml
+++ b/subzero_range.yaml
@@ -296,23 +296,21 @@ button:
     icon: "mdi:bug-play"
     entity_category: diagnostic
     on_press:
-      # Ranges respond to get_async on D5 with the full state.
+      # Run the full subscribe chain (CCCD + unlock + get_async) instead of
+      # writing get_async directly. On fw 8.5 appliances the unlock session
+      # silently expires within ~1 minute, so a bare get_async after that
+      # gets no response. subscribe re-issues unlock_channel which refreshes
+      # the session, then writes get_async, all in ~1.5s.
       - lambda: |-
-          uint16_t d5 = id(${prefix}_d5_handle);
-          if (d5 == 0) {
+          if (id(${prefix}_d5_handle) == 0) {
             id(${prefix}_debug).publish_state("ERROR: Not connected");
             return;
           }
           id(${prefix}_debug_mode) = true;
           id(${prefix}_debug_switch).publish_state(true);
-          auto *client = id(${prefix}_appliance);
-          std::string cmd = "{\"cmd\":\"get_async\"}\n";
-          esp_err_t err = esp_ble_gattc_write_char(
-            client->get_gattc_if(), client->get_conn_id(),
-            d5, cmd.size(), (uint8_t*)cmd.data(),
-            ESP_GATT_WRITE_TYPE_RSP, ESP_GATT_AUTH_REQ_NONE);
-          ESP_LOGI("ble", "[${appliance_name}] Debug poll via D5 (h=%d) err=%d", d5, err);
-          id(${prefix}_debug).publish_state("Debug mode ON - full state logged");
+          ESP_LOGI("ble", "[${appliance_name}] Debug poll: re-running subscribe");
+          id(${prefix}_debug).publish_state("Debug mode ON - refreshing session...");
+      - script.execute: ${prefix}_subscribe
 
 script:
   - id: ${prefix}_parse_json
@@ -436,6 +434,9 @@ script:
           if (s.common.version.rtapp)     id(${prefix}_rtapp_version).publish_state(*s.common.version.rtapp);
           if (s.common.version.appliance) id(${prefix}_board_version).publish_state(*s.common.version.appliance);
           id(${prefix}_poll_ok) = true;
-          id(${prefix}_first_poll_seen) = true;
+          // Clear poll_in_flight only on a real poll response, not on pushes.
+          // Pushes prove the connection is alive but don't prove the poll
+          // command channel is responding.
+          if (s.is_poll) id(${prefix}_poll_in_flight) = false;
           id(${prefix}_fast_retries) = 0;
           buf.clear();

--- a/subzero_range.yaml
+++ b/subzero_range.yaml
@@ -436,5 +436,6 @@ script:
           if (s.common.version.rtapp)     id(${prefix}_rtapp_version).publish_state(*s.common.version.rtapp);
           if (s.common.version.appliance) id(${prefix}_board_version).publish_state(*s.common.version.appliance);
           id(${prefix}_poll_ok) = true;
+          id(${prefix}_first_poll_seen) = true;
           id(${prefix}_fast_retries) = 0;
           buf.clear();

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -2,7 +2,7 @@
 
 Captured from real appliances via debug-mode ESPHome logs. Each `*.json` is a raw BLE payload; the paired `*.expected.json` is the expected output of `subzero_protocol::parse_*` for that input.
 
-To regenerate an expected file: **turn on Debug Mode** on the appliance (the `*_debug_switch` in HA) — chunked payload logging is gated behind it so normal operation never logs raw BLE bytes. Then concatenate the `Response[N/M]:` lines from the ESPHome logs (the payload is chunked at 400 bytes to fit the per-line log budget) into `tests/fixtures/<name>.json` and record the entity publish log lines that follow into `<name>.expected.json`. Note that non-printable bytes in the log are replaced with `?` (anti-footgun against non-UTF-8 in HA's protobuf log channel); fixtures should be hand-edited to use the real bytes or captured from a clean poll with no ACL corruption.
+To regenerate an expected file: press the appliance's *Log Debug Info* button (which turns on Debug Mode and lands a fresh poll - subscribe-refresh on fw 2.27, force-reconnect on fw 8.5). Wait ~1.5s on fw 2.27 or ~10-15s on fw 8.5 for the chunked log lines to appear. Then concatenate the `Response[N/M]:` lines from the ESPHome logs (the payload is chunked at 400 bytes to fit the per-line log budget) into `tests/fixtures/<name>.json` and record the entity publish log lines that follow into `<name>.expected.json`. Note that non-printable bytes in the log are replaced with `?` (anti-footgun against non-UTF-8 in HA's protobuf log channel); fixtures should be hand-edited to use the real bytes or captured from a clean poll with no ACL corruption.
 
 ## Layout
 


### PR DESCRIPTION
## Problem

Two distinct conditions land an appliance bonded and connected at the GATT layer with the command channel completely silent:

1. **Cold-boot race.** Multiple appliances reconnecting simultaneously at boot occasionally drop one peer's `unlock_channel` write under the ESP-IDF Bluedroid stack's concurrent-bonding traffic. That appliance never gets unlocked. `get_async` writes go through (status 0) but produce no response.

2. **fw 8.5 unlock-session expiry.** Sub-Zero fridges and wall ovens running fw 8.5 / API 5.4 silently invalidate the unlock session within ~1 minute. Subsequent `get_async` writes are accepted at the BLE layer but produce no indication response. Push notifications keep flowing because they're CCCD-based, not session-based.

User-confirmed: Main Fridge and Wall Oven (both fw 8.5) respond to the boot poll, then go silent for periodic polls AND the *Log Debug Info* button. Dishwashers and Kitchen Range (fw 2.27) don't have this issue.

## Fix - three layers

**A. Boot stagger via `poll_offset`.** Apply the existing `poll_offset` substitution at the top of `post_bond` and `fast_reconnect` (it was already at the top of `periodic_poll`). Setting per-appliance values like `0s / 5s / 10s` spreads the bonding chains in time so the cold-boot race doesn't trigger. Default `0s` keeps single-appliance behavior unchanged.

**B. Subscribe-retry safety net via `poll_in_flight`.** Per-appliance bool, cleared on disconnect. Set to `true` whenever a `get_async` is written (in `subscribe` or `periodic_poll`). Cleared only by a valid poll response (parser sets `is_poll=true` for `{\"status\":0,\"resp\":...}`). Push notifications do **not** clear it - they prove the connection is alive but don't prove the command channel responded.

When `periodic_poll` fires and finds `poll_in_flight` still `true` from the previous tick, instead of writing another bare `get_async` it runs `_subscribe.execute()` - which re-writes CCCDs (idempotent), re-issues `unlock_channel`, and writes `get_async` again. The `unlock_channel` response is small (40 bytes, single fragment, not vulnerable to ACL drops) so it parses cleanly as `is_poll=true` and clears `poll_in_flight`. Next tick is back on the bare-poll fast path.

This handles **both** scenarios with one mechanism:
- Cold-boot race: poll_in_flight stays true after subscribe's get_async goes unanswered → next periodic re-runs subscribe
- fw 8.5 expiry: poll_in_flight stays true after a periodic poll goes unanswered → next periodic re-runs subscribe (refreshing unlock)

**C. Log Debug Info buttons route through subscribe.** All three appliance types now call `${prefix}_subscribe.execute()` from the debug button instead of writing `get_async` directly. Same reason: a bare get_async from the button doesn't work on a stale-unlock fw 8.5 appliance. Going through subscribe refreshes the session first.

## False-positive edge case (previously a problem)

Earlier revisions had a similar tracker (`poll_in_flight` + `poll_no_response`) that **forced a reconnect** after 2 unanswered polls. That misfired on push-interleaved-with-poll on fw 8.5: short push during a fragmented poll response → poll's brace balance never reaches zero → parser never sees `is_poll=true` → counter never resets → reconnect loop.

This version re-runs subscribe instead of reconnecting. The unlock_channel response always parses cleanly (single fragment), which clears poll_in_flight. No reconnect loop, no false positives. Reconnects only happen via the existing zombie detector (15 min total silence) or stale-bond clear (3 consecutive bond failures).

## Files

- `subzero_base.yaml` - new `poll_in_flight` global, on_disconnect clear, `poll_offset` delays in `post_bond` and `fast_reconnect`, retry branch in `periodic_poll`, set on get_async write in `_subscribe`
- `subzero_fridge.yaml` / `subzero_dishwasher.yaml` / `subzero_range.yaml` - clear `poll_in_flight` on valid `is_poll=true` parse; debug buttons route through `_subscribe`
- `docs/advanced.adoc` - Reconnect Logic section documents the unified retry mechanism and both scenarios

## Test plan

- [x] `esphome config` validates all three minimal configs
- [x] `esphome compile wolf-minimal-range.yaml` succeeds
- [x] C++ parser unit tests: 37/37 pass
- [ ] Flash to multi-appliance ESP32. Confirm:
  - Healthy fw 2.27 appliances (dishwashers, range): bare-poll fast path every 60s, no \"Previous poll unanswered\" warnings
  - fw 8.5 appliances (Main Fridge, Wall Oven): expect periodic \"Previous poll unanswered - re-running subscribe\" warnings as the unlock session refreshes; sensors keep updating
  - Log Debug Info button on Main Fridge / Wall Oven: should produce parsed output (no longer silent)
  - Cold-flash hang: the same poll_in_flight retry covers this; should self-heal within 60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to stop periodic polling after the first successful poll and rely on pushes; configurable modes and staggered boot/bond timing.

* **Bug Fixes**
  * Per-device tracking of unanswered requests with automatic forced reconnect after repeated failures to recover stuck sessions.
  * Debug action now refreshes subscription/session or forces reconnect depending on firmware to restore unlock/session timing.

* **Documentation**
  * Expanded reconnect/keepalive docs, log-message updates, and updated test fixture instructions for the debug workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->