### PR TITLE
refactor: extract testable C++ helpers from YAML lambdas (phase 1)

### DIFF
--- a/components/subzero_protocol/buffer.cpp
+++ b/components/subzero_protocol/buffer.cpp
@@ -1,59 +1,8 @@
+// All MessageBuffer implementations are inline in buffer.h. This .cpp is
+// kept as a stub (rather than removed) so existing ESPHome build dirs —
+// whose CMake source-list cache references this filename from earlier
+// versions of this PR — continue to compile without requiring a manual
+// "Clean Build Files" step. CMake's FILE(GLOB_RECURSE ...) caches the
+// resolved source list across builds, so adding or removing .cpp files
+// in an external_components dir requires a clean to be picked up.
 #include "buffer.h"
-
-namespace esphome {
-namespace subzero_protocol {
-
-bool MessageBuffer::feed(const std::uint8_t *data, std::size_t len) {
-  if (buf_.size() > kMaxBytes) {
-    clear();
-  }
-  if (buf_.capacity() < kReserveHint) {
-    buf_.reserve(kReserveHint);
-  }
-  for (std::size_t i = 0; i < len; i++) {
-    char c = static_cast<char>(data[i]);
-    buf_.push_back(c);
-    if (complete_) {
-      continue;
-    }
-    if (c == '{') {
-      depth_++;
-    } else if (c == '}') {
-      // Clamp at 0: a stray '}' in pre-message ACL-corruption garbage
-      // would otherwise drive depth_ negative, leaving the matching '}' of
-      // the real message at -1 instead of 0 — the message would never
-      // trip complete_ and would be silently lost when kMaxBytes flushes.
-      // Naive in the same way the prior YAML scanner was, just underflow-safe.
-      if (depth_ > 0) {
-        depth_--;
-        if (depth_ == 0) {
-          complete_ = true;
-        }
-      }
-    }
-  }
-  return complete_;
-}
-
-std::optional<std::string> MessageBuffer::take_message() {
-  if (!complete_) {
-    return std::nullopt;
-  }
-  std::size_t start = buf_.find('{');
-  if (start == std::string::npos) {
-    clear();
-    return std::nullopt;
-  }
-  std::string out = (start == 0) ? std::move(buf_) : buf_.substr(start);
-  clear();
-  return out;
-}
-
-void MessageBuffer::clear() {
-  buf_.clear();
-  depth_ = 0;
-  complete_ = false;
-}
-
-}  // namespace subzero_protocol
-}  // namespace esphome

--- a/components/subzero_protocol/buffer.cpp
+++ b/components/subzero_protocol/buffer.cpp
@@ -3,7 +3,7 @@
 namespace esphome {
 namespace subzero_protocol {
 
-bool JsonBuffer::feed(const std::uint8_t *data, std::size_t len) {
+bool MessageBuffer::feed(const std::uint8_t *data, std::size_t len) {
   if (buf_.size() > kMaxBytes) {
     clear();
   }
@@ -19,16 +19,23 @@ bool JsonBuffer::feed(const std::uint8_t *data, std::size_t len) {
     if (c == '{') {
       depth_++;
     } else if (c == '}') {
-      depth_--;
-      if (depth_ == 0) {
-        complete_ = true;
+      // Clamp at 0: a stray '}' in pre-message ACL-corruption garbage
+      // would otherwise drive depth_ negative, leaving the matching '}' of
+      // the real message at -1 instead of 0 — the message would never
+      // trip complete_ and would be silently lost when kMaxBytes flushes.
+      // Naive in the same way the prior YAML scanner was, just underflow-safe.
+      if (depth_ > 0) {
+        depth_--;
+        if (depth_ == 0) {
+          complete_ = true;
+        }
       }
     }
   }
   return complete_;
 }
 
-std::optional<std::string> JsonBuffer::take_message() {
+std::optional<std::string> MessageBuffer::take_message() {
   if (!complete_) {
     return std::nullopt;
   }
@@ -42,7 +49,7 @@ std::optional<std::string> JsonBuffer::take_message() {
   return out;
 }
 
-void JsonBuffer::clear() {
+void MessageBuffer::clear() {
   buf_.clear();
   depth_ = 0;
   complete_ = false;

--- a/components/subzero_protocol/buffer.cpp
+++ b/components/subzero_protocol/buffer.cpp
@@ -1,0 +1,52 @@
+#include "buffer.h"
+
+namespace esphome {
+namespace subzero_protocol {
+
+bool JsonBuffer::feed(const std::uint8_t *data, std::size_t len) {
+  if (buf_.size() > kMaxBytes) {
+    clear();
+  }
+  if (buf_.capacity() < kReserveHint) {
+    buf_.reserve(kReserveHint);
+  }
+  for (std::size_t i = 0; i < len; i++) {
+    char c = static_cast<char>(data[i]);
+    buf_.push_back(c);
+    if (complete_) {
+      continue;
+    }
+    if (c == '{') {
+      depth_++;
+    } else if (c == '}') {
+      depth_--;
+      if (depth_ == 0) {
+        complete_ = true;
+      }
+    }
+  }
+  return complete_;
+}
+
+std::optional<std::string> JsonBuffer::take_message() {
+  if (!complete_) {
+    return std::nullopt;
+  }
+  std::size_t start = buf_.find('{');
+  if (start == std::string::npos) {
+    clear();
+    return std::nullopt;
+  }
+  std::string out = (start == 0) ? std::move(buf_) : buf_.substr(start);
+  clear();
+  return out;
+}
+
+void JsonBuffer::clear() {
+  buf_.clear();
+  depth_ = 0;
+  complete_ = false;
+}
+
+}  // namespace subzero_protocol
+}  // namespace esphome

--- a/components/subzero_protocol/buffer.h
+++ b/components/subzero_protocol/buffer.h
@@ -14,6 +14,12 @@
 // (PR #56's "stray { mid-buffer means corruption") was reverted in PR #61
 // after it threw away legitimate poll responses whenever a short push
 // arrived during a long poll. Keep this simple.
+//
+// Underflow guard: the depth counter is clamped at 0 on `}`. The prior YAML
+// scanner did not clamp; an unmatched `}` in pre-message ACL-corruption
+// garbage would drive depth negative, and a complete message arriving after
+// it would never trip the depth==0 check. See buffer_test.cpp's
+// StrayClosingBraceInPrefixIgnored regression test.
 
 #include <cstddef>
 #include <cstdint>
@@ -23,7 +29,7 @@
 namespace esphome {
 namespace subzero_protocol {
 
-class JsonBuffer {
+class MessageBuffer {
  public:
   // Reserve hint matches the prior YAML behavior. Initial reserve avoids
   // repeated reallocs across the ~50 fragments of a typical poll response.

--- a/components/subzero_protocol/buffer.h
+++ b/components/subzero_protocol/buffer.h
@@ -1,0 +1,66 @@
+#pragma once
+
+// JSON message buffer for fragmented BLE indications.
+//
+// BLE delivers responses as a sequence of indications (small packets, often
+// ~20-40 bytes each, sometimes ACL-fragmented further). The full appliance
+// response is a single JSON object that may span ~50 fragments. This class
+// accumulates fragments and detects when a complete object has been buffered
+// by counting unbalanced braces.
+//
+// Brace counting is intentionally naive (no string-aware skipping): a `}`
+// inside a JSON string value would falsely complete. The real protocol does
+// not produce such strings in practice, and a more "clever" detector
+// (PR #56's "stray { mid-buffer means corruption") was reverted in PR #61
+// after it threw away legitimate poll responses whenever a short push
+// arrived during a long poll. Keep this simple.
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace esphome {
+namespace subzero_protocol {
+
+class JsonBuffer {
+ public:
+  // Reserve hint matches the prior YAML behavior. Initial reserve avoids
+  // repeated reallocs across the ~50 fragments of a typical poll response.
+  static constexpr std::size_t kReserveHint = 2048;
+
+  // Hard cap before forced reset on the next feed(). Guards against a
+  // wedged session that stops emitting `}` and would otherwise grow the
+  // buffer forever.
+  static constexpr std::size_t kMaxBytes = 4096;
+
+  // Append bytes; return true once a complete message is buffered (a `}`
+  // has brought running brace depth to 0). Sticky: once true, stays true
+  // through subsequent appends until clear()/take_message() resets state.
+  //
+  // If the buffer was already over-capacity *before* this append, it is
+  // reset first — same recovery semantics as the prior YAML lambda.
+  bool feed(const std::uint8_t *data, std::size_t len);
+
+  // If a complete message is buffered, return the substring starting at
+  // the first `{` (leading garbage from ACL corruption is dropped) and
+  // reset internal state. If no message is complete or no `{` exists,
+  // returns nullopt; in the no-`{` case the buffer is also cleared as
+  // unrecoverable garbage (matches the prior parse_json script behavior).
+  std::optional<std::string> take_message();
+
+  // Manual reset (use on disconnect or when callers detect parse failure
+  // and want to discard the current buffer).
+  void clear();
+
+  std::size_t size() const { return buf_.size(); }
+  bool complete() const { return complete_; }
+
+ private:
+  std::string buf_;
+  int depth_ = 0;
+  bool complete_ = false;
+};
+
+}  // namespace subzero_protocol
+}  // namespace esphome

--- a/components/subzero_protocol/buffer.h
+++ b/components/subzero_protocol/buffer.h
@@ -46,18 +46,70 @@ class MessageBuffer {
   //
   // If the buffer was already over-capacity *before* this append, it is
   // reset first — same recovery semantics as the prior YAML lambda.
-  bool feed(const std::uint8_t *data, std::size_t len);
+  //
+  // Defined inline (header-only): keeping all of subzero_protocol's
+  // implementation in protocol.cpp avoids tripping ESPHome's
+  // GLOB_RECURSE source-list cache when this PR ships and existing
+  // installs do an incremental rebuild.
+  inline bool feed(const std::uint8_t *data, std::size_t len) {
+    if (buf_.size() > kMaxBytes) {
+      clear();
+    }
+    if (buf_.capacity() < kReserveHint) {
+      buf_.reserve(kReserveHint);
+    }
+    for (std::size_t i = 0; i < len; i++) {
+      char c = static_cast<char>(data[i]);
+      buf_.push_back(c);
+      if (complete_) {
+        continue;
+      }
+      if (c == '{') {
+        depth_++;
+      } else if (c == '}') {
+        // Clamp at 0: a stray '}' in pre-message ACL-corruption garbage
+        // would otherwise drive depth_ negative, leaving the matching
+        // '}' of the real message at -1 instead of 0 — the message
+        // would never trip complete_ and would be silently lost when
+        // kMaxBytes flushes. Naive in the same way the prior YAML
+        // scanner was, just underflow-safe.
+        if (depth_ > 0) {
+          depth_--;
+          if (depth_ == 0) {
+            complete_ = true;
+          }
+        }
+      }
+    }
+    return complete_;
+  }
 
   // If a complete message is buffered, return the substring starting at
   // the first `{` (leading garbage from ACL corruption is dropped) and
   // reset internal state. If no message is complete or no `{` exists,
   // returns nullopt; in the no-`{` case the buffer is also cleared as
   // unrecoverable garbage (matches the prior parse_json script behavior).
-  std::optional<std::string> take_message();
+  inline std::optional<std::string> take_message() {
+    if (!complete_) {
+      return std::nullopt;
+    }
+    std::size_t start = buf_.find('{');
+    if (start == std::string::npos) {
+      clear();
+      return std::nullopt;
+    }
+    std::string out = (start == 0) ? std::move(buf_) : buf_.substr(start);
+    clear();
+    return out;
+  }
 
   // Manual reset (use on disconnect or when callers detect parse failure
   // and want to discard the current buffer).
-  void clear();
+  inline void clear() {
+    buf_.clear();
+    depth_ = 0;
+    complete_ = false;
+  }
 
   std::size_t size() const { return buf_.size(); }
   bool complete() const { return complete_; }

--- a/components/subzero_protocol/log_sanitize.cpp
+++ b/components/subzero_protocol/log_sanitize.cpp
@@ -1,0 +1,26 @@
+#include "log_sanitize.h"
+
+namespace esphome {
+namespace subzero_protocol {
+
+std::string sanitize_for_log(const std::string &s, std::size_t off, std::size_t len) {
+  if (off >= s.size()) {
+    return std::string();
+  }
+  std::size_t avail = s.size() - off;
+  if (len > avail) {
+    len = avail;
+  }
+  std::string out(s, off, len);
+  for (char &c : out) {
+    unsigned char u = static_cast<unsigned char>(c);
+    bool ok = (u >= 0x20 && u <= 0x7E) || u == 0x09 || u == 0x0A || u == 0x0D;
+    if (!ok) {
+      c = '?';
+    }
+  }
+  return out;
+}
+
+}  // namespace subzero_protocol
+}  // namespace esphome

--- a/components/subzero_protocol/log_sanitize.cpp
+++ b/components/subzero_protocol/log_sanitize.cpp
@@ -1,26 +1,3 @@
+// All log-sanitize implementations are inline in log_sanitize.h. See
+// buffer.cpp for why this stub exists.
 #include "log_sanitize.h"
-
-namespace esphome {
-namespace subzero_protocol {
-
-std::string sanitize_for_log(const std::string &s, std::size_t off, std::size_t len) {
-  if (off >= s.size()) {
-    return std::string();
-  }
-  std::size_t avail = s.size() - off;
-  if (len > avail) {
-    len = avail;
-  }
-  std::string out(s, off, len);
-  for (char &c : out) {
-    unsigned char u = static_cast<unsigned char>(c);
-    bool ok = (u >= 0x20 && u <= 0x7E) || u == 0x09 || u == 0x0A || u == 0x0D;
-    if (!ok) {
-      c = '?';
-    }
-  }
-  return out;
-}
-
-}  // namespace subzero_protocol
-}  // namespace esphome

--- a/components/subzero_protocol/log_sanitize.h
+++ b/components/subzero_protocol/log_sanitize.h
@@ -1,0 +1,47 @@
+#pragma once
+
+// Sanitization helpers for logging raw BLE-buffer contents.
+//
+// The raw buffer may contain non-UTF-8 bytes from ACL fragment corruption.
+// Anything we log MUST be sanitized first: ESPHome ships log lines to HA
+// over a protobuf-typed transport (UTF-8 required); a high-bit byte
+// (0x80-0xFF) that isn't a valid multi-byte sequence crashes HA's protobuf
+// decoder, which then caches the bad event and loops.
+//
+// Allowlist: printable ASCII (0x20..0x7E) and the whitespace controls
+// \t \n \r — all valid UTF-8 and harmless in protobuf. Everything else
+// becomes '?'. Keeping \n unsanitized means the protocol's terminator at
+// the end of every response no longer triggers a nuisance '?', so any '?'
+// appearing in a log line is a real corruption signal.
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+
+namespace esphome {
+namespace subzero_protocol {
+
+// Replaces non-printable bytes in [off, off+len) of `s` with '?' and
+// returns the resulting string. Out-of-range len is clamped.
+std::string sanitize_for_log(const std::string &s, std::size_t off, std::size_t len);
+
+// Splits a message into chunks (default 400 bytes, sized for ESPHome's
+// per-line log budget so the full payload survives) and invokes
+// cb(idx_1based, total, sanitized_chunk) for each. Used for fixture-capture
+// debug logging — grep `Response\[` and concatenate the chunks to
+// reassemble the raw payload.
+template <typename Cb>
+void chunk_for_log(const std::string &msg, Cb cb, std::size_t chunk_size = 400) {
+  if (msg.empty() || chunk_size == 0) {
+    return;
+  }
+  std::size_t total = (msg.size() + chunk_size - 1) / chunk_size;
+  for (std::size_t i = 0; i < total; i++) {
+    std::size_t off = i * chunk_size;
+    std::size_t len = std::min(chunk_size, msg.size() - off);
+    cb(i + 1, total, sanitize_for_log(msg, off, len));
+  }
+}
+
+}  // namespace subzero_protocol
+}  // namespace esphome

--- a/components/subzero_protocol/log_sanitize.h
+++ b/components/subzero_protocol/log_sanitize.h
@@ -23,7 +23,27 @@ namespace subzero_protocol {
 
 // Replaces non-printable bytes in [off, off+len) of `s` with '?' and
 // returns the resulting string. Out-of-range len is clamped.
-std::string sanitize_for_log(const std::string &s, std::size_t off, std::size_t len);
+//
+// Defined inline (header-only): see buffer.h for rationale (avoid
+// tripping ESPHome's GLOB_RECURSE source-list cache).
+inline std::string sanitize_for_log(const std::string &s, std::size_t off, std::size_t len) {
+  if (off >= s.size()) {
+    return std::string();
+  }
+  std::size_t avail = s.size() - off;
+  if (len > avail) {
+    len = avail;
+  }
+  std::string out(s, off, len);
+  for (char &c : out) {
+    unsigned char u = static_cast<unsigned char>(c);
+    bool ok = (u >= 0x20 && u <= 0x7E) || u == 0x09 || u == 0x0A || u == 0x0D;
+    if (!ok) {
+      c = '?';
+    }
+  }
+  return out;
+}
 
 // Splits a message into chunks (default 400 bytes, sized for ESPHome's
 // per-line log budget so the full payload survives) and invokes

--- a/components/subzero_protocol/poll_state.h
+++ b/components/subzero_protocol/poll_state.h
@@ -1,0 +1,55 @@
+#pragma once
+
+// Post-parse state-machine mutation, extracted from the per-appliance
+// parse_json scripts (where it lived as ~10 lines of identical boilerplate
+// across subzero_fridge.yaml, subzero_dishwasher.yaml, subzero_range.yaml).
+//
+// Invariants preserved here:
+//
+// 1. Only `is_poll == true` responses reset poll-related counters.
+//    Push notifications prove the connection is alive (they do reset
+//    poll_ok in the notify handler) but do NOT prove the command channel
+//    is responding. If we cleared poll_in_flight on a push, the unlock-
+//    expiry detector in periodic_poll would never escalate to a reconnect
+//    on fw 8.5 appliances whose unlock session expires while pushes keep
+//    flowing.
+//
+// 2. fw_85_detected is set sticky once seen, on a poll response only.
+//    Cleared on disconnect (by the YAML on_disconnect handler).
+//
+// 3. fast_retries is reset on EVERY successful parse (poll or push) — any
+//    valid response means the connection is functional, so prior fast-
+//    reconnect failures aren't relevant anymore.
+
+#include <string>
+
+namespace esphome {
+namespace subzero_protocol {
+
+// Updates the YAML-side state-machine globals after a successful parse.
+// Pass each global by reference (callers are ESPHome lambdas that look
+// them up via id()).
+//
+// Templated on the parser-result type (FridgeState / DishwasherState /
+// RangeState) — they all expose `.is_poll` and
+// `.common.version.fw` (std::optional<std::string>).
+template <typename T>
+inline void apply_parse_result(bool &poll_in_flight,
+                               int &unanswered_polls,
+                               bool &first_poll_done,
+                               bool &fw_85_detected,
+                               int &fast_retries,
+                               const T &s) {
+  if (s.is_poll) {
+    poll_in_flight = false;
+    unanswered_polls = 0;
+    first_poll_done = true;
+    if (s.common.version.fw && *s.common.version.fw == std::string("8.5")) {
+      fw_85_detected = true;
+    }
+  }
+  fast_retries = 0;
+}
+
+}  // namespace subzero_protocol
+}  // namespace esphome

--- a/subzero_base.yaml
+++ b/subzero_base.yaml
@@ -80,7 +80,7 @@ globals:
     type: int
     initial_value: "0"
   - id: ${prefix}_json_buf
-    type: esphome::subzero_protocol::JsonBuffer
+    type: esphome::subzero_protocol::MessageBuffer
     restore_value: false
   - id: ${prefix}_stored_pin
     type: std::string

--- a/subzero_base.yaml
+++ b/subzero_base.yaml
@@ -80,7 +80,7 @@ globals:
     type: int
     initial_value: "0"
   - id: ${prefix}_json_buf
-    type: std::string
+    type: esphome::subzero_protocol::JsonBuffer
     restore_value: false
   - id: ${prefix}_stored_pin
     type: std::string
@@ -248,19 +248,9 @@ sensor:
     notify: true
     update_interval: never
     lambda: |-
-      auto &buf = id(${prefix}_json_buf);
-      if (buf.capacity() < 2048) buf.reserve(2048);
-      if (buf.size() > 4096) { buf.clear(); return {}; }
-      buf.append((char*)x.data(), x.size());
-      // Any notification = connection alive (resets zombie detection)
+      // Any notification = connection alive (resets zombie detection).
       id(${prefix}_poll_ok) = true;
-      int depth = 0;
-      bool complete = false;
-      for (char c : buf) {
-        if (c == '{') depth++;
-        else if (c == '}') { depth--; if (depth == 0) { complete = true; break; } }
-      }
-      if (complete) {
+      if (id(${prefix}_json_buf).feed(x.data(), x.size())) {
         id(${prefix}_parse_json).execute();
       }
       return {};

--- a/subzero_dishwasher.yaml
+++ b/subzero_dishwasher.yaml
@@ -154,50 +154,21 @@ script:
     mode: single
     then:
       - lambda: |-
-          auto &buf = id(${prefix}_json_buf);
-          size_t start = buf.find('{');
-          if (start == std::string::npos) { buf.clear(); return; }
-          if (start > 0) buf.erase(0, start);
+          auto msg = id(${prefix}_json_buf).take_message();
+          if (!msg) return;
           bool dbg = id(${prefix}_debug_mode);
-          ESP_LOGI("szg", "[${appliance_name}] Parsing JSON (%d bytes)", (int)buf.size());
-          // Raw buf may contain non-UTF-8 bytes from ACL fragment corruption.
-          // Anything we log from buf MUST be sanitized first: the log message
-          // is sent to HA as a protobuf `string` (UTF-8 required) and a
-          // high-bit byte (0x80-0xFF) that isn't part of a valid multi-byte
-          // sequence crashes HA's protobuf decoder, which caches the bad
-          // event and loops. Allow printable ASCII plus \t \n \r (all valid
-          // UTF-8 and harmless in protobuf); everything else becomes '?'.
-          // Keeping \n unsanitized means the normal protocol terminator at
-          // the end of every response no longer triggers a nuisance '?' -
-          // so any '?' that now appears is a real signal of corruption.
-          auto sanitize = [](const std::string &s, size_t off, size_t len) {
-            std::string out(s, off, len);
-            for (char &c : out) {
-              unsigned char u = c;
-              bool ok = (u >= 0x20 && u <= 0x7E) || u == 0x09 || u == 0x0A || u == 0x0D;
-              if (!ok) c = '?';
-            }
-            return out;
-          };
+          ESP_LOGI("szg", "[${appliance_name}] Parsing JSON (%d bytes)", (int)msg->size());
           if (dbg) {
-            // Chunked so the full payload survives the per-line log budget.
-            // Grep `Response\[` and concatenate to reassemble - used for fixture
-            // capture. Gated on debug mode so normal operation never logs raw
-            // buf contents.
-            const size_t CHUNK = 400;
-            size_t total = (buf.size() + CHUNK - 1) / CHUNK;
-            for (size_t i = 0; i < total; i++) {
-              size_t off = i * CHUNK;
-              size_t len = std::min(CHUNK, buf.size() - off);
-              ESP_LOGI("szg", "[${appliance_name}] Response[%d/%d]: %s",
-                       (int)(i + 1), (int)total, sanitize(buf, off, len).c_str());
-            }
+            esphome::subzero_protocol::chunk_for_log(*msg,
+              [](size_t idx, size_t total, const std::string &chunk) {
+                ESP_LOGI("szg", "[${appliance_name}] Response[%d/%d]: %s",
+                         (int)idx, (int)total, chunk.c_str());
+              });
           }
-          auto s = esphome::subzero_protocol::parse_dishwasher(buf);
+          auto s = esphome::subzero_protocol::parse_dishwasher(*msg);
           if (!s.valid) {
             ESP_LOGW("szg", "[${appliance_name}] Parse failed or status!=0, skipping (%s...)",
-                     sanitize(buf, 0, std::min<size_t>(80, buf.size())).c_str());
-            buf.clear();
+                     esphome::subzero_protocol::sanitize_for_log(*msg, 0, std::min<size_t>(80, msg->size())).c_str());
             return;
           }
           if (dbg) {
@@ -257,19 +228,11 @@ script:
           if (s.common.version.rtapp)     id(${prefix}_rtapp_version).publish_state(*s.common.version.rtapp);
           if (s.common.version.appliance) id(${prefix}_board_version).publish_state(*s.common.version.appliance);
           id(${prefix}_poll_ok) = true;
-          // Clear poll_in_flight + reset unanswered_polls only on a real
-          // poll response, not on pushes. Pushes prove the connection is
-          // alive but don't prove the command channel is responding.
-          // first_poll_done gates push_only_after_first_poll's early-return.
-          // fw_85_detected drives "auto" mode (rare on dishwashers but
-          // included for parity).
-          if (s.is_poll) {
-            id(${prefix}_poll_in_flight) = false;
-            id(${prefix}_unanswered_polls) = 0;
-            id(${prefix}_first_poll_done) = true;
-            if (s.common.version.fw && *s.common.version.fw == "8.5") {
-              id(${prefix}_fw_85_detected) = true;
-            }
-          }
-          id(${prefix}_fast_retries) = 0;
-          buf.clear();
+          // Post-parse state-machine mutation. See poll_state.h for invariants.
+          esphome::subzero_protocol::apply_parse_result(
+              id(${prefix}_poll_in_flight),
+              id(${prefix}_unanswered_polls),
+              id(${prefix}_first_poll_done),
+              id(${prefix}_fw_85_detected),
+              id(${prefix}_fast_retries),
+              s);

--- a/subzero_fridge.yaml
+++ b/subzero_fridge.yaml
@@ -81,18 +81,9 @@ sensor:
     notify: true
     update_interval: never
     lambda: |-
-      auto &buf = id(${prefix}_json_buf);
-      if (buf.capacity() < 2048) buf.reserve(2048);
-      if (buf.size() > 4096) { buf.clear(); return {}; }
-      buf.append((char*)x.data(), x.size());
+      // Any notification = connection alive (resets zombie detection).
       id(${prefix}_poll_ok) = true;
-      int depth = 0;
-      bool complete = false;
-      for (char c : buf) {
-        if (c == '{') depth++;
-        else if (c == '}') { depth--; if (depth == 0) { complete = true; break; } }
-      }
-      if (complete) {
+      if (id(${prefix}_json_buf).feed(x.data(), x.size())) {
         id(${prefix}_parse_json).execute();
       }
       return {};
@@ -258,50 +249,25 @@ script:
     mode: single
     then:
       - lambda: |-
-          auto &buf = id(${prefix}_json_buf);
-          size_t start = buf.find('{');
-          if (start == std::string::npos) { buf.clear(); return; }
-          if (start > 0) buf.erase(0, start);
+          auto msg = id(${prefix}_json_buf).take_message();
+          if (!msg) return;
           bool dbg = id(${prefix}_debug_mode);
-          ESP_LOGI("szg", "[${appliance_name}] Parsing JSON (%d bytes)", (int)buf.size());
-          // Raw buf may contain non-UTF-8 bytes from ACL fragment corruption.
-          // Anything we log from buf MUST be sanitized first: the log message
-          // is sent to HA as a protobuf `string` (UTF-8 required) and a
-          // high-bit byte (0x80-0xFF) that isn't part of a valid multi-byte
-          // sequence crashes HA's protobuf decoder, which caches the bad
-          // event and loops. Allow printable ASCII plus \t \n \r (all valid
-          // UTF-8 and harmless in protobuf); everything else becomes '?'.
-          // Keeping \n unsanitized means the normal protocol terminator at
-          // the end of every response no longer triggers a nuisance '?' -
-          // so any '?' that now appears is a real signal of corruption.
-          auto sanitize = [](const std::string &s, size_t off, size_t len) {
-            std::string out(s, off, len);
-            for (char &c : out) {
-              unsigned char u = c;
-              bool ok = (u >= 0x20 && u <= 0x7E) || u == 0x09 || u == 0x0A || u == 0x0D;
-              if (!ok) c = '?';
-            }
-            return out;
-          };
+          ESP_LOGI("szg", "[${appliance_name}] Parsing JSON (%d bytes)", (int)msg->size());
           if (dbg) {
             // Chunked so the full payload survives the per-line log budget.
             // Grep `Response\[` and concatenate to reassemble - used for fixture
             // capture. Gated on debug mode so normal operation never logs raw
             // buf contents.
-            const size_t CHUNK = 400;
-            size_t total = (buf.size() + CHUNK - 1) / CHUNK;
-            for (size_t i = 0; i < total; i++) {
-              size_t off = i * CHUNK;
-              size_t len = std::min(CHUNK, buf.size() - off);
-              ESP_LOGI("szg", "[${appliance_name}] Response[%d/%d]: %s",
-                       (int)(i + 1), (int)total, sanitize(buf, off, len).c_str());
-            }
+            esphome::subzero_protocol::chunk_for_log(*msg,
+              [](size_t idx, size_t total, const std::string &chunk) {
+                ESP_LOGI("szg", "[${appliance_name}] Response[%d/%d]: %s",
+                         (int)idx, (int)total, chunk.c_str());
+              });
           }
-          auto s = esphome::subzero_protocol::parse_fridge(buf);
+          auto s = esphome::subzero_protocol::parse_fridge(*msg);
           if (!s.valid) {
             ESP_LOGW("szg", "[${appliance_name}] Parse failed or status!=0, skipping (%s...)",
-                     sanitize(buf, 0, std::min<size_t>(80, buf.size())).c_str());
-            buf.clear();
+                     esphome::subzero_protocol::sanitize_for_log(*msg, 0, std::min<size_t>(80, msg->size())).c_str());
             return;
           }
           if (dbg) {
@@ -354,20 +320,14 @@ script:
           if (s.common.version.rtapp)     id(${prefix}_rtapp_version).publish_state(*s.common.version.rtapp);
           if (s.common.version.appliance) id(${prefix}_board_version).publish_state(*s.common.version.appliance);
           id(${prefix}_poll_ok) = true;
-          // Clear poll_in_flight + reset unanswered_polls only on a real
-          // poll response, not on pushes. Pushes prove the connection is
-          // alive but don't prove the command channel is responding.
-          // first_poll_done gates push_only_after_first_poll's early-return.
-          // fw_85_detected drives "auto" mode - lets push-only enable
-          // itself on Sub-Zero 313, Wolf SO3050PESP, etc. without
-          // per-appliance config.
-          if (s.is_poll) {
-            id(${prefix}_poll_in_flight) = false;
-            id(${prefix}_unanswered_polls) = 0;
-            id(${prefix}_first_poll_done) = true;
-            if (s.common.version.fw && *s.common.version.fw == "8.5") {
-              id(${prefix}_fw_85_detected) = true;
-            }
-          }
-          id(${prefix}_fast_retries) = 0;
-          buf.clear();
+          // Post-parse state-machine mutation. See poll_state.h for invariants:
+          //   - only is_poll responses clear poll_in_flight / unanswered_polls
+          //   - fw_85_detected sticky on first sight of "8.5"
+          //   - fast_retries reset on any valid parse
+          esphome::subzero_protocol::apply_parse_result(
+              id(${prefix}_poll_in_flight),
+              id(${prefix}_unanswered_polls),
+              id(${prefix}_first_poll_done),
+              id(${prefix}_fw_85_detected),
+              id(${prefix}_fast_retries),
+              s);

--- a/subzero_range.yaml
+++ b/subzero_range.yaml
@@ -329,50 +329,21 @@ script:
     mode: single
     then:
       - lambda: |-
-          auto &buf = id(${prefix}_json_buf);
-          size_t start = buf.find('{');
-          if (start == std::string::npos) { buf.clear(); return; }
-          if (start > 0) buf.erase(0, start);
+          auto msg = id(${prefix}_json_buf).take_message();
+          if (!msg) return;
           bool dbg = id(${prefix}_debug_mode);
-          ESP_LOGI("szg", "[${appliance_name}] Parsing JSON (%d bytes)", (int)buf.size());
-          // Raw buf may contain non-UTF-8 bytes from ACL fragment corruption.
-          // Anything we log from buf MUST be sanitized first: the log message
-          // is sent to HA as a protobuf `string` (UTF-8 required) and a
-          // high-bit byte (0x80-0xFF) that isn't part of a valid multi-byte
-          // sequence crashes HA's protobuf decoder, which caches the bad
-          // event and loops. Allow printable ASCII plus \t \n \r (all valid
-          // UTF-8 and harmless in protobuf); everything else becomes '?'.
-          // Keeping \n unsanitized means the normal protocol terminator at
-          // the end of every response no longer triggers a nuisance '?' -
-          // so any '?' that now appears is a real signal of corruption.
-          auto sanitize = [](const std::string &s, size_t off, size_t len) {
-            std::string out(s, off, len);
-            for (char &c : out) {
-              unsigned char u = c;
-              bool ok = (u >= 0x20 && u <= 0x7E) || u == 0x09 || u == 0x0A || u == 0x0D;
-              if (!ok) c = '?';
-            }
-            return out;
-          };
+          ESP_LOGI("szg", "[${appliance_name}] Parsing JSON (%d bytes)", (int)msg->size());
           if (dbg) {
-            // Chunked so the full payload survives the per-line log budget.
-            // Grep `Response\[` and concatenate to reassemble - used for fixture
-            // capture. Gated on debug mode so normal operation never logs raw
-            // buf contents.
-            const size_t CHUNK = 400;
-            size_t total = (buf.size() + CHUNK - 1) / CHUNK;
-            for (size_t i = 0; i < total; i++) {
-              size_t off = i * CHUNK;
-              size_t len = std::min(CHUNK, buf.size() - off);
-              ESP_LOGI("szg", "[${appliance_name}] Response[%d/%d]: %s",
-                       (int)(i + 1), (int)total, sanitize(buf, off, len).c_str());
-            }
+            esphome::subzero_protocol::chunk_for_log(*msg,
+              [](size_t idx, size_t total, const std::string &chunk) {
+                ESP_LOGI("szg", "[${appliance_name}] Response[%d/%d]: %s",
+                         (int)idx, (int)total, chunk.c_str());
+              });
           }
-          auto s = esphome::subzero_protocol::parse_range(buf);
+          auto s = esphome::subzero_protocol::parse_range(*msg);
           if (!s.valid) {
             ESP_LOGW("szg", "[${appliance_name}] Parse failed or status!=0, skipping (%s...)",
-                     sanitize(buf, 0, std::min<size_t>(80, buf.size())).c_str());
-            buf.clear();
+                     esphome::subzero_protocol::sanitize_for_log(*msg, 0, std::min<size_t>(80, msg->size())).c_str());
             return;
           }
           if (dbg) {
@@ -446,20 +417,11 @@ script:
           if (s.common.version.rtapp)     id(${prefix}_rtapp_version).publish_state(*s.common.version.rtapp);
           if (s.common.version.appliance) id(${prefix}_board_version).publish_state(*s.common.version.appliance);
           id(${prefix}_poll_ok) = true;
-          // Clear poll_in_flight + reset unanswered_polls only on a real
-          // poll response, not on pushes. Pushes prove the connection is
-          // alive but don't prove the command channel is responding.
-          // first_poll_done gates push_only_after_first_poll's early-return.
-          // fw_85_detected drives "auto" mode - lets push-only enable
-          // itself on Sub-Zero 313, Wolf SO3050PESP, etc. without
-          // per-appliance config.
-          if (s.is_poll) {
-            id(${prefix}_poll_in_flight) = false;
-            id(${prefix}_unanswered_polls) = 0;
-            id(${prefix}_first_poll_done) = true;
-            if (s.common.version.fw && *s.common.version.fw == "8.5") {
-              id(${prefix}_fw_85_detected) = true;
-            }
-          }
-          id(${prefix}_fast_retries) = 0;
-          buf.clear();
+          // Post-parse state-machine mutation. See poll_state.h for invariants.
+          esphome::subzero_protocol::apply_parse_result(
+              id(${prefix}_poll_in_flight),
+              id(${prefix}_unanswered_polls),
+              id(${prefix}_first_poll_done),
+              id(${prefix}_fw_85_detected),
+              id(${prefix}_fast_retries),
+              s);

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -44,6 +44,8 @@ set(FIXTURES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../fixtures)
 
 add_library(subzero_protocol STATIC
   ${PROTOCOL_DIR}/protocol.cpp
+  ${PROTOCOL_DIR}/buffer.cpp
+  ${PROTOCOL_DIR}/log_sanitize.cpp
 )
 target_include_directories(subzero_protocol PUBLIC ${PROTOCOL_DIR})
 target_link_libraries(subzero_protocol PUBLIC ArduinoJson)
@@ -52,6 +54,9 @@ enable_testing()
 
 add_executable(protocol_tests
   protocol_test.cpp
+  buffer_test.cpp
+  sanitize_test.cpp
+  poll_state_test.cpp
 )
 target_link_libraries(protocol_tests PRIVATE
   subzero_protocol

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -44,8 +44,6 @@ set(FIXTURES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../fixtures)
 
 add_library(subzero_protocol STATIC
   ${PROTOCOL_DIR}/protocol.cpp
-  ${PROTOCOL_DIR}/buffer.cpp
-  ${PROTOCOL_DIR}/log_sanitize.cpp
 )
 target_include_directories(subzero_protocol PUBLIC ${PROTOCOL_DIR})
 target_link_libraries(subzero_protocol PUBLIC ArduinoJson)

--- a/tests/cpp/buffer_test.cpp
+++ b/tests/cpp/buffer_test.cpp
@@ -7,26 +7,26 @@
 #include <string>
 #include <vector>
 
-using esphome::subzero_protocol::JsonBuffer;
+using esphome::subzero_protocol::MessageBuffer;
 
 namespace {
 
 // Convenience: feed a string literal as bytes.
-bool feed_str(JsonBuffer &b, const char *s) {
+bool feed_str(MessageBuffer &b, const char *s) {
   return b.feed(reinterpret_cast<const std::uint8_t *>(s), std::strlen(s));
 }
 
 }  // namespace
 
-TEST(JsonBuffer, EmptyByDefault) {
-  JsonBuffer b;
+TEST(MessageBuffer, EmptyByDefault) {
+  MessageBuffer b;
   EXPECT_FALSE(b.complete());
   EXPECT_EQ(b.size(), 0u);
   EXPECT_FALSE(b.take_message().has_value());
 }
 
-TEST(JsonBuffer, SingleChunkComplete) {
-  JsonBuffer b;
+TEST(MessageBuffer, SingleChunkComplete) {
+  MessageBuffer b;
   EXPECT_TRUE(feed_str(b, "{\"a\":1}"));
   EXPECT_TRUE(b.complete());
   auto msg = b.take_message();
@@ -36,8 +36,8 @@ TEST(JsonBuffer, SingleChunkComplete) {
   EXPECT_EQ(b.size(), 0u);
 }
 
-TEST(JsonBuffer, FragmentedDelivery) {
-  JsonBuffer b;
+TEST(MessageBuffer, FragmentedDelivery) {
+  MessageBuffer b;
   EXPECT_FALSE(feed_str(b, "{\"a"));
   EXPECT_FALSE(feed_str(b, "\":1,"));
   EXPECT_FALSE(feed_str(b, "\"b\":{\"c\":2}"));  // nested {}: depth back to 1
@@ -49,8 +49,8 @@ TEST(JsonBuffer, FragmentedDelivery) {
   EXPECT_EQ(*msg, "{\"a\":1,\"b\":{\"c\":2}}");
 }
 
-TEST(JsonBuffer, SingleByteAtATime) {
-  JsonBuffer b;
+TEST(MessageBuffer, SingleByteAtATime) {
+  MessageBuffer b;
   const char *s = "{\"x\":[1,2,3]}";
   for (size_t i = 0; i < std::strlen(s) - 1; i++) {
     auto ch = static_cast<std::uint8_t>(s[i]);
@@ -61,26 +61,26 @@ TEST(JsonBuffer, SingleByteAtATime) {
   EXPECT_EQ(*b.take_message(), s);
 }
 
-TEST(JsonBuffer, GarbagePrefixTrimmedOnTake) {
+TEST(MessageBuffer, GarbagePrefixTrimmedOnTake) {
   // ACL corruption can deliver bytes before the JSON starts.
   // take_message() returns the substring from the first '{'.
-  JsonBuffer b;
+  MessageBuffer b;
   EXPECT_TRUE(feed_str(b, "\x01\x02garbage{\"a\":1}"));
   auto msg = b.take_message();
   ASSERT_TRUE(msg.has_value());
   EXPECT_EQ(*msg, "{\"a\":1}");
 }
 
-TEST(JsonBuffer, OverCapacityResetsOnNextFeed) {
+TEST(MessageBuffer, OverCapacityResetsOnNextFeed) {
   // Wedged session: many fragments arrive without a closing `}`.
   // Once the buffer exceeds kMaxBytes, the NEXT feed clears it before
   // appending new bytes — preempts unbounded growth.
-  JsonBuffer b;
-  std::string huge(JsonBuffer::kMaxBytes + 100, 'x');
+  MessageBuffer b;
+  std::string huge(MessageBuffer::kMaxBytes + 100, 'x');
   // Prepend a `{` so depth goes to 1 (not complete).
   std::string bytes = "{" + huge;
   EXPECT_FALSE(b.feed(reinterpret_cast<const std::uint8_t *>(bytes.data()), bytes.size()));
-  EXPECT_GT(b.size(), JsonBuffer::kMaxBytes);
+  EXPECT_GT(b.size(), MessageBuffer::kMaxBytes);
 
   // Next feed: pre-emptive reset, then append the new fragment.
   EXPECT_TRUE(feed_str(b, "{\"a\":1}"));
@@ -89,8 +89,8 @@ TEST(JsonBuffer, OverCapacityResetsOnNextFeed) {
   EXPECT_EQ(*msg, "{\"a\":1}");
 }
 
-TEST(JsonBuffer, ClearResetsState) {
-  JsonBuffer b;
+TEST(MessageBuffer, ClearResetsState) {
+  MessageBuffer b;
   feed_str(b, "{");
   b.clear();
   EXPECT_EQ(b.size(), 0u);
@@ -99,8 +99,8 @@ TEST(JsonBuffer, ClearResetsState) {
   EXPECT_TRUE(feed_str(b, "{\"a\":1}"));
 }
 
-TEST(JsonBuffer, TakeWithoutCompleteReturnsNullopt) {
-  JsonBuffer b;
+TEST(MessageBuffer, TakeWithoutCompleteReturnsNullopt) {
+  MessageBuffer b;
   feed_str(b, "{\"a");
   EXPECT_FALSE(b.complete());
   EXPECT_FALSE(b.take_message().has_value());
@@ -109,8 +109,8 @@ TEST(JsonBuffer, TakeWithoutCompleteReturnsNullopt) {
   EXPECT_GT(b.size(), 0u);
 }
 
-TEST(JsonBuffer, NoBraceClearsOnTake) {
-  JsonBuffer b;
+TEST(MessageBuffer, NoBraceClearsOnTake) {
+  MessageBuffer b;
   // Force complete_ = true by feeding a balanced pair, but starting with
   // garbage that has no `{`. There's no realistic path where complete_
   // is true with no `{`, so we just exercise the defensive branch by
@@ -122,8 +122,33 @@ TEST(JsonBuffer, NoBraceClearsOnTake) {
   EXPECT_EQ(b.size(), 0u);
 }
 
-TEST(JsonBuffer, NestedBracesDoNotFalseComplete) {
-  JsonBuffer b;
+TEST(MessageBuffer, StrayClosingBraceInPrefixIgnored) {
+  // Regression test (CodeRabbit on PR #71): an unmatched '}' in pre-message
+  // ACL-corruption garbage used to drive depth_ to -1, which then left the
+  // matching '}' of the real JSON object at -1 instead of 0. The message
+  // never tripped complete_ and was silently lost. Clamp at depth_ > 0
+  // keeps the scanner underflow-safe.
+  MessageBuffer b;
+  EXPECT_FALSE(feed_str(b, "}garbage"));
+  EXPECT_TRUE(feed_str(b, "{\"a\":1}"));
+  auto msg = b.take_message();
+  ASSERT_TRUE(msg.has_value());
+  EXPECT_EQ(*msg, "{\"a\":1}");
+}
+
+TEST(MessageBuffer, MultipleStrayClosingBracesInPrefixIgnored) {
+  // Same defect, but with several stray closes — verifies the clamp,
+  // not just a single-decrement guard.
+  MessageBuffer b;
+  EXPECT_FALSE(feed_str(b, "}}}corrupted"));
+  EXPECT_TRUE(feed_str(b, "{\"version\":{\"fw\":\"8.5\"}}"));
+  auto msg = b.take_message();
+  ASSERT_TRUE(msg.has_value());
+  EXPECT_EQ(*msg, "{\"version\":{\"fw\":\"8.5\"}}");
+}
+
+TEST(MessageBuffer, NestedBracesDoNotFalseComplete) {
+  MessageBuffer b;
   // Depth 2 reached by nested object; only the outer `}` brings it to 0.
   EXPECT_FALSE(feed_str(b, "{\"version\":{\"fw\":\"8.5\"}"));
   EXPECT_FALSE(b.complete());
@@ -131,12 +156,12 @@ TEST(JsonBuffer, NestedBracesDoNotFalseComplete) {
   EXPECT_TRUE(b.complete());
 }
 
-TEST(JsonBuffer, StickyCompleteThroughTrailingBytes) {
+TEST(MessageBuffer, StickyCompleteThroughTrailingBytes) {
   // Once complete, subsequent feeds accumulate bytes (next message) but
   // complete_ stays true until take_message()/clear(). The notify lambda
   // calls take_message() promptly so trailing bytes for the next response
   // don't accumulate in practice — but verify the sticky property.
-  JsonBuffer b;
+  MessageBuffer b;
   EXPECT_TRUE(feed_str(b, "{\"a\":1}"));
   EXPECT_TRUE(feed_str(b, "extra"));  // doesn't affect completion
   EXPECT_TRUE(b.complete());
@@ -145,14 +170,14 @@ TEST(JsonBuffer, StickyCompleteThroughTrailingBytes) {
   EXPECT_EQ(*msg, "{\"a\":1}extra");
 }
 
-TEST(JsonBuffer, RealWorldFridgePollResponse) {
+TEST(MessageBuffer, RealWorldFridgePollResponse) {
   // Approximate a fragmented Sub-Zero poll response — small fragments
   // similar to default-MTU ACL chunks (~20-40 bytes).
   static const char *kFull =
       "{\"status\":0,\"resp\":{\"appliance_model\":\"BI36UFDID\",\"uptime\":\"1d2h\","
       "\"version\":{\"fw\":\"2.27\",\"api\":\"4.0\"},\"ref_set_temp\":38,\"frz_set_temp\":-2,"
       "\"door_ajar\":false,\"frz_door_ajar\":false}}";
-  JsonBuffer b;
+  MessageBuffer b;
   size_t total = std::strlen(kFull);
   size_t off = 0;
   while (off < total) {

--- a/tests/cpp/buffer_test.cpp
+++ b/tests/cpp/buffer_test.cpp
@@ -1,0 +1,171 @@
+#include "buffer.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+using esphome::subzero_protocol::JsonBuffer;
+
+namespace {
+
+// Convenience: feed a string literal as bytes.
+bool feed_str(JsonBuffer &b, const char *s) {
+  return b.feed(reinterpret_cast<const std::uint8_t *>(s), std::strlen(s));
+}
+
+}  // namespace
+
+TEST(JsonBuffer, EmptyByDefault) {
+  JsonBuffer b;
+  EXPECT_FALSE(b.complete());
+  EXPECT_EQ(b.size(), 0u);
+  EXPECT_FALSE(b.take_message().has_value());
+}
+
+TEST(JsonBuffer, SingleChunkComplete) {
+  JsonBuffer b;
+  EXPECT_TRUE(feed_str(b, "{\"a\":1}"));
+  EXPECT_TRUE(b.complete());
+  auto msg = b.take_message();
+  ASSERT_TRUE(msg.has_value());
+  EXPECT_EQ(*msg, "{\"a\":1}");
+  EXPECT_FALSE(b.complete());
+  EXPECT_EQ(b.size(), 0u);
+}
+
+TEST(JsonBuffer, FragmentedDelivery) {
+  JsonBuffer b;
+  EXPECT_FALSE(feed_str(b, "{\"a"));
+  EXPECT_FALSE(feed_str(b, "\":1,"));
+  EXPECT_FALSE(feed_str(b, "\"b\":{\"c\":2}"));  // nested {}: depth back to 1
+  EXPECT_FALSE(b.complete());
+  EXPECT_TRUE(feed_str(b, "}"));
+  ASSERT_TRUE(b.complete());
+  auto msg = b.take_message();
+  ASSERT_TRUE(msg.has_value());
+  EXPECT_EQ(*msg, "{\"a\":1,\"b\":{\"c\":2}}");
+}
+
+TEST(JsonBuffer, SingleByteAtATime) {
+  JsonBuffer b;
+  const char *s = "{\"x\":[1,2,3]}";
+  for (size_t i = 0; i < std::strlen(s) - 1; i++) {
+    auto ch = static_cast<std::uint8_t>(s[i]);
+    EXPECT_FALSE(b.feed(&ch, 1)) << "completed early at i=" << i;
+  }
+  auto last = static_cast<std::uint8_t>(s[std::strlen(s) - 1]);
+  EXPECT_TRUE(b.feed(&last, 1));
+  EXPECT_EQ(*b.take_message(), s);
+}
+
+TEST(JsonBuffer, GarbagePrefixTrimmedOnTake) {
+  // ACL corruption can deliver bytes before the JSON starts.
+  // take_message() returns the substring from the first '{'.
+  JsonBuffer b;
+  EXPECT_TRUE(feed_str(b, "\x01\x02garbage{\"a\":1}"));
+  auto msg = b.take_message();
+  ASSERT_TRUE(msg.has_value());
+  EXPECT_EQ(*msg, "{\"a\":1}");
+}
+
+TEST(JsonBuffer, OverCapacityResetsOnNextFeed) {
+  // Wedged session: many fragments arrive without a closing `}`.
+  // Once the buffer exceeds kMaxBytes, the NEXT feed clears it before
+  // appending new bytes — preempts unbounded growth.
+  JsonBuffer b;
+  std::string huge(JsonBuffer::kMaxBytes + 100, 'x');
+  // Prepend a `{` so depth goes to 1 (not complete).
+  std::string bytes = "{" + huge;
+  EXPECT_FALSE(b.feed(reinterpret_cast<const std::uint8_t *>(bytes.data()), bytes.size()));
+  EXPECT_GT(b.size(), JsonBuffer::kMaxBytes);
+
+  // Next feed: pre-emptive reset, then append the new fragment.
+  EXPECT_TRUE(feed_str(b, "{\"a\":1}"));
+  auto msg = b.take_message();
+  ASSERT_TRUE(msg.has_value());
+  EXPECT_EQ(*msg, "{\"a\":1}");
+}
+
+TEST(JsonBuffer, ClearResetsState) {
+  JsonBuffer b;
+  feed_str(b, "{");
+  b.clear();
+  EXPECT_EQ(b.size(), 0u);
+  EXPECT_FALSE(b.complete());
+  // After clear, the next feed starts fresh (depth was reset).
+  EXPECT_TRUE(feed_str(b, "{\"a\":1}"));
+}
+
+TEST(JsonBuffer, TakeWithoutCompleteReturnsNullopt) {
+  JsonBuffer b;
+  feed_str(b, "{\"a");
+  EXPECT_FALSE(b.complete());
+  EXPECT_FALSE(b.take_message().has_value());
+  // The buffer is preserved (not cleared) when take_message() finds
+  // nothing to take — caller should keep feeding.
+  EXPECT_GT(b.size(), 0u);
+}
+
+TEST(JsonBuffer, NoBraceClearsOnTake) {
+  JsonBuffer b;
+  // Force complete_ = true by feeding a balanced pair, but starting with
+  // garbage that has no `{`. There's no realistic path where complete_
+  // is true with no `{`, so we just exercise the defensive branch by
+  // feeding a complete message and taking.
+  feed_str(b, "{\"a\":1}");
+  EXPECT_TRUE(b.complete());
+  auto msg = b.take_message();
+  EXPECT_TRUE(msg.has_value());
+  EXPECT_EQ(b.size(), 0u);
+}
+
+TEST(JsonBuffer, NestedBracesDoNotFalseComplete) {
+  JsonBuffer b;
+  // Depth 2 reached by nested object; only the outer `}` brings it to 0.
+  EXPECT_FALSE(feed_str(b, "{\"version\":{\"fw\":\"8.5\"}"));
+  EXPECT_FALSE(b.complete());
+  EXPECT_TRUE(feed_str(b, "}"));
+  EXPECT_TRUE(b.complete());
+}
+
+TEST(JsonBuffer, StickyCompleteThroughTrailingBytes) {
+  // Once complete, subsequent feeds accumulate bytes (next message) but
+  // complete_ stays true until take_message()/clear(). The notify lambda
+  // calls take_message() promptly so trailing bytes for the next response
+  // don't accumulate in practice — but verify the sticky property.
+  JsonBuffer b;
+  EXPECT_TRUE(feed_str(b, "{\"a\":1}"));
+  EXPECT_TRUE(feed_str(b, "extra"));  // doesn't affect completion
+  EXPECT_TRUE(b.complete());
+  auto msg = b.take_message();
+  ASSERT_TRUE(msg.has_value());
+  EXPECT_EQ(*msg, "{\"a\":1}extra");
+}
+
+TEST(JsonBuffer, RealWorldFridgePollResponse) {
+  // Approximate a fragmented Sub-Zero poll response — small fragments
+  // similar to default-MTU ACL chunks (~20-40 bytes).
+  static const char *kFull =
+      "{\"status\":0,\"resp\":{\"appliance_model\":\"BI36UFDID\",\"uptime\":\"1d2h\","
+      "\"version\":{\"fw\":\"2.27\",\"api\":\"4.0\"},\"ref_set_temp\":38,\"frz_set_temp\":-2,"
+      "\"door_ajar\":false,\"frz_door_ajar\":false}}";
+  JsonBuffer b;
+  size_t total = std::strlen(kFull);
+  size_t off = 0;
+  while (off < total) {
+    size_t n = std::min<size_t>(20, total - off);
+    bool done = b.feed(reinterpret_cast<const std::uint8_t *>(kFull + off), n);
+    off += n;
+    if (off < total) {
+      EXPECT_FALSE(done) << "early completion at off=" << off;
+    } else {
+      EXPECT_TRUE(done);
+    }
+  }
+  auto msg = b.take_message();
+  ASSERT_TRUE(msg.has_value());
+  EXPECT_EQ(*msg, kFull);
+}

--- a/tests/cpp/poll_state_test.cpp
+++ b/tests/cpp/poll_state_test.cpp
@@ -1,0 +1,189 @@
+#include "poll_state.h"
+#include "protocol.h"
+
+#include <gtest/gtest.h>
+
+using esphome::subzero_protocol::apply_parse_result;
+using esphome::subzero_protocol::DishwasherState;
+using esphome::subzero_protocol::FridgeState;
+using esphome::subzero_protocol::RangeState;
+
+namespace {
+
+FridgeState make_poll(const char *fw = nullptr) {
+  FridgeState s;
+  s.valid = true;
+  s.is_poll = true;
+  if (fw) {
+    s.common.version.fw = std::string(fw);
+  }
+  return s;
+}
+
+FridgeState make_push() {
+  FridgeState s;
+  s.valid = true;
+  s.is_poll = false;
+  return s;
+}
+
+}  // namespace
+
+TEST(PollState, PollClearsCounters) {
+  bool poll_in_flight = true;
+  int unanswered_polls = 2;
+  bool first_poll_done = false;
+  bool fw_85_detected = false;
+  int fast_retries = 1;
+
+  apply_parse_result(poll_in_flight, unanswered_polls, first_poll_done,
+                     fw_85_detected, fast_retries, make_poll());
+
+  EXPECT_FALSE(poll_in_flight);
+  EXPECT_EQ(unanswered_polls, 0);
+  EXPECT_TRUE(first_poll_done);
+  EXPECT_FALSE(fw_85_detected);  // no fw in payload
+  EXPECT_EQ(fast_retries, 0);
+}
+
+TEST(PollState, PushDoesNotClearPollInFlight) {
+  // CRITICAL: pushes prove the connection is alive but NOT the command
+  // channel. Clearing poll_in_flight on a push would defeat the unlock-
+  // expiry detector for fw 8.5 appliances. See poll_state.h invariant 1.
+  bool poll_in_flight = true;
+  int unanswered_polls = 2;
+  bool first_poll_done = false;
+  bool fw_85_detected = false;
+  int fast_retries = 3;
+
+  apply_parse_result(poll_in_flight, unanswered_polls, first_poll_done,
+                     fw_85_detected, fast_retries, make_push());
+
+  EXPECT_TRUE(poll_in_flight);                      // unchanged
+  EXPECT_EQ(unanswered_polls, 2);                   // unchanged
+  EXPECT_FALSE(first_poll_done);                    // unchanged
+  EXPECT_FALSE(fw_85_detected);                     // unchanged
+  EXPECT_EQ(fast_retries, 0);                       // RESET on any valid parse
+}
+
+TEST(PollState, Fw85StickyOnPoll) {
+  bool poll_in_flight = false;
+  int unanswered_polls = 0;
+  bool first_poll_done = false;
+  bool fw_85_detected = false;
+  int fast_retries = 0;
+
+  apply_parse_result(poll_in_flight, unanswered_polls, first_poll_done,
+                     fw_85_detected, fast_retries, make_poll("8.5"));
+  EXPECT_TRUE(fw_85_detected);
+
+  // Subsequent poll without fw field doesn't clear the sticky flag.
+  apply_parse_result(poll_in_flight, unanswered_polls, first_poll_done,
+                     fw_85_detected, fast_retries, make_poll());
+  EXPECT_TRUE(fw_85_detected);
+}
+
+TEST(PollState, Fw227NotDetected) {
+  bool poll_in_flight = false;
+  int unanswered_polls = 0;
+  bool first_poll_done = false;
+  bool fw_85_detected = false;
+  int fast_retries = 0;
+
+  apply_parse_result(poll_in_flight, unanswered_polls, first_poll_done,
+                     fw_85_detected, fast_retries, make_poll("2.27"));
+  EXPECT_FALSE(fw_85_detected);
+}
+
+TEST(PollState, Fw85PushIgnored) {
+  // version.fw on a push notification (rare but possible) does NOT set
+  // fw_85_detected — only is_poll responses count, because push payloads
+  // don't carry the full version object reliably.
+  FridgeState s = make_push();
+  s.common.version.fw = std::string("8.5");
+
+  bool poll_in_flight = false;
+  int unanswered_polls = 0;
+  bool first_poll_done = false;
+  bool fw_85_detected = false;
+  int fast_retries = 0;
+
+  apply_parse_result(poll_in_flight, unanswered_polls, first_poll_done,
+                     fw_85_detected, fast_retries, s);
+  EXPECT_FALSE(fw_85_detected);
+  EXPECT_FALSE(first_poll_done);
+}
+
+TEST(PollState, FastRetriesResetOnEveryValidParse) {
+  bool poll_in_flight = true;
+  int unanswered_polls = 1;
+  bool first_poll_done = false;
+  bool fw_85_detected = false;
+  int fast_retries = 5;
+
+  // Push: fast_retries still resets.
+  apply_parse_result(poll_in_flight, unanswered_polls, first_poll_done,
+                     fw_85_detected, fast_retries, make_push());
+  EXPECT_EQ(fast_retries, 0);
+
+  // Re-set, then poll.
+  fast_retries = 7;
+  apply_parse_result(poll_in_flight, unanswered_polls, first_poll_done,
+                     fw_85_detected, fast_retries, make_poll());
+  EXPECT_EQ(fast_retries, 0);
+}
+
+TEST(PollState, WorksForDishwasherState) {
+  DishwasherState s;
+  s.valid = true;
+  s.is_poll = true;
+  s.common.version.fw = std::string("8.5");
+
+  bool poll_in_flight = true;
+  int unanswered_polls = 0;
+  bool first_poll_done = false;
+  bool fw_85_detected = false;
+  int fast_retries = 0;
+
+  apply_parse_result(poll_in_flight, unanswered_polls, first_poll_done,
+                     fw_85_detected, fast_retries, s);
+  EXPECT_FALSE(poll_in_flight);
+  EXPECT_TRUE(first_poll_done);
+  EXPECT_TRUE(fw_85_detected);
+}
+
+TEST(PollState, WorksForRangeState) {
+  RangeState s;
+  s.valid = true;
+  s.is_poll = false;  // push
+  s.common.version.fw = std::string("8.5");
+
+  bool poll_in_flight = true;
+  int unanswered_polls = 1;
+  bool first_poll_done = false;
+  bool fw_85_detected = false;
+  int fast_retries = 4;
+
+  apply_parse_result(poll_in_flight, unanswered_polls, first_poll_done,
+                     fw_85_detected, fast_retries, s);
+  EXPECT_TRUE(poll_in_flight);    // push: unchanged
+  EXPECT_FALSE(fw_85_detected);   // push: not sticky-set
+  EXPECT_EQ(fast_retries, 0);     // any valid parse resets
+}
+
+TEST(PollState, FirstPollDoneOneShot) {
+  bool poll_in_flight = false;
+  int unanswered_polls = 0;
+  bool first_poll_done = false;
+  bool fw_85_detected = false;
+  int fast_retries = 0;
+
+  apply_parse_result(poll_in_flight, unanswered_polls, first_poll_done,
+                     fw_85_detected, fast_retries, make_poll());
+  EXPECT_TRUE(first_poll_done);
+
+  // Subsequent push doesn't unset it (first_poll_done is sticky-true).
+  apply_parse_result(poll_in_flight, unanswered_polls, first_poll_done,
+                     fw_85_detected, fast_retries, make_push());
+  EXPECT_TRUE(first_poll_done);
+}

--- a/tests/cpp/sanitize_test.cpp
+++ b/tests/cpp/sanitize_test.cpp
@@ -1,0 +1,161 @@
+#include "log_sanitize.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+using esphome::subzero_protocol::chunk_for_log;
+using esphome::subzero_protocol::sanitize_for_log;
+
+TEST(Sanitize, AsciiPassthrough) {
+  std::string s = "hello world";
+  EXPECT_EQ(sanitize_for_log(s, 0, s.size()), s);
+}
+
+TEST(Sanitize, HighBitBecomesQuestionMark) {
+  std::string s;
+  s.push_back(0x80);
+  s.push_back('a');
+  s.push_back(static_cast<char>(0xFF));
+  s.push_back('b');
+  EXPECT_EQ(sanitize_for_log(s, 0, s.size()), "?a?b");
+}
+
+TEST(Sanitize, EmbeddedNullBecomesQuestionMark) {
+  std::string s = std::string("a\0b", 3);
+  EXPECT_EQ(sanitize_for_log(s, 0, s.size()), "a?b");
+}
+
+TEST(Sanitize, WhitespaceAllowed) {
+  std::string s = "line1\nline2\rcol\twidth";
+  EXPECT_EQ(sanitize_for_log(s, 0, s.size()), s);
+}
+
+TEST(Sanitize, ControlCharsBecomeQuestionMark) {
+  std::string s;
+  s.push_back(0x01);  // SOH
+  s.push_back('a');
+  s.push_back(0x1F);  // US (just below 0x20)
+  s.push_back(0x7F);  // DEL (just above 0x7E)
+  EXPECT_EQ(sanitize_for_log(s, 0, s.size()), "?a??");
+}
+
+TEST(Sanitize, OffsetAndLengthRespected) {
+  std::string s = "abcdefghij";
+  EXPECT_EQ(sanitize_for_log(s, 2, 4), "cdef");
+  EXPECT_EQ(sanitize_for_log(s, 0, 3), "abc");
+  EXPECT_EQ(sanitize_for_log(s, 8, 2), "ij");
+}
+
+TEST(Sanitize, LengthClampedToBuffer) {
+  std::string s = "abc";
+  EXPECT_EQ(sanitize_for_log(s, 1, 100), "bc");
+  EXPECT_EQ(sanitize_for_log(s, 0, 100), "abc");
+}
+
+TEST(Sanitize, OffsetPastEndReturnsEmpty) {
+  std::string s = "abc";
+  EXPECT_EQ(sanitize_for_log(s, 5, 10), "");
+  EXPECT_EQ(sanitize_for_log(s, 3, 1), "");
+}
+
+TEST(Sanitize, EmptyInput) {
+  EXPECT_EQ(sanitize_for_log("", 0, 0), "");
+  EXPECT_EQ(sanitize_for_log("", 0, 100), "");
+}
+
+TEST(Sanitize, NewlineKeptForJsonTerminator) {
+  // The Sub-Zero protocol terminates every response with \n. Keeping it
+  // unsanitized means a real corruption byte stands out as '?'.
+  std::string s = "{\"a\":1}\n";
+  EXPECT_EQ(sanitize_for_log(s, 0, s.size()), s);
+}
+
+namespace {
+
+struct Recorded {
+  std::size_t idx;
+  std::size_t total;
+  std::string chunk;
+};
+
+}  // namespace
+
+TEST(ChunkForLog, SingleChunkBelowSize) {
+  std::vector<Recorded> calls;
+  std::string msg = "small";
+  chunk_for_log(msg,
+                [&](std::size_t i, std::size_t t, const std::string &c) {
+                  calls.push_back({i, t, c});
+                });
+  ASSERT_EQ(calls.size(), 1u);
+  EXPECT_EQ(calls[0].idx, 1u);
+  EXPECT_EQ(calls[0].total, 1u);
+  EXPECT_EQ(calls[0].chunk, "small");
+}
+
+TEST(ChunkForLog, ExactBoundary) {
+  std::vector<Recorded> calls;
+  std::string msg(800, 'x');  // exactly 2 chunks at 400
+  chunk_for_log(msg,
+                [&](std::size_t i, std::size_t t, const std::string &c) {
+                  calls.push_back({i, t, c});
+                });
+  ASSERT_EQ(calls.size(), 2u);
+  EXPECT_EQ(calls[0].idx, 1u);
+  EXPECT_EQ(calls[0].total, 2u);
+  EXPECT_EQ(calls[0].chunk.size(), 400u);
+  EXPECT_EQ(calls[1].idx, 2u);
+  EXPECT_EQ(calls[1].total, 2u);
+  EXPECT_EQ(calls[1].chunk.size(), 400u);
+}
+
+TEST(ChunkForLog, TrailingPartial) {
+  std::vector<Recorded> calls;
+  std::string msg(950, 'x');  // 2.375 chunks → 3 chunks (400, 400, 150)
+  chunk_for_log(msg,
+                [&](std::size_t i, std::size_t t, const std::string &c) {
+                  calls.push_back({i, t, c});
+                });
+  ASSERT_EQ(calls.size(), 3u);
+  EXPECT_EQ(calls[0].chunk.size(), 400u);
+  EXPECT_EQ(calls[1].chunk.size(), 400u);
+  EXPECT_EQ(calls[2].chunk.size(), 150u);
+  EXPECT_EQ(calls[2].total, 3u);
+}
+
+TEST(ChunkForLog, EmptyMessageNoCalls) {
+  int calls = 0;
+  chunk_for_log("", [&](std::size_t, std::size_t, const std::string &) { calls++; });
+  EXPECT_EQ(calls, 0);
+}
+
+TEST(ChunkForLog, SanitizesEachChunk) {
+  // High-bit bytes anywhere in the message become '?' in the chunk
+  // delivered to the callback.
+  std::string msg = std::string(400, 'a');
+  msg.push_back(static_cast<char>(0xFF));
+  msg.append(std::string(50, 'b'));
+  std::vector<Recorded> calls;
+  chunk_for_log(msg,
+                [&](std::size_t i, std::size_t t, const std::string &c) {
+                  calls.push_back({i, t, c});
+                });
+  ASSERT_EQ(calls.size(), 2u);
+  EXPECT_EQ(calls[0].chunk, std::string(400, 'a'));
+  EXPECT_EQ(calls[1].chunk, "?" + std::string(50, 'b'));
+}
+
+TEST(ChunkForLog, CustomChunkSize) {
+  std::vector<Recorded> calls;
+  chunk_for_log("abcdef",
+                [&](std::size_t i, std::size_t t, const std::string &c) {
+                  calls.push_back({i, t, c});
+                },
+                2);
+  ASSERT_EQ(calls.size(), 3u);
+  EXPECT_EQ(calls[0].chunk, "ab");
+  EXPECT_EQ(calls[1].chunk, "cd");
+  EXPECT_EQ(calls[2].chunk, "ef");
+}


### PR DESCRIPTION
## Summary

Phase 1 of moving embedded C++ out of YAML so the integration's hot path becomes unit-testable. State machine, scripts, and per-sensor dispatch stay in YAML this PR — they just call into the new helpers for the duplicated boilerplate.

**New testable helpers** (`components/subzero_protocol/`):

- **`JsonBuffer`** (buffer.h/.cpp): replaces the 15-line append + brace-depth scan duplicated across the D5 notify lambda in `subzero_base.yaml` and the D4 notify lambda in `subzero_fridge.yaml`. Naive depth counting, matching v0.21.0 behavior — the cleverer ACL-corruption detector was reverted in #61. `take_message()` also performs the leading-garbage trim that previously lived at the top of every `parse_json` script.
- **`sanitize_for_log()` + `chunk_for_log()`** (log_sanitize.h/.cpp): the ~10-line lambda + 10-line chunk loop duplicated in all three appliance `parse_json` scripts. ESP_LOGI calls stay at the call sites via a stateless callback, so the helpers are pure and host-testable.
- **`apply_parse_result()`** (poll_state.h): the post-parse state mutation block, identical across all three appliance files. Encodes the invariants in one place: only `is_poll` responses clear `poll_in_flight` / `unanswered_polls` / `first_poll_done`; `fw_85_detected` is sticky and poll-only; `fast_retries` resets on any valid parse.

**Test wins:** 37 new gtest cases (74 total, all green) cover fragmented BLE delivery, single-byte feeds, garbage-prefix trim, capacity overflow recovery, nested braces, and explicitly the "push must NOT clear `poll_in_flight`" invariant that the fw 8.5 unlock-expiry recovery depends on.

**YAML changes:** ~220 net lines removed. The `${prefix}_json_buf` global type changes from `std::string` to `esphome::subzero_protocol::JsonBuffer` (same `.clear()` method, so on_disconnect / reset / connect handlers are unchanged). All other state-machine globals, scripts, buttons, and per-sensor dispatch are untouched.

**Future phases (separate PRs):**
- Phase 2: sensor-dispatch extraction
- Phase 3: state-machine class + mock BLE transport
- Phase 4: native `subzero_appliance:` config schema replacing the package YAMLs

## Test plan

Host-side already verified:
- [x] `cd tests/cpp/build && ctest` — 74/74 passed
- [x] `esphome config` — all 6 entry-point YAMLs valid
- [x] `esphome compile` — `wolf-minimal-fridge`, `cove-minimal-dishwasher`, `wolf-minimal-range` all build to firmware

On-device verification needed before merge:
- [ ] Flash a fridge (`scripts/basement.sh` or similar) and confirm normal poll cycle in logs (`Response[N/M]` chunks visible with debug switch on).
- [ ] Flash a dishwasher and confirm wash cycle data publishes; verify push notifications (light toggle, door open) still work.
- [ ] Flash a range and confirm dual-oven and timer text sensors update; trigger the kitchen timer to see push-driven state changes.
- [ ] Force a reconnect (toggle airplane on appliance or pull power briefly); confirm fast-reconnect path works (cached handles, no full discovery).
- [ ] On a fw 8.5 appliance: confirm push-only auto-detection still kicks in after the first poll response. (Watch for the `fw_85_detected` global to flip.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved JSON message buffering to reliably handle fragmented data streams from connected devices.
  * Enhanced logging utilities with automatic output sanitization for safer debug output.

* **Tests**
  * Added comprehensive unit tests for message buffering, log output sanitization, and state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->