### PR TITLE
refactor: extract command builders, GATT handle parsing, sensor dispatch (phase 2)

### DIFF
--- a/components/subzero_protocol/buffer.h
+++ b/components/subzero_protocol/buffer.h
@@ -30,7 +30,7 @@ namespace esphome {
 namespace subzero_protocol {
 
 class MessageBuffer {
- public:
+public:
   // Reserve hint matches the prior YAML behavior. Initial reserve avoids
   // repeated reallocs across the ~50 fragments of a typical poll response.
   static constexpr std::size_t kReserveHint = 2048;
@@ -114,11 +114,11 @@ class MessageBuffer {
   std::size_t size() const { return buf_.size(); }
   bool complete() const { return complete_; }
 
- private:
+private:
   std::string buf_;
   int depth_ = 0;
   bool complete_ = false;
 };
 
-}  // namespace subzero_protocol
-}  // namespace esphome
+} // namespace subzero_protocol
+} // namespace esphome

--- a/components/subzero_protocol/commands.h
+++ b/components/subzero_protocol/commands.h
@@ -37,28 +37,42 @@ inline std::string escape_json_string(const std::string &s) {
   for (char c : s) {
     unsigned char u = static_cast<unsigned char>(c);
     switch (c) {
-      case '"':  out += "\\\""; break;
-      case '\\': out += "\\\\"; break;
-      case '\b': out += "\\b"; break;
-      case '\f': out += "\\f"; break;
-      case '\n': out += "\\n"; break;
-      case '\r': out += "\\r"; break;
-      case '\t': out += "\\t"; break;
-      default:
-        if (u < 0x20) {
-          char buf[8];
-          std::snprintf(buf, sizeof(buf), "\\u%04X", u);
-          out += buf;
-        } else {
-          out.push_back(c);
-        }
-        break;
+    case '"':
+      out += "\\\"";
+      break;
+    case '\\':
+      out += "\\\\";
+      break;
+    case '\b':
+      out += "\\b";
+      break;
+    case '\f':
+      out += "\\f";
+      break;
+    case '\n':
+      out += "\\n";
+      break;
+    case '\r':
+      out += "\\r";
+      break;
+    case '\t':
+      out += "\\t";
+      break;
+    default:
+      if (u < 0x20) {
+        char buf[8];
+        std::snprintf(buf, sizeof(buf), "\\u%04X", u);
+        out += buf;
+      } else {
+        out.push_back(c);
+      }
+      break;
     }
   }
   return out;
 }
 
-}  // namespace detail
+} // namespace detail
 
 // `unlock_channel` opens the encrypted command/data channel after bonding
 // using the appliance's currently-displayed PIN. Sent on D5 (control)
@@ -76,9 +90,7 @@ inline std::string build_unlock_channel(const std::string &pin) {
 
 // `get_async` requests a full state dump on the channel it's written to.
 // Used on D6 only post-PR-#72 — D5 returns nothing for get_async.
-inline std::string build_get_async() {
-  return "{\"cmd\":\"get_async\"}\n";
-}
+inline std::string build_get_async() { return "{\"cmd\":\"get_async\"}\n"; }
 
 // `display_pin` makes the appliance show its random pairing PIN on its
 // front-panel display for the requested duration (seconds). Sent on D5
@@ -88,5 +100,5 @@ inline std::string build_display_pin(int duration_seconds = 30) {
          std::to_string(duration_seconds) + "}}\n";
 }
 
-}  // namespace subzero_protocol
-}  // namespace esphome
+} // namespace subzero_protocol
+} // namespace esphome

--- a/components/subzero_protocol/commands.h
+++ b/components/subzero_protocol/commands.h
@@ -1,0 +1,42 @@
+#pragma once
+
+// JSON command builders for the Sub-Zero BLE protocol.
+//
+// All commands are written to the appliance's D5 (control) or D6 (data)
+// characteristic and MUST be terminated with '\n' — the appliance's serial
+// parser only emits a response once the newline arrives.
+//
+// Pure string functions, host-testable. Existing call sites in the YAML
+// scripts inline these literals; centralizing them makes the protocol
+// vocabulary explicit and gives Phase 3's eventual BleTransport a single
+// source of truth for what bytes go on the wire.
+
+#include <string>
+
+namespace esphome {
+namespace subzero_protocol {
+
+// `unlock_channel` opens the encrypted command/data channel after bonding
+// using the appliance's currently-displayed PIN. Sent on D5 (control)
+// during initial subscribe and on D6 (data) before every periodic poll
+// — D6's session expires independently of the BLE link.
+inline std::string build_unlock_channel(const std::string &pin) {
+  return "{\"cmd\":\"unlock_channel\",\"params\":{\"pin\":\"" + pin + "\"}}\n";
+}
+
+// `get_async` requests a full state dump on the channel it's written to.
+// Used on D6 only post-PR-#72 — D5 returns nothing for get_async.
+inline std::string build_get_async() {
+  return "{\"cmd\":\"get_async\"}\n";
+}
+
+// `display_pin` makes the appliance show its random pairing PIN on its
+// front-panel display for the requested duration (seconds). Sent on D5
+// before the user enters that PIN into HA.
+inline std::string build_display_pin(int duration_seconds = 30) {
+  return "{\"cmd\":\"display_pin\",\"params\":{\"duration\": " +
+         std::to_string(duration_seconds) + "}}\n";
+}
+
+}  // namespace subzero_protocol
+}  // namespace esphome

--- a/components/subzero_protocol/commands.h
+++ b/components/subzero_protocol/commands.h
@@ -11,17 +11,67 @@
 // vocabulary explicit and gives Phase 3's eventual BleTransport a single
 // source of truth for what bytes go on the wire.
 
+#include <cstdio>
 #include <string>
 
 namespace esphome {
 namespace subzero_protocol {
 
+namespace detail {
+
+// JSON-escape a string for safe embedding inside a `"..."` literal.
+// Real Sub-Zero PINs are 4-5 digit numeric, but the HA text input that
+// stores the PIN is `mode: text` and accepts arbitrary chars — a user
+// could paste a string containing a quote or backslash, which would
+// silently corrupt the unlock_channel payload and either drop the
+// command on the floor or, worse, confuse the appliance's serial parser.
+//
+// Handles the spec-required escapes (RFC 8259 §7): backslash, quote,
+// and the named C0 controls (\b \f \n \r \t). Other control bytes
+// (0x00..0x1F) become `\u00XX`. Higher-bit bytes are passed through
+// unmodified — the protocol is ASCII in practice and we don't want to
+// re-encode arbitrary UTF-8.
+inline std::string escape_json_string(const std::string &s) {
+  std::string out;
+  out.reserve(s.size() + 2);
+  for (char c : s) {
+    unsigned char u = static_cast<unsigned char>(c);
+    switch (c) {
+      case '"':  out += "\\\""; break;
+      case '\\': out += "\\\\"; break;
+      case '\b': out += "\\b"; break;
+      case '\f': out += "\\f"; break;
+      case '\n': out += "\\n"; break;
+      case '\r': out += "\\r"; break;
+      case '\t': out += "\\t"; break;
+      default:
+        if (u < 0x20) {
+          char buf[8];
+          std::snprintf(buf, sizeof(buf), "\\u%04X", u);
+          out += buf;
+        } else {
+          out.push_back(c);
+        }
+        break;
+    }
+  }
+  return out;
+}
+
+}  // namespace detail
+
 // `unlock_channel` opens the encrypted command/data channel after bonding
 // using the appliance's currently-displayed PIN. Sent on D5 (control)
 // during initial subscribe and on D6 (data) before every periodic poll
 // — D6's session expires independently of the BLE link.
+//
+// PIN is JSON-escaped before embedding (CodeRabbit on PR #73). Sub-Zero
+// PINs are numeric in practice, but the HA text input stores arbitrary
+// strings and we want a malformed PIN to produce well-formed JSON rather
+// than a corrupted wire payload.
 inline std::string build_unlock_channel(const std::string &pin) {
-  return "{\"cmd\":\"unlock_channel\",\"params\":{\"pin\":\"" + pin + "\"}}\n";
+  return "{\"cmd\":\"unlock_channel\",\"params\":{\"pin\":\"" +
+         detail::escape_json_string(pin) + "\"}}\n";
 }
 
 // `get_async` requests a full state dump on the channel it's written to.

--- a/components/subzero_protocol/dispatch.h
+++ b/components/subzero_protocol/dispatch.h
@@ -1,0 +1,148 @@
+#pragma once
+
+// Sensor dispatch helpers — convert a parsed appliance state struct into a
+// sequence of named publish calls on a "bus". Templated on Bus so production
+// (ESPHome sensor pointers, see dispatch_esphome.h) and tests (a recording
+// bus that captures method calls, see dispatch_test.cpp) share the same
+// pure-logic dispatcher.
+//
+// Bus method-name convention: `publish_<entity_id_suffix>(value)`, where
+// `<entity_id_suffix>` is the YAML id without the `${prefix}_` prefix
+// (e.g. `${prefix}_set_temp` → `publish_set_temp`). The dispatch functions
+// here are the single source of truth for the parser-field → entity-id
+// mapping; production buses MUST provide every method this header calls,
+// or the on-device build won't link.
+//
+// PIN confirmation, status-302 detection, and post-parse global-state
+// mutation (poll_ok, fast_retries) intentionally remain in YAML — they
+// touch ESPHome globals + scripts that aren't worth threading through a
+// host-buildable abstraction.
+
+#include "protocol.h"
+
+namespace esphome {
+namespace subzero_protocol {
+
+// Dispatches every CommonFields entry to its corresponding bus method.
+// Called by each appliance dispatcher; production buses inherit a
+// CommonBus base struct that provides these methods (see
+// dispatch_esphome.h).
+template <typename Bus>
+inline void dispatch_common(const CommonFields &c, Bus &bus) {
+  if (c.sabbath_on) bus.publish_sabbath_on(*c.sabbath_on);
+  if (c.service_required) bus.publish_svc_required(*c.service_required);
+  if (c.appliance_model) bus.publish_model(*c.appliance_model);
+  if (c.uptime) bus.publish_uptime(*c.uptime);
+  if (c.appliance_serial) bus.publish_serial(*c.appliance_serial);
+  if (c.appliance_type) bus.publish_appliance_type(*c.appliance_type);
+  if (c.diagnostic_status) bus.publish_diag_status(*c.diagnostic_status);
+  if (c.build_date) bus.publish_build_date(*c.build_date);
+  if (c.version.fw) bus.publish_fw_version(*c.version.fw);
+  if (c.version.api) bus.publish_api_version(*c.version.api);
+  if (c.version.bleapp) bus.publish_bleapp_version(*c.version.bleapp);
+  if (c.version.os) bus.publish_os_version(*c.version.os);
+  if (c.version.rtapp) bus.publish_rtapp_version(*c.version.rtapp);
+  if (c.version.appliance) bus.publish_board_version(*c.version.appliance);
+}
+
+template <typename Bus>
+inline void dispatch_fridge(const FridgeState &s, Bus &bus) {
+  dispatch_common(s.common, bus);
+  // Fridge / Freezer
+  if (s.ref_set_temp) bus.publish_set_temp(*s.ref_set_temp);
+  if (s.door_ajar) bus.publish_door_ajar(*s.door_ajar);
+  if (s.frz_set_temp) bus.publish_frz_set_temp(*s.frz_set_temp);
+  if (s.frz_door_ajar) bus.publish_frz_door_ajar(*s.frz_door_ajar);
+  if (s.ice_maker_on) bus.publish_ice_maker(*s.ice_maker_on);
+  // Refrigerator drawer
+  if (s.ref2_set_temp) bus.publish_ref2_set_temp(*s.ref2_set_temp);
+  if (s.ref2_door_ajar) bus.publish_ref2_door_ajar(*s.ref2_door_ajar);
+  // Wine
+  if (s.wine_door_ajar) bus.publish_wine_door_ajar(*s.wine_door_ajar);
+  if (s.wine_set_temp) bus.publish_wine_set_temp(*s.wine_set_temp);
+  if (s.wine2_set_temp) bus.publish_wine2_set_temp(*s.wine2_set_temp);
+  if (s.wine_temp_alert_on) bus.publish_wine_temp_alert(*s.wine_temp_alert_on);
+  // Crisper
+  if (s.crisp_set_temp) bus.publish_crisp_set_temp(*s.crisp_set_temp);
+  // Filters
+  if (s.air_filter_on) bus.publish_air_filter_on(*s.air_filter_on);
+  if (s.air_filter_pct_remaining) bus.publish_air_filter_pct(*s.air_filter_pct_remaining);
+  if (s.water_filter_pct_remaining) bus.publish_water_filter_pct(*s.water_filter_pct_remaining);
+}
+
+template <typename Bus>
+inline void dispatch_dishwasher(const DishwasherState &s, Bus &bus) {
+  dispatch_common(s.common, bus);
+  if (s.door_ajar) bus.publish_door_ajar(*s.door_ajar);
+  if (s.wash_cycle_on) bus.publish_wash_cycle_on(*s.wash_cycle_on);
+  if (s.heated_dry_on) bus.publish_heated_dry(*s.heated_dry_on);
+  if (s.extended_dry_on) bus.publish_extended_dry(*s.extended_dry_on);
+  if (s.high_temp_wash_on) bus.publish_high_temp_wash(*s.high_temp_wash_on);
+  if (s.sani_rinse_on) bus.publish_sani_rinse(*s.sani_rinse_on);
+  if (s.rinse_aid_low) bus.publish_rinse_aid_low(*s.rinse_aid_low);
+  if (s.softener_low) bus.publish_softener_low(*s.softener_low);
+  if (s.light_on) bus.publish_light_on(*s.light_on);
+  if (s.remote_ready) bus.publish_remote_ready(*s.remote_ready);
+  if (s.delay_start_timer_active) bus.publish_delay_start(*s.delay_start_timer_active);
+  if (s.wash_status) bus.publish_wash_status(*s.wash_status);
+  if (s.wash_cycle) bus.publish_wash_cycle(*s.wash_cycle);
+  if (s.wash_cycle_end_time) bus.publish_wash_cycle_end_time(*s.wash_cycle_end_time);
+  if (s.wash_time_remaining_min) bus.publish_wash_time_remaining(*s.wash_time_remaining_min);
+  // Stateful: when wash_cycle_on flips false, force the remaining-time
+  // sensor to 0 (otherwise it sticks at the last computed minute count
+  // until the next wash cycle starts).
+  if (s.wash_cycle_on && !*s.wash_cycle_on) {
+    bus.clear_wash_time_remaining_if_running();
+  }
+}
+
+template <typename Bus>
+inline void dispatch_range(const RangeState &s, Bus &bus) {
+  dispatch_common(s.common, bus);
+  if (s.door_ajar) bus.publish_door_ajar(*s.door_ajar);
+  // Primary cavity
+  if (s.cav_unit_on) bus.publish_cav_unit_on(*s.cav_unit_on);
+  if (s.cav_at_set_temp) bus.publish_cav_at_set_temp(*s.cav_at_set_temp);
+  if (s.cav_light_on) bus.publish_cav_light_on(*s.cav_light_on);
+  if (s.cav_remote_ready) bus.publish_cav_remote_ready(*s.cav_remote_ready);
+  if (s.cav_probe_on) bus.publish_cav_probe_on(*s.cav_probe_on);
+  if (s.cav_probe_at_set_temp) bus.publish_cav_probe_at_temp(*s.cav_probe_at_set_temp);
+  if (s.cav_probe_within_10deg) bus.publish_cav_probe_near(*s.cav_probe_within_10deg);
+  if (s.cav_gourmet_mode_on) bus.publish_cav_gourmet(*s.cav_gourmet_mode_on);
+  if (s.cav_gourmet_recipe) bus.publish_cav_gourmet_recipe(*s.cav_gourmet_recipe);
+  if (s.cav_cook_timer_complete) bus.publish_cook_timer_done(*s.cav_cook_timer_complete);
+  if (s.cav_cook_timer_within_1min) bus.publish_cook_timer_near(*s.cav_cook_timer_within_1min);
+  if (s.cav_temp) bus.publish_cav_temp(*s.cav_temp);
+  if (s.cav_set_temp) bus.publish_cav_set_temp(*s.cav_set_temp);
+  if (s.cav_cook_mode) bus.publish_cav_cook_mode(*s.cav_cook_mode);
+  if (s.cav_probe_temp) bus.publish_probe_temp(*s.cav_probe_temp);
+  if (s.cav_probe_set_temp) bus.publish_probe_set_temp(*s.cav_probe_set_temp);
+  // Kitchen timers
+  if (s.kitchen_timer_active) bus.publish_ktimer_active(*s.kitchen_timer_active);
+  if (s.kitchen_timer_complete) bus.publish_ktimer_done(*s.kitchen_timer_complete);
+  if (s.kitchen_timer_within_1min) bus.publish_ktimer_near(*s.kitchen_timer_within_1min);
+  if (s.kitchen_timer_end_time) bus.publish_ktimer_end_time(*s.kitchen_timer_end_time);
+  if (s.kitchen_timer2_active) bus.publish_ktimer2_active(*s.kitchen_timer2_active);
+  if (s.kitchen_timer2_complete) bus.publish_ktimer2_done(*s.kitchen_timer2_complete);
+  if (s.kitchen_timer2_within_1min) bus.publish_ktimer2_near(*s.kitchen_timer2_within_1min);
+  if (s.kitchen_timer2_end_time) bus.publish_ktimer2_end_time(*s.kitchen_timer2_end_time);
+  // Secondary cavity (dual-oven ranges)
+  if (s.cav2_unit_on) bus.publish_cav2_unit_on(*s.cav2_unit_on);
+  if (s.cav2_door_ajar) bus.publish_cav2_door_ajar(*s.cav2_door_ajar);
+  if (s.cav2_at_set_temp) bus.publish_cav2_at_set_temp(*s.cav2_at_set_temp);
+  if (s.cav2_light_on) bus.publish_cav2_light_on(*s.cav2_light_on);
+  if (s.cav2_remote_ready) bus.publish_cav2_remote_ready(*s.cav2_remote_ready);
+  if (s.cav2_probe_on) bus.publish_cav2_probe_on(*s.cav2_probe_on);
+  if (s.cav2_probe_at_set_temp) bus.publish_cav2_probe_at_temp(*s.cav2_probe_at_set_temp);
+  if (s.cav2_probe_within_10deg) bus.publish_cav2_probe_near(*s.cav2_probe_within_10deg);
+  if (s.cav2_gourmet_mode_on) bus.publish_cav2_gourmet(*s.cav2_gourmet_mode_on);
+  if (s.cav2_cook_timer_complete) bus.publish_cav2_cook_timer_done(*s.cav2_cook_timer_complete);
+  if (s.cav2_temp) bus.publish_cav2_temp(*s.cav2_temp);
+  if (s.cav2_set_temp) bus.publish_cav2_set_temp(*s.cav2_set_temp);
+  if (s.cav2_cook_mode) bus.publish_cav2_cook_mode(*s.cav2_cook_mode);
+  if (s.cav2_probe_temp) bus.publish_cav2_probe_temp(*s.cav2_probe_temp);
+  if (s.cav2_probe_set_temp) bus.publish_cav2_probe_set_temp(*s.cav2_probe_set_temp);
+}
+
+}  // namespace subzero_protocol
+}  // namespace esphome

--- a/components/subzero_protocol/dispatch.h
+++ b/components/subzero_protocol/dispatch.h
@@ -29,65 +29,109 @@ namespace subzero_protocol {
 // dispatch_esphome.h).
 template <typename Bus>
 inline void dispatch_common(const CommonFields &c, Bus &bus) {
-  if (c.sabbath_on) bus.publish_sabbath_on(*c.sabbath_on);
-  if (c.service_required) bus.publish_svc_required(*c.service_required);
-  if (c.appliance_model) bus.publish_model(*c.appliance_model);
-  if (c.uptime) bus.publish_uptime(*c.uptime);
-  if (c.appliance_serial) bus.publish_serial(*c.appliance_serial);
-  if (c.appliance_type) bus.publish_appliance_type(*c.appliance_type);
-  if (c.diagnostic_status) bus.publish_diag_status(*c.diagnostic_status);
-  if (c.build_date) bus.publish_build_date(*c.build_date);
-  if (c.version.fw) bus.publish_fw_version(*c.version.fw);
-  if (c.version.api) bus.publish_api_version(*c.version.api);
-  if (c.version.bleapp) bus.publish_bleapp_version(*c.version.bleapp);
-  if (c.version.os) bus.publish_os_version(*c.version.os);
-  if (c.version.rtapp) bus.publish_rtapp_version(*c.version.rtapp);
-  if (c.version.appliance) bus.publish_board_version(*c.version.appliance);
+  if (c.sabbath_on)
+    bus.publish_sabbath_on(*c.sabbath_on);
+  if (c.service_required)
+    bus.publish_svc_required(*c.service_required);
+  if (c.appliance_model)
+    bus.publish_model(*c.appliance_model);
+  if (c.uptime)
+    bus.publish_uptime(*c.uptime);
+  if (c.appliance_serial)
+    bus.publish_serial(*c.appliance_serial);
+  if (c.appliance_type)
+    bus.publish_appliance_type(*c.appliance_type);
+  if (c.diagnostic_status)
+    bus.publish_diag_status(*c.diagnostic_status);
+  if (c.build_date)
+    bus.publish_build_date(*c.build_date);
+  if (c.version.fw)
+    bus.publish_fw_version(*c.version.fw);
+  if (c.version.api)
+    bus.publish_api_version(*c.version.api);
+  if (c.version.bleapp)
+    bus.publish_bleapp_version(*c.version.bleapp);
+  if (c.version.os)
+    bus.publish_os_version(*c.version.os);
+  if (c.version.rtapp)
+    bus.publish_rtapp_version(*c.version.rtapp);
+  if (c.version.appliance)
+    bus.publish_board_version(*c.version.appliance);
 }
 
 template <typename Bus>
 inline void dispatch_fridge(const FridgeState &s, Bus &bus) {
   dispatch_common(s.common, bus);
   // Fridge / Freezer
-  if (s.ref_set_temp) bus.publish_set_temp(*s.ref_set_temp);
-  if (s.door_ajar) bus.publish_door_ajar(*s.door_ajar);
-  if (s.frz_set_temp) bus.publish_frz_set_temp(*s.frz_set_temp);
-  if (s.frz_door_ajar) bus.publish_frz_door_ajar(*s.frz_door_ajar);
-  if (s.ice_maker_on) bus.publish_ice_maker(*s.ice_maker_on);
+  if (s.ref_set_temp)
+    bus.publish_set_temp(*s.ref_set_temp);
+  if (s.door_ajar)
+    bus.publish_door_ajar(*s.door_ajar);
+  if (s.frz_set_temp)
+    bus.publish_frz_set_temp(*s.frz_set_temp);
+  if (s.frz_door_ajar)
+    bus.publish_frz_door_ajar(*s.frz_door_ajar);
+  if (s.ice_maker_on)
+    bus.publish_ice_maker(*s.ice_maker_on);
   // Refrigerator drawer
-  if (s.ref2_set_temp) bus.publish_ref2_set_temp(*s.ref2_set_temp);
-  if (s.ref2_door_ajar) bus.publish_ref2_door_ajar(*s.ref2_door_ajar);
+  if (s.ref2_set_temp)
+    bus.publish_ref2_set_temp(*s.ref2_set_temp);
+  if (s.ref2_door_ajar)
+    bus.publish_ref2_door_ajar(*s.ref2_door_ajar);
   // Wine
-  if (s.wine_door_ajar) bus.publish_wine_door_ajar(*s.wine_door_ajar);
-  if (s.wine_set_temp) bus.publish_wine_set_temp(*s.wine_set_temp);
-  if (s.wine2_set_temp) bus.publish_wine2_set_temp(*s.wine2_set_temp);
-  if (s.wine_temp_alert_on) bus.publish_wine_temp_alert(*s.wine_temp_alert_on);
+  if (s.wine_door_ajar)
+    bus.publish_wine_door_ajar(*s.wine_door_ajar);
+  if (s.wine_set_temp)
+    bus.publish_wine_set_temp(*s.wine_set_temp);
+  if (s.wine2_set_temp)
+    bus.publish_wine2_set_temp(*s.wine2_set_temp);
+  if (s.wine_temp_alert_on)
+    bus.publish_wine_temp_alert(*s.wine_temp_alert_on);
   // Crisper
-  if (s.crisp_set_temp) bus.publish_crisp_set_temp(*s.crisp_set_temp);
+  if (s.crisp_set_temp)
+    bus.publish_crisp_set_temp(*s.crisp_set_temp);
   // Filters
-  if (s.air_filter_on) bus.publish_air_filter_on(*s.air_filter_on);
-  if (s.air_filter_pct_remaining) bus.publish_air_filter_pct(*s.air_filter_pct_remaining);
-  if (s.water_filter_pct_remaining) bus.publish_water_filter_pct(*s.water_filter_pct_remaining);
+  if (s.air_filter_on)
+    bus.publish_air_filter_on(*s.air_filter_on);
+  if (s.air_filter_pct_remaining)
+    bus.publish_air_filter_pct(*s.air_filter_pct_remaining);
+  if (s.water_filter_pct_remaining)
+    bus.publish_water_filter_pct(*s.water_filter_pct_remaining);
 }
 
 template <typename Bus>
 inline void dispatch_dishwasher(const DishwasherState &s, Bus &bus) {
   dispatch_common(s.common, bus);
-  if (s.door_ajar) bus.publish_door_ajar(*s.door_ajar);
-  if (s.wash_cycle_on) bus.publish_wash_cycle_on(*s.wash_cycle_on);
-  if (s.heated_dry_on) bus.publish_heated_dry(*s.heated_dry_on);
-  if (s.extended_dry_on) bus.publish_extended_dry(*s.extended_dry_on);
-  if (s.high_temp_wash_on) bus.publish_high_temp_wash(*s.high_temp_wash_on);
-  if (s.sani_rinse_on) bus.publish_sani_rinse(*s.sani_rinse_on);
-  if (s.rinse_aid_low) bus.publish_rinse_aid_low(*s.rinse_aid_low);
-  if (s.softener_low) bus.publish_softener_low(*s.softener_low);
-  if (s.light_on) bus.publish_light_on(*s.light_on);
-  if (s.remote_ready) bus.publish_remote_ready(*s.remote_ready);
-  if (s.delay_start_timer_active) bus.publish_delay_start(*s.delay_start_timer_active);
-  if (s.wash_status) bus.publish_wash_status(*s.wash_status);
-  if (s.wash_cycle) bus.publish_wash_cycle(*s.wash_cycle);
-  if (s.wash_cycle_end_time) bus.publish_wash_cycle_end_time(*s.wash_cycle_end_time);
-  if (s.wash_time_remaining_min) bus.publish_wash_time_remaining(*s.wash_time_remaining_min);
+  if (s.door_ajar)
+    bus.publish_door_ajar(*s.door_ajar);
+  if (s.wash_cycle_on)
+    bus.publish_wash_cycle_on(*s.wash_cycle_on);
+  if (s.heated_dry_on)
+    bus.publish_heated_dry(*s.heated_dry_on);
+  if (s.extended_dry_on)
+    bus.publish_extended_dry(*s.extended_dry_on);
+  if (s.high_temp_wash_on)
+    bus.publish_high_temp_wash(*s.high_temp_wash_on);
+  if (s.sani_rinse_on)
+    bus.publish_sani_rinse(*s.sani_rinse_on);
+  if (s.rinse_aid_low)
+    bus.publish_rinse_aid_low(*s.rinse_aid_low);
+  if (s.softener_low)
+    bus.publish_softener_low(*s.softener_low);
+  if (s.light_on)
+    bus.publish_light_on(*s.light_on);
+  if (s.remote_ready)
+    bus.publish_remote_ready(*s.remote_ready);
+  if (s.delay_start_timer_active)
+    bus.publish_delay_start(*s.delay_start_timer_active);
+  if (s.wash_status)
+    bus.publish_wash_status(*s.wash_status);
+  if (s.wash_cycle)
+    bus.publish_wash_cycle(*s.wash_cycle);
+  if (s.wash_cycle_end_time)
+    bus.publish_wash_cycle_end_time(*s.wash_cycle_end_time);
+  if (s.wash_time_remaining_min)
+    bus.publish_wash_time_remaining(*s.wash_time_remaining_min);
   // Stateful: when wash_cycle_on flips false, force the remaining-time
   // sensor to 0 (otherwise it sticks at the last computed minute count
   // until the next wash cycle starts).
@@ -99,50 +143,90 @@ inline void dispatch_dishwasher(const DishwasherState &s, Bus &bus) {
 template <typename Bus>
 inline void dispatch_range(const RangeState &s, Bus &bus) {
   dispatch_common(s.common, bus);
-  if (s.door_ajar) bus.publish_door_ajar(*s.door_ajar);
+  if (s.door_ajar)
+    bus.publish_door_ajar(*s.door_ajar);
   // Primary cavity
-  if (s.cav_unit_on) bus.publish_cav_unit_on(*s.cav_unit_on);
-  if (s.cav_at_set_temp) bus.publish_cav_at_set_temp(*s.cav_at_set_temp);
-  if (s.cav_light_on) bus.publish_cav_light_on(*s.cav_light_on);
-  if (s.cav_remote_ready) bus.publish_cav_remote_ready(*s.cav_remote_ready);
-  if (s.cav_probe_on) bus.publish_cav_probe_on(*s.cav_probe_on);
-  if (s.cav_probe_at_set_temp) bus.publish_cav_probe_at_temp(*s.cav_probe_at_set_temp);
-  if (s.cav_probe_within_10deg) bus.publish_cav_probe_near(*s.cav_probe_within_10deg);
-  if (s.cav_gourmet_mode_on) bus.publish_cav_gourmet(*s.cav_gourmet_mode_on);
-  if (s.cav_gourmet_recipe) bus.publish_cav_gourmet_recipe(*s.cav_gourmet_recipe);
-  if (s.cav_cook_timer_complete) bus.publish_cook_timer_done(*s.cav_cook_timer_complete);
-  if (s.cav_cook_timer_within_1min) bus.publish_cook_timer_near(*s.cav_cook_timer_within_1min);
-  if (s.cav_temp) bus.publish_cav_temp(*s.cav_temp);
-  if (s.cav_set_temp) bus.publish_cav_set_temp(*s.cav_set_temp);
-  if (s.cav_cook_mode) bus.publish_cav_cook_mode(*s.cav_cook_mode);
-  if (s.cav_probe_temp) bus.publish_probe_temp(*s.cav_probe_temp);
-  if (s.cav_probe_set_temp) bus.publish_probe_set_temp(*s.cav_probe_set_temp);
+  if (s.cav_unit_on)
+    bus.publish_cav_unit_on(*s.cav_unit_on);
+  if (s.cav_at_set_temp)
+    bus.publish_cav_at_set_temp(*s.cav_at_set_temp);
+  if (s.cav_light_on)
+    bus.publish_cav_light_on(*s.cav_light_on);
+  if (s.cav_remote_ready)
+    bus.publish_cav_remote_ready(*s.cav_remote_ready);
+  if (s.cav_probe_on)
+    bus.publish_cav_probe_on(*s.cav_probe_on);
+  if (s.cav_probe_at_set_temp)
+    bus.publish_cav_probe_at_temp(*s.cav_probe_at_set_temp);
+  if (s.cav_probe_within_10deg)
+    bus.publish_cav_probe_near(*s.cav_probe_within_10deg);
+  if (s.cav_gourmet_mode_on)
+    bus.publish_cav_gourmet(*s.cav_gourmet_mode_on);
+  if (s.cav_gourmet_recipe)
+    bus.publish_cav_gourmet_recipe(*s.cav_gourmet_recipe);
+  if (s.cav_cook_timer_complete)
+    bus.publish_cook_timer_done(*s.cav_cook_timer_complete);
+  if (s.cav_cook_timer_within_1min)
+    bus.publish_cook_timer_near(*s.cav_cook_timer_within_1min);
+  if (s.cav_temp)
+    bus.publish_cav_temp(*s.cav_temp);
+  if (s.cav_set_temp)
+    bus.publish_cav_set_temp(*s.cav_set_temp);
+  if (s.cav_cook_mode)
+    bus.publish_cav_cook_mode(*s.cav_cook_mode);
+  if (s.cav_probe_temp)
+    bus.publish_probe_temp(*s.cav_probe_temp);
+  if (s.cav_probe_set_temp)
+    bus.publish_probe_set_temp(*s.cav_probe_set_temp);
   // Kitchen timers
-  if (s.kitchen_timer_active) bus.publish_ktimer_active(*s.kitchen_timer_active);
-  if (s.kitchen_timer_complete) bus.publish_ktimer_done(*s.kitchen_timer_complete);
-  if (s.kitchen_timer_within_1min) bus.publish_ktimer_near(*s.kitchen_timer_within_1min);
-  if (s.kitchen_timer_end_time) bus.publish_ktimer_end_time(*s.kitchen_timer_end_time);
-  if (s.kitchen_timer2_active) bus.publish_ktimer2_active(*s.kitchen_timer2_active);
-  if (s.kitchen_timer2_complete) bus.publish_ktimer2_done(*s.kitchen_timer2_complete);
-  if (s.kitchen_timer2_within_1min) bus.publish_ktimer2_near(*s.kitchen_timer2_within_1min);
-  if (s.kitchen_timer2_end_time) bus.publish_ktimer2_end_time(*s.kitchen_timer2_end_time);
+  if (s.kitchen_timer_active)
+    bus.publish_ktimer_active(*s.kitchen_timer_active);
+  if (s.kitchen_timer_complete)
+    bus.publish_ktimer_done(*s.kitchen_timer_complete);
+  if (s.kitchen_timer_within_1min)
+    bus.publish_ktimer_near(*s.kitchen_timer_within_1min);
+  if (s.kitchen_timer_end_time)
+    bus.publish_ktimer_end_time(*s.kitchen_timer_end_time);
+  if (s.kitchen_timer2_active)
+    bus.publish_ktimer2_active(*s.kitchen_timer2_active);
+  if (s.kitchen_timer2_complete)
+    bus.publish_ktimer2_done(*s.kitchen_timer2_complete);
+  if (s.kitchen_timer2_within_1min)
+    bus.publish_ktimer2_near(*s.kitchen_timer2_within_1min);
+  if (s.kitchen_timer2_end_time)
+    bus.publish_ktimer2_end_time(*s.kitchen_timer2_end_time);
   // Secondary cavity (dual-oven ranges)
-  if (s.cav2_unit_on) bus.publish_cav2_unit_on(*s.cav2_unit_on);
-  if (s.cav2_door_ajar) bus.publish_cav2_door_ajar(*s.cav2_door_ajar);
-  if (s.cav2_at_set_temp) bus.publish_cav2_at_set_temp(*s.cav2_at_set_temp);
-  if (s.cav2_light_on) bus.publish_cav2_light_on(*s.cav2_light_on);
-  if (s.cav2_remote_ready) bus.publish_cav2_remote_ready(*s.cav2_remote_ready);
-  if (s.cav2_probe_on) bus.publish_cav2_probe_on(*s.cav2_probe_on);
-  if (s.cav2_probe_at_set_temp) bus.publish_cav2_probe_at_temp(*s.cav2_probe_at_set_temp);
-  if (s.cav2_probe_within_10deg) bus.publish_cav2_probe_near(*s.cav2_probe_within_10deg);
-  if (s.cav2_gourmet_mode_on) bus.publish_cav2_gourmet(*s.cav2_gourmet_mode_on);
-  if (s.cav2_cook_timer_complete) bus.publish_cav2_cook_timer_done(*s.cav2_cook_timer_complete);
-  if (s.cav2_temp) bus.publish_cav2_temp(*s.cav2_temp);
-  if (s.cav2_set_temp) bus.publish_cav2_set_temp(*s.cav2_set_temp);
-  if (s.cav2_cook_mode) bus.publish_cav2_cook_mode(*s.cav2_cook_mode);
-  if (s.cav2_probe_temp) bus.publish_cav2_probe_temp(*s.cav2_probe_temp);
-  if (s.cav2_probe_set_temp) bus.publish_cav2_probe_set_temp(*s.cav2_probe_set_temp);
+  if (s.cav2_unit_on)
+    bus.publish_cav2_unit_on(*s.cav2_unit_on);
+  if (s.cav2_door_ajar)
+    bus.publish_cav2_door_ajar(*s.cav2_door_ajar);
+  if (s.cav2_at_set_temp)
+    bus.publish_cav2_at_set_temp(*s.cav2_at_set_temp);
+  if (s.cav2_light_on)
+    bus.publish_cav2_light_on(*s.cav2_light_on);
+  if (s.cav2_remote_ready)
+    bus.publish_cav2_remote_ready(*s.cav2_remote_ready);
+  if (s.cav2_probe_on)
+    bus.publish_cav2_probe_on(*s.cav2_probe_on);
+  if (s.cav2_probe_at_set_temp)
+    bus.publish_cav2_probe_at_temp(*s.cav2_probe_at_set_temp);
+  if (s.cav2_probe_within_10deg)
+    bus.publish_cav2_probe_near(*s.cav2_probe_within_10deg);
+  if (s.cav2_gourmet_mode_on)
+    bus.publish_cav2_gourmet(*s.cav2_gourmet_mode_on);
+  if (s.cav2_cook_timer_complete)
+    bus.publish_cav2_cook_timer_done(*s.cav2_cook_timer_complete);
+  if (s.cav2_temp)
+    bus.publish_cav2_temp(*s.cav2_temp);
+  if (s.cav2_set_temp)
+    bus.publish_cav2_set_temp(*s.cav2_set_temp);
+  if (s.cav2_cook_mode)
+    bus.publish_cav2_cook_mode(*s.cav2_cook_mode);
+  if (s.cav2_probe_temp)
+    bus.publish_cav2_probe_temp(*s.cav2_probe_temp);
+  if (s.cav2_probe_set_temp)
+    bus.publish_cav2_probe_set_temp(*s.cav2_probe_set_temp);
 }
 
-}  // namespace subzero_protocol
-}  // namespace esphome
+} // namespace subzero_protocol
+} // namespace esphome

--- a/components/subzero_protocol/dispatch_esphome.h
+++ b/components/subzero_protocol/dispatch_esphome.h
@@ -1,0 +1,276 @@
+#pragma once
+
+// Production "Bus" structs that hold raw ESPHome sensor pointers and
+// implement the publish methods that dispatch.h calls.
+//
+// One struct per appliance type. Each declares a pointer for every
+// `${prefix}_<id>` sensor the appliance YAML creates, plus a one-line
+// `publish_<id>(value)` method that null-checks and forwards to
+// `Sensor::publish_state()`.
+//
+// All buses inherit from CommonBus, which holds the appliance-agnostic
+// fields (model / uptime / firmware version / etc).
+//
+// Population pattern in YAML:
+//
+//     globals:
+//       - id: ${prefix}_bus
+//         type: esphome::subzero_protocol::FridgeBus
+//         restore_value: false
+//
+//     esphome:
+//       on_boot:
+//         - priority: -100
+//           then:
+//             - lambda: |-
+//                 auto& bus = id(${prefix}_bus);
+//                 bus.set_temp = id(${prefix}_set_temp);
+//                 bus.door_ajar = id(${prefix}_door_ajar);
+//                 // ... etc
+//
+// Then parse_json calls `dispatch_fridge(s, id(${prefix}_bus))` once.
+//
+// This header is on-device only — it pulls in ESPHome's typed sensor
+// headers, which aren't available during host gtest builds. Host tests
+// instantiate dispatch.h's templates with their own recording bus.
+
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+
+namespace esphome {
+namespace subzero_protocol {
+
+namespace detail {
+
+// Null-checked publish helpers. Templated on the ESPHome sensor type
+// so we don't write 50 copies of `if (s) s->publish_state(v)`.
+template <typename S, typename V>
+inline void publish_if(S *s, V v) {
+  if (s != nullptr) s->publish_state(v);
+}
+
+}  // namespace detail
+
+// Common (appliance-agnostic) bus. Inherited by every appliance bus.
+struct CommonBus {
+  esphome::binary_sensor::BinarySensor *sabbath_on = nullptr;
+  esphome::binary_sensor::BinarySensor *svc_required = nullptr;
+  esphome::text_sensor::TextSensor *model = nullptr;
+  esphome::text_sensor::TextSensor *uptime = nullptr;
+  esphome::text_sensor::TextSensor *serial = nullptr;
+  esphome::text_sensor::TextSensor *appliance_type = nullptr;
+  esphome::text_sensor::TextSensor *diag_status = nullptr;
+  esphome::text_sensor::TextSensor *build_date = nullptr;
+  esphome::text_sensor::TextSensor *fw_version = nullptr;
+  esphome::text_sensor::TextSensor *api_version = nullptr;
+  esphome::text_sensor::TextSensor *bleapp_version = nullptr;
+  esphome::text_sensor::TextSensor *os_version = nullptr;
+  esphome::text_sensor::TextSensor *rtapp_version = nullptr;
+  esphome::text_sensor::TextSensor *board_version = nullptr;
+
+  void publish_sabbath_on(bool v) { detail::publish_if(sabbath_on, v); }
+  void publish_svc_required(bool v) { detail::publish_if(svc_required, v); }
+  void publish_model(const std::string &v) { detail::publish_if(model, v); }
+  void publish_uptime(const std::string &v) { detail::publish_if(uptime, v); }
+  void publish_serial(const std::string &v) { detail::publish_if(serial, v); }
+  void publish_appliance_type(const std::string &v) { detail::publish_if(appliance_type, v); }
+  void publish_diag_status(const std::string &v) { detail::publish_if(diag_status, v); }
+  void publish_build_date(const std::string &v) { detail::publish_if(build_date, v); }
+  void publish_fw_version(const std::string &v) { detail::publish_if(fw_version, v); }
+  void publish_api_version(const std::string &v) { detail::publish_if(api_version, v); }
+  void publish_bleapp_version(const std::string &v) { detail::publish_if(bleapp_version, v); }
+  void publish_os_version(const std::string &v) { detail::publish_if(os_version, v); }
+  void publish_rtapp_version(const std::string &v) { detail::publish_if(rtapp_version, v); }
+  void publish_board_version(const std::string &v) { detail::publish_if(board_version, v); }
+};
+
+struct FridgeBus : CommonBus {
+  esphome::binary_sensor::BinarySensor *door_ajar = nullptr;
+  esphome::binary_sensor::BinarySensor *frz_door_ajar = nullptr;
+  esphome::binary_sensor::BinarySensor *ice_maker = nullptr;
+  esphome::binary_sensor::BinarySensor *ref2_door_ajar = nullptr;
+  esphome::binary_sensor::BinarySensor *wine_door_ajar = nullptr;
+  esphome::binary_sensor::BinarySensor *wine_temp_alert = nullptr;
+  esphome::binary_sensor::BinarySensor *air_filter_on = nullptr;
+
+  esphome::sensor::Sensor *set_temp = nullptr;
+  esphome::sensor::Sensor *frz_set_temp = nullptr;
+  esphome::sensor::Sensor *ref2_set_temp = nullptr;
+  esphome::sensor::Sensor *wine_set_temp = nullptr;
+  esphome::sensor::Sensor *wine2_set_temp = nullptr;
+  esphome::sensor::Sensor *crisp_set_temp = nullptr;
+  esphome::sensor::Sensor *air_filter_pct = nullptr;
+  esphome::sensor::Sensor *water_filter_pct = nullptr;
+
+  void publish_door_ajar(bool v) { detail::publish_if(door_ajar, v); }
+  void publish_frz_door_ajar(bool v) { detail::publish_if(frz_door_ajar, v); }
+  void publish_ice_maker(bool v) { detail::publish_if(ice_maker, v); }
+  void publish_ref2_door_ajar(bool v) { detail::publish_if(ref2_door_ajar, v); }
+  void publish_wine_door_ajar(bool v) { detail::publish_if(wine_door_ajar, v); }
+  void publish_wine_temp_alert(bool v) { detail::publish_if(wine_temp_alert, v); }
+  void publish_air_filter_on(bool v) { detail::publish_if(air_filter_on, v); }
+
+  void publish_set_temp(float v) { detail::publish_if(set_temp, v); }
+  void publish_frz_set_temp(float v) { detail::publish_if(frz_set_temp, v); }
+  void publish_ref2_set_temp(float v) { detail::publish_if(ref2_set_temp, v); }
+  void publish_wine_set_temp(float v) { detail::publish_if(wine_set_temp, v); }
+  void publish_wine2_set_temp(float v) { detail::publish_if(wine2_set_temp, v); }
+  void publish_crisp_set_temp(float v) { detail::publish_if(crisp_set_temp, v); }
+  void publish_air_filter_pct(float v) { detail::publish_if(air_filter_pct, v); }
+  void publish_water_filter_pct(float v) { detail::publish_if(water_filter_pct, v); }
+};
+
+struct DishwasherBus : CommonBus {
+  esphome::binary_sensor::BinarySensor *door_ajar = nullptr;
+  esphome::binary_sensor::BinarySensor *wash_cycle_on = nullptr;
+  esphome::binary_sensor::BinarySensor *heated_dry = nullptr;
+  esphome::binary_sensor::BinarySensor *extended_dry = nullptr;
+  esphome::binary_sensor::BinarySensor *high_temp_wash = nullptr;
+  esphome::binary_sensor::BinarySensor *sani_rinse = nullptr;
+  esphome::binary_sensor::BinarySensor *rinse_aid_low = nullptr;
+  esphome::binary_sensor::BinarySensor *softener_low = nullptr;
+  esphome::binary_sensor::BinarySensor *light_on = nullptr;
+  esphome::binary_sensor::BinarySensor *remote_ready = nullptr;
+  esphome::binary_sensor::BinarySensor *delay_start = nullptr;
+
+  esphome::sensor::Sensor *wash_status = nullptr;
+  esphome::sensor::Sensor *wash_cycle = nullptr;
+  esphome::sensor::Sensor *wash_time_remaining = nullptr;
+
+  esphome::text_sensor::TextSensor *wash_cycle_end_time = nullptr;
+
+  void publish_door_ajar(bool v) { detail::publish_if(door_ajar, v); }
+  void publish_wash_cycle_on(bool v) { detail::publish_if(wash_cycle_on, v); }
+  void publish_heated_dry(bool v) { detail::publish_if(heated_dry, v); }
+  void publish_extended_dry(bool v) { detail::publish_if(extended_dry, v); }
+  void publish_high_temp_wash(bool v) { detail::publish_if(high_temp_wash, v); }
+  void publish_sani_rinse(bool v) { detail::publish_if(sani_rinse, v); }
+  void publish_rinse_aid_low(bool v) { detail::publish_if(rinse_aid_low, v); }
+  void publish_softener_low(bool v) { detail::publish_if(softener_low, v); }
+  void publish_light_on(bool v) { detail::publish_if(light_on, v); }
+  void publish_remote_ready(bool v) { detail::publish_if(remote_ready, v); }
+  void publish_delay_start(bool v) { detail::publish_if(delay_start, v); }
+
+  void publish_wash_status(int v) { detail::publish_if(wash_status, static_cast<float>(v)); }
+  void publish_wash_cycle(int v) { detail::publish_if(wash_cycle, static_cast<float>(v)); }
+  void publish_wash_time_remaining(int v) {
+    detail::publish_if(wash_time_remaining, static_cast<float>(v));
+  }
+
+  void publish_wash_cycle_end_time(const std::string &v) {
+    detail::publish_if(wash_cycle_end_time, v);
+  }
+
+  // Stateful: only force the remaining-time sensor to 0 if its current
+  // state is non-zero. Avoids publishing 0 every poll cycle once a wash
+  // ends and the cycle stays off (would spam HA history with zeros).
+  void clear_wash_time_remaining_if_running() {
+    if (wash_time_remaining != nullptr && wash_time_remaining->state > 0) {
+      wash_time_remaining->publish_state(0);
+    }
+  }
+};
+
+struct RangeBus : CommonBus {
+  // Primary cavity
+  esphome::binary_sensor::BinarySensor *door_ajar = nullptr;
+  esphome::binary_sensor::BinarySensor *cav_unit_on = nullptr;
+  esphome::binary_sensor::BinarySensor *cav_at_set_temp = nullptr;
+  esphome::binary_sensor::BinarySensor *cav_light_on = nullptr;
+  esphome::binary_sensor::BinarySensor *cav_remote_ready = nullptr;
+  esphome::binary_sensor::BinarySensor *cav_probe_on = nullptr;
+  esphome::binary_sensor::BinarySensor *cav_probe_at_temp = nullptr;
+  esphome::binary_sensor::BinarySensor *cav_probe_near = nullptr;
+  esphome::binary_sensor::BinarySensor *cav_gourmet = nullptr;
+  esphome::binary_sensor::BinarySensor *cook_timer_done = nullptr;
+  esphome::binary_sensor::BinarySensor *cook_timer_near = nullptr;
+
+  esphome::sensor::Sensor *cav_temp = nullptr;
+  esphome::sensor::Sensor *cav_set_temp = nullptr;
+  esphome::sensor::Sensor *cav_cook_mode = nullptr;
+  esphome::sensor::Sensor *cav_gourmet_recipe = nullptr;
+  esphome::sensor::Sensor *probe_temp = nullptr;
+  esphome::sensor::Sensor *probe_set_temp = nullptr;
+
+  // Kitchen timers (1 + 2)
+  esphome::binary_sensor::BinarySensor *ktimer_active = nullptr;
+  esphome::binary_sensor::BinarySensor *ktimer_done = nullptr;
+  esphome::binary_sensor::BinarySensor *ktimer_near = nullptr;
+  esphome::binary_sensor::BinarySensor *ktimer2_active = nullptr;
+  esphome::binary_sensor::BinarySensor *ktimer2_done = nullptr;
+  esphome::binary_sensor::BinarySensor *ktimer2_near = nullptr;
+  esphome::text_sensor::TextSensor *ktimer_end_time = nullptr;
+  esphome::text_sensor::TextSensor *ktimer2_end_time = nullptr;
+
+  // Secondary cavity (dual-oven)
+  esphome::binary_sensor::BinarySensor *cav2_unit_on = nullptr;
+  esphome::binary_sensor::BinarySensor *cav2_door_ajar = nullptr;
+  esphome::binary_sensor::BinarySensor *cav2_at_set_temp = nullptr;
+  esphome::binary_sensor::BinarySensor *cav2_light_on = nullptr;
+  esphome::binary_sensor::BinarySensor *cav2_remote_ready = nullptr;
+  esphome::binary_sensor::BinarySensor *cav2_probe_on = nullptr;
+  esphome::binary_sensor::BinarySensor *cav2_probe_at_temp = nullptr;
+  esphome::binary_sensor::BinarySensor *cav2_probe_near = nullptr;
+  esphome::binary_sensor::BinarySensor *cav2_gourmet = nullptr;
+  esphome::binary_sensor::BinarySensor *cav2_cook_timer_done = nullptr;
+
+  esphome::sensor::Sensor *cav2_temp = nullptr;
+  esphome::sensor::Sensor *cav2_set_temp = nullptr;
+  esphome::sensor::Sensor *cav2_cook_mode = nullptr;
+  esphome::sensor::Sensor *cav2_probe_temp = nullptr;
+  esphome::sensor::Sensor *cav2_probe_set_temp = nullptr;
+
+  // Primary cavity publishes
+  void publish_door_ajar(bool v) { detail::publish_if(door_ajar, v); }
+  void publish_cav_unit_on(bool v) { detail::publish_if(cav_unit_on, v); }
+  void publish_cav_at_set_temp(bool v) { detail::publish_if(cav_at_set_temp, v); }
+  void publish_cav_light_on(bool v) { detail::publish_if(cav_light_on, v); }
+  void publish_cav_remote_ready(bool v) { detail::publish_if(cav_remote_ready, v); }
+  void publish_cav_probe_on(bool v) { detail::publish_if(cav_probe_on, v); }
+  void publish_cav_probe_at_temp(bool v) { detail::publish_if(cav_probe_at_temp, v); }
+  void publish_cav_probe_near(bool v) { detail::publish_if(cav_probe_near, v); }
+  void publish_cav_gourmet(bool v) { detail::publish_if(cav_gourmet, v); }
+  void publish_cook_timer_done(bool v) { detail::publish_if(cook_timer_done, v); }
+  void publish_cook_timer_near(bool v) { detail::publish_if(cook_timer_near, v); }
+
+  void publish_cav_temp(float v) { detail::publish_if(cav_temp, v); }
+  void publish_cav_set_temp(float v) { detail::publish_if(cav_set_temp, v); }
+  void publish_cav_cook_mode(int v) { detail::publish_if(cav_cook_mode, static_cast<float>(v)); }
+  void publish_cav_gourmet_recipe(int v) {
+    detail::publish_if(cav_gourmet_recipe, static_cast<float>(v));
+  }
+  void publish_probe_temp(float v) { detail::publish_if(probe_temp, v); }
+  void publish_probe_set_temp(float v) { detail::publish_if(probe_set_temp, v); }
+
+  // Kitchen timer publishes
+  void publish_ktimer_active(bool v) { detail::publish_if(ktimer_active, v); }
+  void publish_ktimer_done(bool v) { detail::publish_if(ktimer_done, v); }
+  void publish_ktimer_near(bool v) { detail::publish_if(ktimer_near, v); }
+  void publish_ktimer2_active(bool v) { detail::publish_if(ktimer2_active, v); }
+  void publish_ktimer2_done(bool v) { detail::publish_if(ktimer2_done, v); }
+  void publish_ktimer2_near(bool v) { detail::publish_if(ktimer2_near, v); }
+  void publish_ktimer_end_time(const std::string &v) { detail::publish_if(ktimer_end_time, v); }
+  void publish_ktimer2_end_time(const std::string &v) { detail::publish_if(ktimer2_end_time, v); }
+
+  // Secondary cavity publishes
+  void publish_cav2_unit_on(bool v) { detail::publish_if(cav2_unit_on, v); }
+  void publish_cav2_door_ajar(bool v) { detail::publish_if(cav2_door_ajar, v); }
+  void publish_cav2_at_set_temp(bool v) { detail::publish_if(cav2_at_set_temp, v); }
+  void publish_cav2_light_on(bool v) { detail::publish_if(cav2_light_on, v); }
+  void publish_cav2_remote_ready(bool v) { detail::publish_if(cav2_remote_ready, v); }
+  void publish_cav2_probe_on(bool v) { detail::publish_if(cav2_probe_on, v); }
+  void publish_cav2_probe_at_temp(bool v) { detail::publish_if(cav2_probe_at_temp, v); }
+  void publish_cav2_probe_near(bool v) { detail::publish_if(cav2_probe_near, v); }
+  void publish_cav2_gourmet(bool v) { detail::publish_if(cav2_gourmet, v); }
+  void publish_cav2_cook_timer_done(bool v) { detail::publish_if(cav2_cook_timer_done, v); }
+
+  void publish_cav2_temp(float v) { detail::publish_if(cav2_temp, v); }
+  void publish_cav2_set_temp(float v) { detail::publish_if(cav2_set_temp, v); }
+  void publish_cav2_cook_mode(int v) { detail::publish_if(cav2_cook_mode, static_cast<float>(v)); }
+  void publish_cav2_probe_temp(float v) { detail::publish_if(cav2_probe_temp, v); }
+  void publish_cav2_probe_set_temp(float v) { detail::publish_if(cav2_probe_set_temp, v); }
+};
+
+}  // namespace subzero_protocol
+}  // namespace esphome

--- a/components/subzero_protocol/dispatch_esphome.h
+++ b/components/subzero_protocol/dispatch_esphome.h
@@ -45,12 +45,12 @@ namespace detail {
 
 // Null-checked publish helpers. Templated on the ESPHome sensor type
 // so we don't write 50 copies of `if (s) s->publish_state(v)`.
-template <typename S, typename V>
-inline void publish_if(S *s, V v) {
-  if (s != nullptr) s->publish_state(v);
+template <typename S, typename V> inline void publish_if(S *s, V v) {
+  if (s != nullptr)
+    s->publish_state(v);
 }
 
-}  // namespace detail
+} // namespace detail
 
 // Common (appliance-agnostic) bus. Inherited by every appliance bus.
 struct CommonBus {
@@ -74,15 +74,33 @@ struct CommonBus {
   void publish_model(const std::string &v) { detail::publish_if(model, v); }
   void publish_uptime(const std::string &v) { detail::publish_if(uptime, v); }
   void publish_serial(const std::string &v) { detail::publish_if(serial, v); }
-  void publish_appliance_type(const std::string &v) { detail::publish_if(appliance_type, v); }
-  void publish_diag_status(const std::string &v) { detail::publish_if(diag_status, v); }
-  void publish_build_date(const std::string &v) { detail::publish_if(build_date, v); }
-  void publish_fw_version(const std::string &v) { detail::publish_if(fw_version, v); }
-  void publish_api_version(const std::string &v) { detail::publish_if(api_version, v); }
-  void publish_bleapp_version(const std::string &v) { detail::publish_if(bleapp_version, v); }
-  void publish_os_version(const std::string &v) { detail::publish_if(os_version, v); }
-  void publish_rtapp_version(const std::string &v) { detail::publish_if(rtapp_version, v); }
-  void publish_board_version(const std::string &v) { detail::publish_if(board_version, v); }
+  void publish_appliance_type(const std::string &v) {
+    detail::publish_if(appliance_type, v);
+  }
+  void publish_diag_status(const std::string &v) {
+    detail::publish_if(diag_status, v);
+  }
+  void publish_build_date(const std::string &v) {
+    detail::publish_if(build_date, v);
+  }
+  void publish_fw_version(const std::string &v) {
+    detail::publish_if(fw_version, v);
+  }
+  void publish_api_version(const std::string &v) {
+    detail::publish_if(api_version, v);
+  }
+  void publish_bleapp_version(const std::string &v) {
+    detail::publish_if(bleapp_version, v);
+  }
+  void publish_os_version(const std::string &v) {
+    detail::publish_if(os_version, v);
+  }
+  void publish_rtapp_version(const std::string &v) {
+    detail::publish_if(rtapp_version, v);
+  }
+  void publish_board_version(const std::string &v) {
+    detail::publish_if(board_version, v);
+  }
 };
 
 struct FridgeBus : CommonBus {
@@ -108,17 +126,27 @@ struct FridgeBus : CommonBus {
   void publish_ice_maker(bool v) { detail::publish_if(ice_maker, v); }
   void publish_ref2_door_ajar(bool v) { detail::publish_if(ref2_door_ajar, v); }
   void publish_wine_door_ajar(bool v) { detail::publish_if(wine_door_ajar, v); }
-  void publish_wine_temp_alert(bool v) { detail::publish_if(wine_temp_alert, v); }
+  void publish_wine_temp_alert(bool v) {
+    detail::publish_if(wine_temp_alert, v);
+  }
   void publish_air_filter_on(bool v) { detail::publish_if(air_filter_on, v); }
 
   void publish_set_temp(float v) { detail::publish_if(set_temp, v); }
   void publish_frz_set_temp(float v) { detail::publish_if(frz_set_temp, v); }
   void publish_ref2_set_temp(float v) { detail::publish_if(ref2_set_temp, v); }
   void publish_wine_set_temp(float v) { detail::publish_if(wine_set_temp, v); }
-  void publish_wine2_set_temp(float v) { detail::publish_if(wine2_set_temp, v); }
-  void publish_crisp_set_temp(float v) { detail::publish_if(crisp_set_temp, v); }
-  void publish_air_filter_pct(float v) { detail::publish_if(air_filter_pct, v); }
-  void publish_water_filter_pct(float v) { detail::publish_if(water_filter_pct, v); }
+  void publish_wine2_set_temp(float v) {
+    detail::publish_if(wine2_set_temp, v);
+  }
+  void publish_crisp_set_temp(float v) {
+    detail::publish_if(crisp_set_temp, v);
+  }
+  void publish_air_filter_pct(float v) {
+    detail::publish_if(air_filter_pct, v);
+  }
+  void publish_water_filter_pct(float v) {
+    detail::publish_if(water_filter_pct, v);
+  }
 };
 
 struct DishwasherBus : CommonBus {
@@ -152,8 +180,12 @@ struct DishwasherBus : CommonBus {
   void publish_remote_ready(bool v) { detail::publish_if(remote_ready, v); }
   void publish_delay_start(bool v) { detail::publish_if(delay_start, v); }
 
-  void publish_wash_status(int v) { detail::publish_if(wash_status, static_cast<float>(v)); }
-  void publish_wash_cycle(int v) { detail::publish_if(wash_cycle, static_cast<float>(v)); }
+  void publish_wash_status(int v) {
+    detail::publish_if(wash_status, static_cast<float>(v));
+  }
+  void publish_wash_cycle(int v) {
+    detail::publish_if(wash_cycle, static_cast<float>(v));
+  }
   void publish_wash_time_remaining(int v) {
     detail::publish_if(wash_time_remaining, static_cast<float>(v));
   }
@@ -224,24 +256,38 @@ struct RangeBus : CommonBus {
   // Primary cavity publishes
   void publish_door_ajar(bool v) { detail::publish_if(door_ajar, v); }
   void publish_cav_unit_on(bool v) { detail::publish_if(cav_unit_on, v); }
-  void publish_cav_at_set_temp(bool v) { detail::publish_if(cav_at_set_temp, v); }
+  void publish_cav_at_set_temp(bool v) {
+    detail::publish_if(cav_at_set_temp, v);
+  }
   void publish_cav_light_on(bool v) { detail::publish_if(cav_light_on, v); }
-  void publish_cav_remote_ready(bool v) { detail::publish_if(cav_remote_ready, v); }
+  void publish_cav_remote_ready(bool v) {
+    detail::publish_if(cav_remote_ready, v);
+  }
   void publish_cav_probe_on(bool v) { detail::publish_if(cav_probe_on, v); }
-  void publish_cav_probe_at_temp(bool v) { detail::publish_if(cav_probe_at_temp, v); }
+  void publish_cav_probe_at_temp(bool v) {
+    detail::publish_if(cav_probe_at_temp, v);
+  }
   void publish_cav_probe_near(bool v) { detail::publish_if(cav_probe_near, v); }
   void publish_cav_gourmet(bool v) { detail::publish_if(cav_gourmet, v); }
-  void publish_cook_timer_done(bool v) { detail::publish_if(cook_timer_done, v); }
-  void publish_cook_timer_near(bool v) { detail::publish_if(cook_timer_near, v); }
+  void publish_cook_timer_done(bool v) {
+    detail::publish_if(cook_timer_done, v);
+  }
+  void publish_cook_timer_near(bool v) {
+    detail::publish_if(cook_timer_near, v);
+  }
 
   void publish_cav_temp(float v) { detail::publish_if(cav_temp, v); }
   void publish_cav_set_temp(float v) { detail::publish_if(cav_set_temp, v); }
-  void publish_cav_cook_mode(int v) { detail::publish_if(cav_cook_mode, static_cast<float>(v)); }
+  void publish_cav_cook_mode(int v) {
+    detail::publish_if(cav_cook_mode, static_cast<float>(v));
+  }
   void publish_cav_gourmet_recipe(int v) {
     detail::publish_if(cav_gourmet_recipe, static_cast<float>(v));
   }
   void publish_probe_temp(float v) { detail::publish_if(probe_temp, v); }
-  void publish_probe_set_temp(float v) { detail::publish_if(probe_set_temp, v); }
+  void publish_probe_set_temp(float v) {
+    detail::publish_if(probe_set_temp, v);
+  }
 
   // Kitchen timer publishes
   void publish_ktimer_active(bool v) { detail::publish_if(ktimer_active, v); }
@@ -250,27 +296,47 @@ struct RangeBus : CommonBus {
   void publish_ktimer2_active(bool v) { detail::publish_if(ktimer2_active, v); }
   void publish_ktimer2_done(bool v) { detail::publish_if(ktimer2_done, v); }
   void publish_ktimer2_near(bool v) { detail::publish_if(ktimer2_near, v); }
-  void publish_ktimer_end_time(const std::string &v) { detail::publish_if(ktimer_end_time, v); }
-  void publish_ktimer2_end_time(const std::string &v) { detail::publish_if(ktimer2_end_time, v); }
+  void publish_ktimer_end_time(const std::string &v) {
+    detail::publish_if(ktimer_end_time, v);
+  }
+  void publish_ktimer2_end_time(const std::string &v) {
+    detail::publish_if(ktimer2_end_time, v);
+  }
 
   // Secondary cavity publishes
   void publish_cav2_unit_on(bool v) { detail::publish_if(cav2_unit_on, v); }
   void publish_cav2_door_ajar(bool v) { detail::publish_if(cav2_door_ajar, v); }
-  void publish_cav2_at_set_temp(bool v) { detail::publish_if(cav2_at_set_temp, v); }
+  void publish_cav2_at_set_temp(bool v) {
+    detail::publish_if(cav2_at_set_temp, v);
+  }
   void publish_cav2_light_on(bool v) { detail::publish_if(cav2_light_on, v); }
-  void publish_cav2_remote_ready(bool v) { detail::publish_if(cav2_remote_ready, v); }
+  void publish_cav2_remote_ready(bool v) {
+    detail::publish_if(cav2_remote_ready, v);
+  }
   void publish_cav2_probe_on(bool v) { detail::publish_if(cav2_probe_on, v); }
-  void publish_cav2_probe_at_temp(bool v) { detail::publish_if(cav2_probe_at_temp, v); }
-  void publish_cav2_probe_near(bool v) { detail::publish_if(cav2_probe_near, v); }
+  void publish_cav2_probe_at_temp(bool v) {
+    detail::publish_if(cav2_probe_at_temp, v);
+  }
+  void publish_cav2_probe_near(bool v) {
+    detail::publish_if(cav2_probe_near, v);
+  }
   void publish_cav2_gourmet(bool v) { detail::publish_if(cav2_gourmet, v); }
-  void publish_cav2_cook_timer_done(bool v) { detail::publish_if(cav2_cook_timer_done, v); }
+  void publish_cav2_cook_timer_done(bool v) {
+    detail::publish_if(cav2_cook_timer_done, v);
+  }
 
   void publish_cav2_temp(float v) { detail::publish_if(cav2_temp, v); }
   void publish_cav2_set_temp(float v) { detail::publish_if(cav2_set_temp, v); }
-  void publish_cav2_cook_mode(int v) { detail::publish_if(cav2_cook_mode, static_cast<float>(v)); }
-  void publish_cav2_probe_temp(float v) { detail::publish_if(cav2_probe_temp, v); }
-  void publish_cav2_probe_set_temp(float v) { detail::publish_if(cav2_probe_set_temp, v); }
+  void publish_cav2_cook_mode(int v) {
+    detail::publish_if(cav2_cook_mode, static_cast<float>(v));
+  }
+  void publish_cav2_probe_temp(float v) {
+    detail::publish_if(cav2_probe_temp, v);
+  }
+  void publish_cav2_probe_set_temp(float v) {
+    detail::publish_if(cav2_probe_set_temp, v);
+  }
 };
 
-}  // namespace subzero_protocol
-}  // namespace esphome
+} // namespace subzero_protocol
+} // namespace esphome

--- a/components/subzero_protocol/gatt_handles.h
+++ b/components/subzero_protocol/gatt_handles.h
@@ -28,10 +28,11 @@ namespace subzero_protocol {
 // Decoupling from esp_gattc_api.h keeps the helper host-buildable
 // (ESP-IDF headers aren't available outside the ESP32 build).
 struct GattEntry {
-  bool is_characteristic = false;   // true if type == ESP_GATT_DB_CHARACTERISTIC
-  bool is_uuid128 = false;          // true if uuid.len == ESP_UUID_LEN_128
-  std::uint8_t uuid_first_byte = 0; // uuid.uuid.uuid128[0]; valid only if is_uuid128
-  std::uint16_t handle = 0;         // attribute_handle
+  bool is_characteristic = false; // true if type == ESP_GATT_DB_CHARACTERISTIC
+  bool is_uuid128 = false;        // true if uuid.len == ESP_UUID_LEN_128
+  std::uint8_t uuid_first_byte =
+      0;                    // uuid.uuid.uuid128[0]; valid only if is_uuid128
+  std::uint16_t handle = 0; // attribute_handle
 };
 
 // Sub-Zero's data-plane handles, populated incrementally across
@@ -60,20 +61,24 @@ struct AppHandles {
 template <typename Range>
 inline void extract_handles(const Range &entries, AppHandles &out) {
   for (const auto &e : entries) {
-    if (!e.is_characteristic || !e.is_uuid128) continue;
+    if (!e.is_characteristic || !e.is_uuid128)
+      continue;
     switch (e.uuid_first_byte) {
-      case 0xD5:
-        if (out.d5 == 0) out.d5 = e.handle;
-        break;
-      case 0xD6:
-        if (out.d6 == 0) out.d6 = e.handle;
-        break;
-      case 0xD7:
-        if (out.d7 == 0) out.d7 = e.handle;
-        break;
+    case 0xD5:
+      if (out.d5 == 0)
+        out.d5 = e.handle;
+      break;
+    case 0xD6:
+      if (out.d6 == 0)
+        out.d6 = e.handle;
+      break;
+    case 0xD7:
+      if (out.d7 == 0)
+        out.d7 = e.handle;
+      break;
     }
   }
 }
 
-}  // namespace subzero_protocol
-}  // namespace esphome
+} // namespace subzero_protocol
+} // namespace esphome

--- a/components/subzero_protocol/gatt_handles.h
+++ b/components/subzero_protocol/gatt_handles.h
@@ -1,0 +1,79 @@
+#pragma once
+
+// GATT characteristic handle extraction for the Sub-Zero BLE protocol.
+//
+// Sub-Zero appliances expose five 128-bit-UUID characteristics whose only
+// distinguishing byte is the first byte of the UUID — D4 / D5 / D6 / D7 / D8.
+// Post-PR-#72 we only care about three:
+//
+//   D5 = encrypted control channel
+//   D6 = encrypted data channel
+//   D7 = open pre-auth diagnostic channel
+//
+// The post_bond script polls the GATT database up to four times during
+// discovery (initial dump, then 3 retry passes 5s apart), and each pass
+// repeats the same "scan db, find characteristics, extract handles by
+// UUID first byte" loop. This header centralizes that logic so it can be
+// host-tested with synthetic GATT entries.
+
+#include <cstdint>
+
+namespace esphome {
+namespace subzero_protocol {
+
+// A trimmed-down view of esp_gattc_db_elem_t carrying only the fields
+// the handle-extractor needs. The YAML lambda converts each
+// esp_gattc_db_elem_t to one of these before calling extract_handles.
+//
+// Decoupling from esp_gattc_api.h keeps the helper host-buildable
+// (ESP-IDF headers aren't available outside the ESP32 build).
+struct GattEntry {
+  bool is_characteristic = false;   // true if type == ESP_GATT_DB_CHARACTERISTIC
+  bool is_uuid128 = false;          // true if uuid.len == ESP_UUID_LEN_128
+  std::uint8_t uuid_first_byte = 0; // uuid.uuid.uuid128[0]; valid only if is_uuid128
+  std::uint16_t handle = 0;         // attribute_handle
+};
+
+// Sub-Zero's data-plane handles, populated incrementally across
+// discovery retries. A value of 0 means "not yet found".
+struct AppHandles {
+  std::uint16_t d5 = 0;
+  std::uint16_t d6 = 0;
+  std::uint16_t d7 = 0;
+
+  bool has_d5() const { return d5 != 0; }
+  bool has_d6() const { return d6 != 0; }
+  bool has_d7() const { return d7 != 0; }
+
+  // True once we have everything we need to subscribe + poll.
+  bool ready() const { return has_d5() && has_d6(); }
+};
+
+// Iterate `entries` and update any not-yet-found handle in `out` whose
+// UUID first byte matches D5/D6/D7. Existing non-zero handles in `out`
+// are preserved — calling this across multiple discovery passes is
+// idempotent and additive.
+//
+// Templated on Range so callers can pass a std::vector<GattEntry>,
+// std::array, or a raw range constructed directly from
+// esp_gattc_db_elem_t[] (see the YAML conversion call site).
+template <typename Range>
+inline void extract_handles(const Range &entries, AppHandles &out) {
+  for (const auto &e : entries) {
+    if (!e.is_characteristic || !e.is_uuid128) continue;
+    switch (e.uuid_first_byte) {
+      case 0xD5:
+        if (out.d5 == 0) out.d5 = e.handle;
+        break;
+      case 0xD6:
+        if (out.d6 == 0) out.d6 = e.handle;
+        break;
+      case 0xD7:
+        if (out.d7 == 0) out.d7 = e.handle;
+        break;
+    }
+  }
+}
+
+}  // namespace subzero_protocol
+}  // namespace esphome

--- a/components/subzero_protocol/gatt_handles_esphome.h
+++ b/components/subzero_protocol/gatt_handles_esphome.h
@@ -1,0 +1,55 @@
+#pragma once
+
+// On-device wrapper that adapts esp_gattc_db_elem_t arrays directly to
+// the host-buildable extract_handles in gatt_handles.h.
+//
+// Lives in its own header (rather than gatt_handles.h) so the host gtest
+// build can include gatt_handles.h without needing ESP-IDF stubs.
+
+#include "esp_gattc_api.h"
+
+#include "gatt_handles.h"
+
+namespace esphome {
+namespace subzero_protocol {
+
+// Scan an IDF GATT db array (as returned by esp_ble_gattc_get_db) and
+// update the three handle globals in-place. Existing non-zero values
+// are preserved — calling this multiple times across discovery passes
+// is idempotent and additive.
+//
+// The signature takes int refs (rather than uint16_t) to match the YAML
+// globals' declared type — every `${prefix}_d*_handle` is `type: int`.
+inline void update_handles_from_db(const esp_gattc_db_elem_t *db,
+                                   std::uint16_t count,
+                                   int &d5_handle,
+                                   int &d6_handle,
+                                   int &d7_handle) {
+  AppHandles h;
+  h.d5 = static_cast<std::uint16_t>(d5_handle);
+  h.d6 = static_cast<std::uint16_t>(d6_handle);
+  h.d7 = static_cast<std::uint16_t>(d7_handle);
+  for (std::uint16_t i = 0; i < count; i++) {
+    const auto &e = db[i];
+    if (e.type != ESP_GATT_DB_CHARACTERISTIC) continue;
+    if (e.uuid.len != ESP_UUID_LEN_128) continue;
+    std::uint8_t suffix = e.uuid.uuid.uuid128[0];
+    switch (suffix) {
+      case 0xD5:
+        if (h.d5 == 0) h.d5 = e.attribute_handle;
+        break;
+      case 0xD6:
+        if (h.d6 == 0) h.d6 = e.attribute_handle;
+        break;
+      case 0xD7:
+        if (h.d7 == 0) h.d7 = e.attribute_handle;
+        break;
+    }
+  }
+  d5_handle = h.d5;
+  d6_handle = h.d6;
+  d7_handle = h.d7;
+}
+
+}  // namespace subzero_protocol
+}  // namespace esphome

--- a/components/subzero_protocol/gatt_handles_esphome.h
+++ b/components/subzero_protocol/gatt_handles_esphome.h
@@ -21,29 +21,32 @@ namespace subzero_protocol {
 // The signature takes int refs (rather than uint16_t) to match the YAML
 // globals' declared type — every `${prefix}_d*_handle` is `type: int`.
 inline void update_handles_from_db(const esp_gattc_db_elem_t *db,
-                                   std::uint16_t count,
-                                   int &d5_handle,
-                                   int &d6_handle,
-                                   int &d7_handle) {
+                                   std::uint16_t count, int &d5_handle,
+                                   int &d6_handle, int &d7_handle) {
   AppHandles h;
   h.d5 = static_cast<std::uint16_t>(d5_handle);
   h.d6 = static_cast<std::uint16_t>(d6_handle);
   h.d7 = static_cast<std::uint16_t>(d7_handle);
   for (std::uint16_t i = 0; i < count; i++) {
     const auto &e = db[i];
-    if (e.type != ESP_GATT_DB_CHARACTERISTIC) continue;
-    if (e.uuid.len != ESP_UUID_LEN_128) continue;
+    if (e.type != ESP_GATT_DB_CHARACTERISTIC)
+      continue;
+    if (e.uuid.len != ESP_UUID_LEN_128)
+      continue;
     std::uint8_t suffix = e.uuid.uuid.uuid128[0];
     switch (suffix) {
-      case 0xD5:
-        if (h.d5 == 0) h.d5 = e.attribute_handle;
-        break;
-      case 0xD6:
-        if (h.d6 == 0) h.d6 = e.attribute_handle;
-        break;
-      case 0xD7:
-        if (h.d7 == 0) h.d7 = e.attribute_handle;
-        break;
+    case 0xD5:
+      if (h.d5 == 0)
+        h.d5 = e.attribute_handle;
+      break;
+    case 0xD6:
+      if (h.d6 == 0)
+        h.d6 = e.attribute_handle;
+      break;
+    case 0xD7:
+      if (h.d7 == 0)
+        h.d7 = e.attribute_handle;
+      break;
     }
   }
   d5_handle = h.d5;
@@ -51,5 +54,5 @@ inline void update_handles_from_db(const esp_gattc_db_elem_t *db,
   d7_handle = h.d7;
 }
 
-}  // namespace subzero_protocol
-}  // namespace esphome
+} // namespace subzero_protocol
+} // namespace esphome

--- a/components/subzero_protocol/log_sanitize.h
+++ b/components/subzero_protocol/log_sanitize.h
@@ -26,7 +26,8 @@ namespace subzero_protocol {
 //
 // Defined inline (header-only): see buffer.h for rationale (avoid
 // tripping ESPHome's GLOB_RECURSE source-list cache).
-inline std::string sanitize_for_log(const std::string &s, std::size_t off, std::size_t len) {
+inline std::string sanitize_for_log(const std::string &s, std::size_t off,
+                                    std::size_t len) {
   if (off >= s.size()) {
     return std::string();
   }
@@ -51,7 +52,8 @@ inline std::string sanitize_for_log(const std::string &s, std::size_t off, std::
 // debug logging — grep `Response\[` and concatenate the chunks to
 // reassemble the raw payload.
 template <typename Cb>
-void chunk_for_log(const std::string &msg, Cb cb, std::size_t chunk_size = 400) {
+void chunk_for_log(const std::string &msg, Cb cb,
+                   std::size_t chunk_size = 400) {
   if (msg.empty() || chunk_size == 0) {
     return;
   }
@@ -63,5 +65,5 @@ void chunk_for_log(const std::string &msg, Cb cb, std::size_t chunk_size = 400) 
   }
 }
 
-}  // namespace subzero_protocol
-}  // namespace esphome
+} // namespace subzero_protocol
+} // namespace esphome

--- a/components/subzero_protocol/protocol.cpp
+++ b/components/subzero_protocol/protocol.cpp
@@ -4,316 +4,283 @@
 #include <cstdio>
 #include <cstring>
 
-namespace esphome
-{
-  namespace subzero_protocol
-  {
-    namespace
-    {
-      std::string trim(const std::string &s)
-      {
-        size_t start = s.find_first_not_of(" \t");
-        if (start == std::string::npos)
-          return "";
-        size_t end = s.find_last_not_of(" \t");
-        return s.substr(start, end - start + 1);
-      }
+namespace esphome {
+namespace subzero_protocol {
+namespace {
+std::string trim(const std::string &s) {
+  size_t start = s.find_first_not_of(" \t");
+  if (start == std::string::npos)
+    return "";
+  size_t end = s.find_last_not_of(" \t");
+  return s.substr(start, end - start + 1);
+}
 
-      std::optional<std::string> opt_str(JsonVariantConst v)
-      {
-        if (!v.is<const char *>())
-          return std::nullopt;
-        const char *s = v.as<const char *>();
-        return s ? std::optional<std::string>(s) : std::nullopt;
-      }
+std::optional<std::string> opt_str(JsonVariantConst v) {
+  if (!v.is<const char *>())
+    return std::nullopt;
+  const char *s = v.as<const char *>();
+  return s ? std::optional<std::string>(s) : std::nullopt;
+}
 
-      std::optional<bool> opt_bool(JsonVariantConst v)
-      {
-        if (!v.is<bool>())
-          return std::nullopt;
-        return v.as<bool>();
-      }
+std::optional<bool> opt_bool(JsonVariantConst v) {
+  if (!v.is<bool>())
+    return std::nullopt;
+  return v.as<bool>();
+}
 
-      std::optional<int> opt_int(JsonVariantConst v)
-      {
-        if (!v.is<int>())
-          return std::nullopt;
-        return v.as<int>();
-      }
+std::optional<int> opt_int(JsonVariantConst v) {
+  if (!v.is<int>())
+    return std::nullopt;
+  return v.as<int>();
+}
 
-      std::optional<float> opt_float(JsonVariantConst v)
-      {
-        if (!v.is<float>())
-          return std::nullopt;
-        return v.as<float>();
-      }
+std::optional<float> opt_float(JsonVariantConst v) {
+  if (!v.is<float>())
+    return std::nullopt;
+  return v.as<float>();
+}
 
-      // Returns the data object (resp for polls, props for pushes) and sets is_poll.
-      // Returns a null object if the format is unrecognized or status != 0.
-      void capture_keys(JsonObjectConst data, std::vector<std::string> &out)
-      {
-        for (JsonPairConst kv : data)
-        {
-          out.emplace_back(kv.key().c_str());
-        }
-      }
-
-      JsonObjectConst extract_data(JsonObjectConst root, bool &is_poll)
-      {
-        if (root["status"].is<int>())
-        {
-          if (root["status"].as<int>() != 0)
-            return JsonObjectConst();
-          is_poll = true;
-          return root["resp"].as<JsonObjectConst>();
-        }
-        if (root["props"].is<JsonObjectConst>())
-        {
-          is_poll = false;
-          return root["props"].as<JsonObjectConst>();
-        }
-        return JsonObjectConst();
-      }
-
-      void fill_version(JsonObjectConst v, Version &out)
-      {
-        out.fw = opt_str(v["fw"]);
-        out.api = opt_str(v["api"]);
-        out.bleapp = opt_str(v["bleapp"]);
-        out.os = opt_str(v["os"]);
-        out.rtapp = opt_str(v["rtapp"]);
-        out.appliance = opt_str(v["appliance"]);
-      }
-
-      void fill_common(JsonObjectConst data, CommonFields &out)
-      {
-        if (data["pin"].is<const char *>())
-        {
-          const char *pin = data["pin"].as<const char *>();
-          if (pin && std::strlen(pin) <= 10)
-          {
-            out.pin_confirmed = std::string(pin);
-          }
-        }
-        out.sabbath_on = opt_bool(data["sabbath_on"]);
-        out.service_required = opt_bool(data["service_required"]);
-        out.appliance_model = opt_str(data["appliance_model"]);
-        out.uptime = opt_str(data["uptime"]);
-        if (auto s = opt_str(data["appliance_serial"]))
-        {
-          out.appliance_serial = trim(*s);
-        }
-        out.appliance_type = opt_str(data["appliance_type"]);
-        out.diagnostic_status = opt_str(data["diagnostic_status"]);
-        if (data["version"].is<JsonObjectConst>())
-        {
-          fill_version(data["version"].as<JsonObjectConst>(), out.version);
-        }
-        if (data["build_info"].is<JsonObjectConst>())
-        {
-          auto bi = data["build_info"].as<JsonObjectConst>();
-          out.build_date = opt_str(bi["build_date"]);
-        }
-      }
-
-      // Minutes between two ISO-8601 timestamps ("YYYY-MM-DDTHH:MM[:SS...]").
-      // Returns nullopt if either string can't be parsed. Uses day-of-month math,
-      // which matches the legacy lambda behavior (adequate for wash cycles under
-      // a month). Same-month assumption.
-      std::optional<int> minutes_between(const char *now_iso, const std::string &end_iso)
-      {
-        if (end_iso.size() < 16)
-          return std::nullopt;
-        int ey, emo, ed, eh, emi;
-        if (std::sscanf(end_iso.c_str(), "%d-%d-%dT%d:%d", &ey, &emo, &ed, &eh, &emi) != 5)
-        {
-          return std::nullopt;
-        }
-        int cy, cmo, cd, ch, cmi, cs = 0;
-        if (std::sscanf(now_iso, "%d-%d-%dT%d:%d:%d", &cy, &cmo, &cd, &ch, &cmi, &cs) < 5)
-        {
-          return std::nullopt;
-        }
-        int end_mins = (ed * 24 * 60) + (eh * 60) + emi;
-        int cur_mins = (cd * 24 * 60) + (ch * 60) + cmi;
-        int remaining = end_mins - cur_mins;
-        return remaining < 0 ? 0 : remaining;
-      }
-
-    } // namespace
-
-    FridgeState parse_fridge(const std::string &json)
-    {
-      FridgeState state;
-      JsonDocument doc;
-      if (deserializeJson(doc, json))
-        return state;
-      if (!doc.is<JsonObject>())
-        return state;
-      bool is_poll = true;
-      JsonObjectConst data = extract_data(doc.as<JsonObjectConst>(), is_poll);
-      if (data.isNull())
-        return state;
-      state.valid = true;
-      state.is_poll = is_poll;
-      capture_keys(data, state.data_keys);
-      fill_common(data, state.common);
-
-      // Setpoint with freezer-only fallback.
-      if (data["ref_set_temp"].is<float>())
-      {
-        state.ref_set_temp = data["ref_set_temp"].as<float>();
-      }
-      else if (data["frz_set_temp"].is<float>())
-      {
-        state.ref_set_temp = data["frz_set_temp"].as<float>();
-      }
-      // Door with generic fallback.
-      if (data["ref_door_ajar"].is<bool>())
-      {
-        state.door_ajar = data["ref_door_ajar"].as<bool>();
-      }
-      else if (data["door_ajar"].is<bool>())
-      {
-        state.door_ajar = data["door_ajar"].as<bool>();
-      }
-      state.frz_set_temp = opt_float(data["frz_set_temp"]);
-      state.frz_door_ajar = opt_bool(data["frz_door_ajar"]);
-      state.ice_maker_on = opt_bool(data["ice_maker_on"]);
-      state.ref2_set_temp = opt_float(data["ref2_set_temp"]);
-      state.ref2_door_ajar = opt_bool(data["ref2_door_ajar"]);
-      state.wine_door_ajar = opt_bool(data["wine_door_ajar"]);
-      state.wine_set_temp = opt_float(data["wine_set_temp"]);
-      state.wine2_set_temp = opt_float(data["wine2_set_temp"]);
-      state.wine_temp_alert_on = opt_bool(data["wine_temp_alert_on"]);
-      state.crisp_set_temp = opt_float(data["crisp_set_temp"]);
-      state.air_filter_on = opt_bool(data["air_filter_on"]);
-      state.air_filter_pct_remaining = opt_float(data["air_filter_pct_remaining"]);
-      state.water_filter_pct_remaining = opt_float(data["water_filter_pct_remaining"]);
-      return state;
-    }
-
-    DishwasherState parse_dishwasher(const std::string &json)
-    {
-      DishwasherState state;
-      JsonDocument doc;
-      if (deserializeJson(doc, json))
-        return state;
-      if (!doc.is<JsonObject>())
-        return state;
-      bool is_poll = true;
-      JsonObjectConst root = doc.as<JsonObjectConst>();
-      JsonObjectConst data = extract_data(root, is_poll);
-      if (data.isNull())
-        return state;
-      state.valid = true;
-      state.is_poll = is_poll;
-      capture_keys(data, state.data_keys);
-      fill_common(data, state.common);
-
-      state.door_ajar = opt_bool(data["door_ajar"]);
-      state.wash_cycle_on = opt_bool(data["wash_cycle_on"]);
-      state.heated_dry_on = opt_bool(data["heated_dry_on"]);
-      state.extended_dry_on = opt_bool(data["extended_dry_on"]);
-      state.high_temp_wash_on = opt_bool(data["high_temp_wash_on"]);
-      state.sani_rinse_on = opt_bool(data["sani_rinse_on"]);
-      state.rinse_aid_low = opt_bool(data["rinse_aid_low"]);
-      state.softener_low = opt_bool(data["softener_low"]);
-      state.light_on = opt_bool(data["light_on"]);
-      state.remote_ready = opt_bool(data["remote_ready"]);
-      state.delay_start_timer_active = opt_bool(data["delay_start_timer_active"]);
-      state.wash_status = opt_int(data["wash_status"]);
-      state.wash_cycle = opt_int(data["wash_cycle"]);
-      state.wash_cycle_end_time = opt_str(data["wash_cycle_end_time"]);
-
-      if (state.wash_cycle_end_time)
-      {
-        const char *now_iso = nullptr;
-        if (root["timestamp"].is<const char *>())
-        {
-          now_iso = root["timestamp"].as<const char *>();
-        }
-        else if (is_poll && data["time"].is<const char *>())
-        {
-          now_iso = data["time"].as<const char *>();
-        }
-        if (now_iso)
-        {
-          state.wash_time_remaining_min = minutes_between(now_iso, *state.wash_cycle_end_time);
-        }
-      }
-      return state;
-    }
-
-    RangeState parse_range(const std::string &json)
-    {
-      RangeState state;
-      JsonDocument doc;
-      if (deserializeJson(doc, json))
-        return state;
-      if (!doc.is<JsonObject>())
-        return state;
-      bool is_poll = true;
-      JsonObjectConst data = extract_data(doc.as<JsonObjectConst>(), is_poll);
-      if (data.isNull())
-        return state;
-      state.valid = true;
-      state.is_poll = is_poll;
-      capture_keys(data, state.data_keys);
-      fill_common(data, state.common);
-
-      // Door with generic fallback.
-      if (data["cav_door_ajar"].is<bool>())
-      {
-        state.door_ajar = data["cav_door_ajar"].as<bool>();
-      }
-      else if (data["door_ajar"].is<bool>())
-      {
-        state.door_ajar = data["door_ajar"].as<bool>();
-      }
-
-      state.cav_unit_on = opt_bool(data["cav_unit_on"]);
-      state.cav_at_set_temp = opt_bool(data["cav_at_set_temp"]);
-      state.cav_light_on = opt_bool(data["cav_light_on"]);
-      state.cav_remote_ready = opt_bool(data["cav_remote_ready"]);
-      state.cav_probe_on = opt_bool(data["cav_probe_on"]);
-      state.cav_probe_at_set_temp = opt_bool(data["cav_probe_at_set_temp"]);
-      state.cav_probe_within_10deg = opt_bool(data["cav_probe_within_10deg"]);
-      state.cav_gourmet_mode_on = opt_bool(data["cav_gourmet_mode_on"]);
-      state.cav_gourmet_recipe = opt_int(data["cav_gourmet_recipe"]);
-      state.cav_cook_timer_complete = opt_bool(data["cav_cook_timer_complete"]);
-      state.cav_cook_timer_within_1min = opt_bool(data["cav_cook_timer_within_1min"]);
-      state.cav_temp = opt_float(data["cav_temp"]);
-      state.cav_set_temp = opt_float(data["cav_set_temp"]);
-      state.cav_cook_mode = opt_int(data["cav_cook_mode"]);
-      state.cav_probe_temp = opt_float(data["cav_probe_temp"]);
-      state.cav_probe_set_temp = opt_float(data["cav_probe_set_temp"]);
-
-      state.kitchen_timer_active = opt_bool(data["kitchen_timer_active"]);
-      state.kitchen_timer_complete = opt_bool(data["kitchen_timer_complete"]);
-      state.kitchen_timer_within_1min = opt_bool(data["kitchen_timer_within_1min"]);
-      state.kitchen_timer_end_time = opt_str(data["kitchen_timer_end_time"]);
-      state.kitchen_timer2_active = opt_bool(data["kitchen_timer2_active"]);
-      state.kitchen_timer2_complete = opt_bool(data["kitchen_timer2_complete"]);
-      state.kitchen_timer2_within_1min = opt_bool(data["kitchen_timer2_within_1min"]);
-      state.kitchen_timer2_end_time = opt_str(data["kitchen_timer2_end_time"]);
-
-      state.cav2_unit_on = opt_bool(data["cav2_unit_on"]);
-      state.cav2_door_ajar = opt_bool(data["cav2_door_ajar"]);
-      state.cav2_at_set_temp = opt_bool(data["cav2_at_set_temp"]);
-      state.cav2_light_on = opt_bool(data["cav2_light_on"]);
-      state.cav2_remote_ready = opt_bool(data["cav2_remote_ready"]);
-      state.cav2_probe_on = opt_bool(data["cav2_probe_on"]);
-      state.cav2_probe_at_set_temp = opt_bool(data["cav2_probe_at_set_temp"]);
-      state.cav2_probe_within_10deg = opt_bool(data["cav2_probe_within_10deg"]);
-      state.cav2_gourmet_mode_on = opt_bool(data["cav2_gourmet_mode_on"]);
-      state.cav2_cook_timer_complete = opt_bool(data["cav2_cook_timer_complete"]);
-      state.cav2_temp = opt_float(data["cav2_temp"]);
-      state.cav2_set_temp = opt_float(data["cav2_set_temp"]);
-      state.cav2_cook_mode = opt_int(data["cav2_cook_mode"]);
-      state.cav2_probe_temp = opt_float(data["cav2_probe_temp"]);
-      state.cav2_probe_set_temp = opt_float(data["cav2_probe_set_temp"]);
-      return state;
-    }
+// Returns the data object (resp for polls, props for pushes) and sets is_poll.
+// Returns a null object if the format is unrecognized or status != 0.
+void capture_keys(JsonObjectConst data, std::vector<std::string> &out) {
+  for (JsonPairConst kv : data) {
+    out.emplace_back(kv.key().c_str());
   }
 }
+
+JsonObjectConst extract_data(JsonObjectConst root, bool &is_poll) {
+  if (root["status"].is<int>()) {
+    if (root["status"].as<int>() != 0)
+      return JsonObjectConst();
+    is_poll = true;
+    return root["resp"].as<JsonObjectConst>();
+  }
+  if (root["props"].is<JsonObjectConst>()) {
+    is_poll = false;
+    return root["props"].as<JsonObjectConst>();
+  }
+  return JsonObjectConst();
+}
+
+void fill_version(JsonObjectConst v, Version &out) {
+  out.fw = opt_str(v["fw"]);
+  out.api = opt_str(v["api"]);
+  out.bleapp = opt_str(v["bleapp"]);
+  out.os = opt_str(v["os"]);
+  out.rtapp = opt_str(v["rtapp"]);
+  out.appliance = opt_str(v["appliance"]);
+}
+
+void fill_common(JsonObjectConst data, CommonFields &out) {
+  if (data["pin"].is<const char *>()) {
+    const char *pin = data["pin"].as<const char *>();
+    if (pin && std::strlen(pin) <= 10) {
+      out.pin_confirmed = std::string(pin);
+    }
+  }
+  out.sabbath_on = opt_bool(data["sabbath_on"]);
+  out.service_required = opt_bool(data["service_required"]);
+  out.appliance_model = opt_str(data["appliance_model"]);
+  out.uptime = opt_str(data["uptime"]);
+  if (auto s = opt_str(data["appliance_serial"])) {
+    out.appliance_serial = trim(*s);
+  }
+  out.appliance_type = opt_str(data["appliance_type"]);
+  out.diagnostic_status = opt_str(data["diagnostic_status"]);
+  if (data["version"].is<JsonObjectConst>()) {
+    fill_version(data["version"].as<JsonObjectConst>(), out.version);
+  }
+  if (data["build_info"].is<JsonObjectConst>()) {
+    auto bi = data["build_info"].as<JsonObjectConst>();
+    out.build_date = opt_str(bi["build_date"]);
+  }
+}
+
+// Minutes between two ISO-8601 timestamps ("YYYY-MM-DDTHH:MM[:SS...]").
+// Returns nullopt if either string can't be parsed. Uses day-of-month math,
+// which matches the legacy lambda behavior (adequate for wash cycles under
+// a month). Same-month assumption.
+std::optional<int> minutes_between(const char *now_iso,
+                                   const std::string &end_iso) {
+  if (end_iso.size() < 16)
+    return std::nullopt;
+  int ey, emo, ed, eh, emi;
+  if (std::sscanf(end_iso.c_str(), "%d-%d-%dT%d:%d", &ey, &emo, &ed, &eh,
+                  &emi) != 5) {
+    return std::nullopt;
+  }
+  int cy, cmo, cd, ch, cmi, cs = 0;
+  if (std::sscanf(now_iso, "%d-%d-%dT%d:%d:%d", &cy, &cmo, &cd, &ch, &cmi,
+                  &cs) < 5) {
+    return std::nullopt;
+  }
+  int end_mins = (ed * 24 * 60) + (eh * 60) + emi;
+  int cur_mins = (cd * 24 * 60) + (ch * 60) + cmi;
+  int remaining = end_mins - cur_mins;
+  return remaining < 0 ? 0 : remaining;
+}
+
+} // namespace
+
+FridgeState parse_fridge(const std::string &json) {
+  FridgeState state;
+  JsonDocument doc;
+  if (deserializeJson(doc, json))
+    return state;
+  if (!doc.is<JsonObject>())
+    return state;
+  bool is_poll = true;
+  JsonObjectConst data = extract_data(doc.as<JsonObjectConst>(), is_poll);
+  if (data.isNull())
+    return state;
+  state.valid = true;
+  state.is_poll = is_poll;
+  capture_keys(data, state.data_keys);
+  fill_common(data, state.common);
+
+  // Setpoint with freezer-only fallback.
+  if (data["ref_set_temp"].is<float>()) {
+    state.ref_set_temp = data["ref_set_temp"].as<float>();
+  } else if (data["frz_set_temp"].is<float>()) {
+    state.ref_set_temp = data["frz_set_temp"].as<float>();
+  }
+  // Door with generic fallback.
+  if (data["ref_door_ajar"].is<bool>()) {
+    state.door_ajar = data["ref_door_ajar"].as<bool>();
+  } else if (data["door_ajar"].is<bool>()) {
+    state.door_ajar = data["door_ajar"].as<bool>();
+  }
+  state.frz_set_temp = opt_float(data["frz_set_temp"]);
+  state.frz_door_ajar = opt_bool(data["frz_door_ajar"]);
+  state.ice_maker_on = opt_bool(data["ice_maker_on"]);
+  state.ref2_set_temp = opt_float(data["ref2_set_temp"]);
+  state.ref2_door_ajar = opt_bool(data["ref2_door_ajar"]);
+  state.wine_door_ajar = opt_bool(data["wine_door_ajar"]);
+  state.wine_set_temp = opt_float(data["wine_set_temp"]);
+  state.wine2_set_temp = opt_float(data["wine2_set_temp"]);
+  state.wine_temp_alert_on = opt_bool(data["wine_temp_alert_on"]);
+  state.crisp_set_temp = opt_float(data["crisp_set_temp"]);
+  state.air_filter_on = opt_bool(data["air_filter_on"]);
+  state.air_filter_pct_remaining = opt_float(data["air_filter_pct_remaining"]);
+  state.water_filter_pct_remaining =
+      opt_float(data["water_filter_pct_remaining"]);
+  return state;
+}
+
+DishwasherState parse_dishwasher(const std::string &json) {
+  DishwasherState state;
+  JsonDocument doc;
+  if (deserializeJson(doc, json))
+    return state;
+  if (!doc.is<JsonObject>())
+    return state;
+  bool is_poll = true;
+  JsonObjectConst root = doc.as<JsonObjectConst>();
+  JsonObjectConst data = extract_data(root, is_poll);
+  if (data.isNull())
+    return state;
+  state.valid = true;
+  state.is_poll = is_poll;
+  capture_keys(data, state.data_keys);
+  fill_common(data, state.common);
+
+  state.door_ajar = opt_bool(data["door_ajar"]);
+  state.wash_cycle_on = opt_bool(data["wash_cycle_on"]);
+  state.heated_dry_on = opt_bool(data["heated_dry_on"]);
+  state.extended_dry_on = opt_bool(data["extended_dry_on"]);
+  state.high_temp_wash_on = opt_bool(data["high_temp_wash_on"]);
+  state.sani_rinse_on = opt_bool(data["sani_rinse_on"]);
+  state.rinse_aid_low = opt_bool(data["rinse_aid_low"]);
+  state.softener_low = opt_bool(data["softener_low"]);
+  state.light_on = opt_bool(data["light_on"]);
+  state.remote_ready = opt_bool(data["remote_ready"]);
+  state.delay_start_timer_active = opt_bool(data["delay_start_timer_active"]);
+  state.wash_status = opt_int(data["wash_status"]);
+  state.wash_cycle = opt_int(data["wash_cycle"]);
+  state.wash_cycle_end_time = opt_str(data["wash_cycle_end_time"]);
+
+  if (state.wash_cycle_end_time) {
+    const char *now_iso = nullptr;
+    if (root["timestamp"].is<const char *>()) {
+      now_iso = root["timestamp"].as<const char *>();
+    } else if (is_poll && data["time"].is<const char *>()) {
+      now_iso = data["time"].as<const char *>();
+    }
+    if (now_iso) {
+      state.wash_time_remaining_min =
+          minutes_between(now_iso, *state.wash_cycle_end_time);
+    }
+  }
+  return state;
+}
+
+RangeState parse_range(const std::string &json) {
+  RangeState state;
+  JsonDocument doc;
+  if (deserializeJson(doc, json))
+    return state;
+  if (!doc.is<JsonObject>())
+    return state;
+  bool is_poll = true;
+  JsonObjectConst data = extract_data(doc.as<JsonObjectConst>(), is_poll);
+  if (data.isNull())
+    return state;
+  state.valid = true;
+  state.is_poll = is_poll;
+  capture_keys(data, state.data_keys);
+  fill_common(data, state.common);
+
+  // Door with generic fallback.
+  if (data["cav_door_ajar"].is<bool>()) {
+    state.door_ajar = data["cav_door_ajar"].as<bool>();
+  } else if (data["door_ajar"].is<bool>()) {
+    state.door_ajar = data["door_ajar"].as<bool>();
+  }
+
+  state.cav_unit_on = opt_bool(data["cav_unit_on"]);
+  state.cav_at_set_temp = opt_bool(data["cav_at_set_temp"]);
+  state.cav_light_on = opt_bool(data["cav_light_on"]);
+  state.cav_remote_ready = opt_bool(data["cav_remote_ready"]);
+  state.cav_probe_on = opt_bool(data["cav_probe_on"]);
+  state.cav_probe_at_set_temp = opt_bool(data["cav_probe_at_set_temp"]);
+  state.cav_probe_within_10deg = opt_bool(data["cav_probe_within_10deg"]);
+  state.cav_gourmet_mode_on = opt_bool(data["cav_gourmet_mode_on"]);
+  state.cav_gourmet_recipe = opt_int(data["cav_gourmet_recipe"]);
+  state.cav_cook_timer_complete = opt_bool(data["cav_cook_timer_complete"]);
+  state.cav_cook_timer_within_1min =
+      opt_bool(data["cav_cook_timer_within_1min"]);
+  state.cav_temp = opt_float(data["cav_temp"]);
+  state.cav_set_temp = opt_float(data["cav_set_temp"]);
+  state.cav_cook_mode = opt_int(data["cav_cook_mode"]);
+  state.cav_probe_temp = opt_float(data["cav_probe_temp"]);
+  state.cav_probe_set_temp = opt_float(data["cav_probe_set_temp"]);
+
+  state.kitchen_timer_active = opt_bool(data["kitchen_timer_active"]);
+  state.kitchen_timer_complete = opt_bool(data["kitchen_timer_complete"]);
+  state.kitchen_timer_within_1min = opt_bool(data["kitchen_timer_within_1min"]);
+  state.kitchen_timer_end_time = opt_str(data["kitchen_timer_end_time"]);
+  state.kitchen_timer2_active = opt_bool(data["kitchen_timer2_active"]);
+  state.kitchen_timer2_complete = opt_bool(data["kitchen_timer2_complete"]);
+  state.kitchen_timer2_within_1min =
+      opt_bool(data["kitchen_timer2_within_1min"]);
+  state.kitchen_timer2_end_time = opt_str(data["kitchen_timer2_end_time"]);
+
+  state.cav2_unit_on = opt_bool(data["cav2_unit_on"]);
+  state.cav2_door_ajar = opt_bool(data["cav2_door_ajar"]);
+  state.cav2_at_set_temp = opt_bool(data["cav2_at_set_temp"]);
+  state.cav2_light_on = opt_bool(data["cav2_light_on"]);
+  state.cav2_remote_ready = opt_bool(data["cav2_remote_ready"]);
+  state.cav2_probe_on = opt_bool(data["cav2_probe_on"]);
+  state.cav2_probe_at_set_temp = opt_bool(data["cav2_probe_at_set_temp"]);
+  state.cav2_probe_within_10deg = opt_bool(data["cav2_probe_within_10deg"]);
+  state.cav2_gourmet_mode_on = opt_bool(data["cav2_gourmet_mode_on"]);
+  state.cav2_cook_timer_complete = opt_bool(data["cav2_cook_timer_complete"]);
+  state.cav2_temp = opt_float(data["cav2_temp"]);
+  state.cav2_set_temp = opt_float(data["cav2_set_temp"]);
+  state.cav2_cook_mode = opt_int(data["cav2_cook_mode"]);
+  state.cav2_probe_temp = opt_float(data["cav2_probe_temp"]);
+  state.cav2_probe_set_temp = opt_float(data["cav2_probe_set_temp"]);
+  return state;
+}
+} // namespace subzero_protocol
+} // namespace esphome

--- a/components/subzero_protocol/protocol.h
+++ b/components/subzero_protocol/protocol.h
@@ -4,140 +4,133 @@
 #include <string>
 #include <vector>
 
-namespace esphome
-{
-  namespace subzero_protocol
-  {
-    struct Version
-    {
-      std::optional<std::string> fw;
-      std::optional<std::string> api;
-      std::optional<std::string> bleapp;
-      std::optional<std::string> os;
-      std::optional<std::string> rtapp;
-      std::optional<std::string> appliance;
-    };
+namespace esphome {
+namespace subzero_protocol {
+struct Version {
+  std::optional<std::string> fw;
+  std::optional<std::string> api;
+  std::optional<std::string> bleapp;
+  std::optional<std::string> os;
+  std::optional<std::string> rtapp;
+  std::optional<std::string> appliance;
+};
 
-    struct CommonFields
-    {
-      std::optional<std::string> pin_confirmed;
-      std::optional<bool> sabbath_on;
-      std::optional<bool> service_required;
-      std::optional<std::string> appliance_model;
-      std::optional<std::string> uptime;
-      std::optional<std::string> appliance_serial;
-      std::optional<std::string> appliance_type;
-      std::optional<std::string> diagnostic_status;
-      std::optional<std::string> build_date;
-      Version version;
-    };
+struct CommonFields {
+  std::optional<std::string> pin_confirmed;
+  std::optional<bool> sabbath_on;
+  std::optional<bool> service_required;
+  std::optional<std::string> appliance_model;
+  std::optional<std::string> uptime;
+  std::optional<std::string> appliance_serial;
+  std::optional<std::string> appliance_type;
+  std::optional<std::string> diagnostic_status;
+  std::optional<std::string> build_date;
+  Version version;
+};
 
-    struct FridgeState
-    {
-      bool valid = false;
-      // true = full poll response (status/resp); false = push notification (seq/props).
-      // Used by the lambdas to distinguish "my poll got a response" from "an unrelated
-      // push arrived" — critical for detecting unlock-session expiry where polls stop
-      // responding but pushes keep flowing.
-      bool is_poll = false;
-      // Top-level keys present in the data object (resp or props), in order.
-      // Populated on every parse; the lambdas log these when debug mode is on.
-      std::vector<std::string> data_keys;
-      CommonFields common;
-      std::optional<float> ref_set_temp;
-      std::optional<bool> door_ajar;
-      std::optional<float> frz_set_temp;
-      std::optional<bool> frz_door_ajar;
-      std::optional<bool> ice_maker_on;
-      std::optional<float> ref2_set_temp;
-      std::optional<bool> ref2_door_ajar;
-      std::optional<bool> wine_door_ajar;
-      std::optional<float> wine_set_temp;
-      std::optional<float> wine2_set_temp;
-      std::optional<bool> wine_temp_alert_on;
-      std::optional<float> crisp_set_temp;
-      std::optional<bool> air_filter_on;
-      std::optional<float> air_filter_pct_remaining;
-      std::optional<float> water_filter_pct_remaining;
-    };
+struct FridgeState {
+  bool valid = false;
+  // true = full poll response (status/resp); false = push notification
+  // (seq/props). Used by the lambdas to distinguish "my poll got a response"
+  // from "an unrelated push arrived" — critical for detecting unlock-session
+  // expiry where polls stop responding but pushes keep flowing.
+  bool is_poll = false;
+  // Top-level keys present in the data object (resp or props), in order.
+  // Populated on every parse; the lambdas log these when debug mode is on.
+  std::vector<std::string> data_keys;
+  CommonFields common;
+  std::optional<float> ref_set_temp;
+  std::optional<bool> door_ajar;
+  std::optional<float> frz_set_temp;
+  std::optional<bool> frz_door_ajar;
+  std::optional<bool> ice_maker_on;
+  std::optional<float> ref2_set_temp;
+  std::optional<bool> ref2_door_ajar;
+  std::optional<bool> wine_door_ajar;
+  std::optional<float> wine_set_temp;
+  std::optional<float> wine2_set_temp;
+  std::optional<bool> wine_temp_alert_on;
+  std::optional<float> crisp_set_temp;
+  std::optional<bool> air_filter_on;
+  std::optional<float> air_filter_pct_remaining;
+  std::optional<float> water_filter_pct_remaining;
+};
 
-    struct DishwasherState
-    {
-      bool valid = false;
-      bool is_poll = false;
-      std::vector<std::string> data_keys;
-      CommonFields common;
-      std::optional<bool> door_ajar;
-      std::optional<bool> wash_cycle_on;
-      std::optional<bool> heated_dry_on;
-      std::optional<bool> extended_dry_on;
-      std::optional<bool> high_temp_wash_on;
-      std::optional<bool> sani_rinse_on;
-      std::optional<bool> rinse_aid_low;
-      std::optional<bool> softener_low;
-      std::optional<bool> light_on;
-      std::optional<bool> remote_ready;
-      std::optional<bool> delay_start_timer_active;
-      std::optional<int> wash_status;
-      std::optional<int> wash_cycle;
-      std::optional<std::string> wash_cycle_end_time;
-      std::optional<int> wash_time_remaining_min;
-    };
+struct DishwasherState {
+  bool valid = false;
+  bool is_poll = false;
+  std::vector<std::string> data_keys;
+  CommonFields common;
+  std::optional<bool> door_ajar;
+  std::optional<bool> wash_cycle_on;
+  std::optional<bool> heated_dry_on;
+  std::optional<bool> extended_dry_on;
+  std::optional<bool> high_temp_wash_on;
+  std::optional<bool> sani_rinse_on;
+  std::optional<bool> rinse_aid_low;
+  std::optional<bool> softener_low;
+  std::optional<bool> light_on;
+  std::optional<bool> remote_ready;
+  std::optional<bool> delay_start_timer_active;
+  std::optional<int> wash_status;
+  std::optional<int> wash_cycle;
+  std::optional<std::string> wash_cycle_end_time;
+  std::optional<int> wash_time_remaining_min;
+};
 
-    struct RangeState
-    {
-      bool valid = false;
-      bool is_poll = false;
-      std::vector<std::string> data_keys;
-      CommonFields common;
-      std::optional<bool> door_ajar;
+struct RangeState {
+  bool valid = false;
+  bool is_poll = false;
+  std::vector<std::string> data_keys;
+  CommonFields common;
+  std::optional<bool> door_ajar;
 
-      std::optional<bool> cav_unit_on;
-      std::optional<bool> cav_at_set_temp;
-      std::optional<bool> cav_light_on;
-      std::optional<bool> cav_remote_ready;
-      std::optional<bool> cav_probe_on;
-      std::optional<bool> cav_probe_at_set_temp;
-      std::optional<bool> cav_probe_within_10deg;
-      std::optional<bool> cav_gourmet_mode_on;
-      std::optional<int> cav_gourmet_recipe;
-      std::optional<bool> cav_cook_timer_complete;
-      std::optional<bool> cav_cook_timer_within_1min;
-      std::optional<float> cav_temp;
-      std::optional<float> cav_set_temp;
-      std::optional<int> cav_cook_mode;
-      std::optional<float> cav_probe_temp;
-      std::optional<float> cav_probe_set_temp;
+  std::optional<bool> cav_unit_on;
+  std::optional<bool> cav_at_set_temp;
+  std::optional<bool> cav_light_on;
+  std::optional<bool> cav_remote_ready;
+  std::optional<bool> cav_probe_on;
+  std::optional<bool> cav_probe_at_set_temp;
+  std::optional<bool> cav_probe_within_10deg;
+  std::optional<bool> cav_gourmet_mode_on;
+  std::optional<int> cav_gourmet_recipe;
+  std::optional<bool> cav_cook_timer_complete;
+  std::optional<bool> cav_cook_timer_within_1min;
+  std::optional<float> cav_temp;
+  std::optional<float> cav_set_temp;
+  std::optional<int> cav_cook_mode;
+  std::optional<float> cav_probe_temp;
+  std::optional<float> cav_probe_set_temp;
 
-      std::optional<bool> kitchen_timer_active;
-      std::optional<bool> kitchen_timer_complete;
-      std::optional<bool> kitchen_timer_within_1min;
-      std::optional<std::string> kitchen_timer_end_time;
-      std::optional<bool> kitchen_timer2_active;
-      std::optional<bool> kitchen_timer2_complete;
-      std::optional<bool> kitchen_timer2_within_1min;
-      std::optional<std::string> kitchen_timer2_end_time;
+  std::optional<bool> kitchen_timer_active;
+  std::optional<bool> kitchen_timer_complete;
+  std::optional<bool> kitchen_timer_within_1min;
+  std::optional<std::string> kitchen_timer_end_time;
+  std::optional<bool> kitchen_timer2_active;
+  std::optional<bool> kitchen_timer2_complete;
+  std::optional<bool> kitchen_timer2_within_1min;
+  std::optional<std::string> kitchen_timer2_end_time;
 
-      std::optional<bool> cav2_unit_on;
-      std::optional<bool> cav2_door_ajar;
-      std::optional<bool> cav2_at_set_temp;
-      std::optional<bool> cav2_light_on;
-      std::optional<bool> cav2_remote_ready;
-      std::optional<bool> cav2_probe_on;
-      std::optional<bool> cav2_probe_at_set_temp;
-      std::optional<bool> cav2_probe_within_10deg;
-      std::optional<bool> cav2_gourmet_mode_on;
-      std::optional<bool> cav2_cook_timer_complete;
-      std::optional<float> cav2_temp;
-      std::optional<float> cav2_set_temp;
-      std::optional<int> cav2_cook_mode;
-      std::optional<float> cav2_probe_temp;
-      std::optional<float> cav2_probe_set_temp;
-    };
+  std::optional<bool> cav2_unit_on;
+  std::optional<bool> cav2_door_ajar;
+  std::optional<bool> cav2_at_set_temp;
+  std::optional<bool> cav2_light_on;
+  std::optional<bool> cav2_remote_ready;
+  std::optional<bool> cav2_probe_on;
+  std::optional<bool> cav2_probe_at_set_temp;
+  std::optional<bool> cav2_probe_within_10deg;
+  std::optional<bool> cav2_gourmet_mode_on;
+  std::optional<bool> cav2_cook_timer_complete;
+  std::optional<float> cav2_temp;
+  std::optional<float> cav2_set_temp;
+  std::optional<int> cav2_cook_mode;
+  std::optional<float> cav2_probe_temp;
+  std::optional<float> cav2_probe_set_temp;
+};
 
-    FridgeState parse_fridge(const std::string &json);
-    DishwasherState parse_dishwasher(const std::string &json);
-    RangeState parse_range(const std::string &json);
+FridgeState parse_fridge(const std::string &json);
+DishwasherState parse_dishwasher(const std::string &json);
+RangeState parse_range(const std::string &json);
 
-  }
-}
+} // namespace subzero_protocol
+} // namespace esphome

--- a/subzero_base.yaml
+++ b/subzero_base.yaml
@@ -345,7 +345,7 @@ button:
             return;
           }
           auto *client = id(${prefix}_appliance);
-          std::string cmd = "{\"cmd\":\"display_pin\",\"params\":{\"duration\": 30}}\n";
+          std::string cmd = esphome::subzero_protocol::build_display_pin();
           esp_err_t err = esp_ble_gattc_write_char(
             client->get_gattc_if(), client->get_conn_id(),
             d5, cmd.size(), (uint8_t*)cmd.data(),
@@ -369,7 +369,7 @@ button:
             return;
           }
           auto *client = id(${prefix}_appliance);
-          std::string cmd = "{\"cmd\":\"unlock_channel\",\"params\":{\"pin\":\"" + pin + "\"}}\n";
+          std::string cmd = esphome::subzero_protocol::build_unlock_channel(pin);
           esp_err_t err = esp_ble_gattc_write_char(
             client->get_gattc_if(), client->get_conn_id(),
             d5, cmd.size(), (uint8_t*)cmd.data(),
@@ -381,7 +381,7 @@ button:
           uint16_t d5 = id(${prefix}_d5_handle);
           if (d5 == 0) return;
           auto *client = id(${prefix}_appliance);
-          std::string cmd = "{\"cmd\":\"get_async\"}\n";
+          std::string cmd = esphome::subzero_protocol::build_get_async();
           esp_ble_gattc_write_char(
             client->get_gattc_if(), client->get_conn_id(),
             d5, cmd.size(), (uint8_t*)cmd.data(),
@@ -401,13 +401,13 @@ button:
           // Re-unlock D6 first (session may have expired since last poll).
           std::string pin = id(${prefix}_stored_pin);
           if (!pin.empty()) {
-            std::string unlock = "{\"cmd\":\"unlock_channel\",\"params\":{\"pin\":\"" + pin + "\"}}\n";
+            std::string unlock = esphome::subzero_protocol::build_unlock_channel(pin);
             esp_ble_gattc_write_char(
               client->get_gattc_if(), client->get_conn_id(),
               d6, unlock.size(), (uint8_t*)unlock.data(),
               ESP_GATT_WRITE_TYPE_RSP, ESP_GATT_AUTH_REQ_NONE);
           }
-          std::string cmd = "{\"cmd\":\"get_async\"}\n";
+          std::string cmd = esphome::subzero_protocol::build_get_async();
           esp_ble_gattc_write_char(
             client->get_gattc_if(), client->get_conn_id(),
             d6, cmd.size(), (uint8_t*)cmd.data(),
@@ -549,13 +549,13 @@ script:
           // is accepted (status 0) but produces no indication response.
           std::string pin = id(${prefix}_stored_pin);
           if (!pin.empty()) {
-            std::string unlock_cmd = "{\"cmd\":\"unlock_channel\",\"params\":{\"pin\":\"" + pin + "\"}}\n";
+            std::string unlock_cmd = esphome::subzero_protocol::build_unlock_channel(pin);
             esp_ble_gattc_write_char(
               client->get_gattc_if(), client->get_conn_id(),
               d6, unlock_cmd.size(), (uint8_t*)unlock_cmd.data(),
               ESP_GATT_WRITE_TYPE_RSP, ESP_GATT_AUTH_REQ_NONE);
           }
-          std::string cmd = "{\"cmd\":\"get_async\"}\n";
+          std::string cmd = esphome::subzero_protocol::build_get_async();
           esp_err_t err = esp_ble_gattc_write_char(
             client->get_gattc_if(), client->get_conn_id(),
             d6, cmd.size(), (uint8_t*)cmd.data(),
@@ -597,6 +597,9 @@ script:
             0x0001, 0xFFFF, db, &count);
           ESP_LOGI("poll", "[${appliance_name}] Initial get_db: err=%d count=%d", err, count);
           if (err == ESP_OK) {
+            // First pass: dump every entry for debug visibility, then extract
+            // handles via the host-tested helper (preserves any already-found
+            // handle from a previous discovery attempt).
             for (int i = 0; i < count; i++) {
               auto &e = db[i];
               const char *t = "?";
@@ -614,13 +617,9 @@ script:
                   u[7],u[6],u[5],u[4],u[3],u[2],u[1],u[0]);
               }
               ESP_LOGI("gatt", "  [%d] %s h=%d uuid=%s p=0x%02X", i, t, e.attribute_handle, us, e.properties);
-              if (e.type == ESP_GATT_DB_CHARACTERISTIC && e.uuid.len == ESP_UUID_LEN_128) {
-                uint8_t suffix = e.uuid.uuid.uuid128[0];
-                if (suffix == 0xD5) id(${prefix}_d5_handle) = e.attribute_handle;
-                else if (suffix == 0xD6) id(${prefix}_d6_handle) = e.attribute_handle;
-                else if (suffix == 0xD7) id(${prefix}_d7_handle) = e.attribute_handle;
-              }
             }
+            esphome::subzero_protocol::update_handles_from_db(db, count,
+                id(${prefix}_d5_handle), id(${prefix}_d6_handle), id(${prefix}_d7_handle));
           }
           // Always request encryption - some appliances (dishwashers) expose D5
           // before bonding but still require encryption for writes (status=5).
@@ -661,14 +660,8 @@ script:
           uint16_t count = 64;
           esp_ble_gattc_get_db(client->get_gattc_if(), client->get_conn_id(), 0x0001, 0xFFFF, db, &count);
           ESP_LOGI("poll", "[${appliance_name}] Poll 1: count=%d", count);
-          for (int i = 0; i < count; i++) {
-            if (db[i].type == ESP_GATT_DB_CHARACTERISTIC && db[i].uuid.len == ESP_UUID_LEN_128) {
-              uint8_t s = db[i].uuid.uuid.uuid128[0];
-              if (s == 0xD5) id(${prefix}_d5_handle) = db[i].attribute_handle;
-              else if (s == 0xD6) id(${prefix}_d6_handle) = db[i].attribute_handle;
-              else if (s == 0xD7) id(${prefix}_d7_handle) = db[i].attribute_handle;
-            }
-          }
+          esphome::subzero_protocol::update_handles_from_db(db, count,
+              id(${prefix}_d5_handle), id(${prefix}_d6_handle), id(${prefix}_d7_handle));
           if (id(${prefix}_d5_handle) > 0) { id(${prefix}_subscribe).execute(); return; }
           id(${prefix}_debug).publish_state("Poll 1: waiting...");
       - delay: 5s
@@ -679,14 +672,8 @@ script:
           uint16_t count = 64;
           esp_ble_gattc_get_db(client->get_gattc_if(), client->get_conn_id(), 0x0001, 0xFFFF, db, &count);
           ESP_LOGI("poll", "[${appliance_name}] Poll 2: count=%d", count);
-          for (int i = 0; i < count; i++) {
-            if (db[i].type == ESP_GATT_DB_CHARACTERISTIC && db[i].uuid.len == ESP_UUID_LEN_128) {
-              uint8_t s = db[i].uuid.uuid.uuid128[0];
-              if (s == 0xD5) id(${prefix}_d5_handle) = db[i].attribute_handle;
-              else if (s == 0xD6) id(${prefix}_d6_handle) = db[i].attribute_handle;
-              else if (s == 0xD7) id(${prefix}_d7_handle) = db[i].attribute_handle;
-            }
-          }
+          esphome::subzero_protocol::update_handles_from_db(db, count,
+              id(${prefix}_d5_handle), id(${prefix}_d6_handle), id(${prefix}_d7_handle));
           if (id(${prefix}_d5_handle) > 0) { id(${prefix}_subscribe).execute(); return; }
           id(${prefix}_debug).publish_state("Poll 2: waiting...");
       - delay: 5s
@@ -697,14 +684,8 @@ script:
           uint16_t count = 64;
           esp_ble_gattc_get_db(client->get_gattc_if(), client->get_conn_id(), 0x0001, 0xFFFF, db, &count);
           ESP_LOGI("poll", "[${appliance_name}] Poll 3: count=%d", count);
-          for (int i = 0; i < count; i++) {
-            if (db[i].type == ESP_GATT_DB_CHARACTERISTIC && db[i].uuid.len == ESP_UUID_LEN_128) {
-              uint8_t s = db[i].uuid.uuid.uuid128[0];
-              if (s == 0xD5) id(${prefix}_d5_handle) = db[i].attribute_handle;
-              else if (s == 0xD6) id(${prefix}_d6_handle) = db[i].attribute_handle;
-              else if (s == 0xD7) id(${prefix}_d7_handle) = db[i].attribute_handle;
-            }
-          }
+          esphome::subzero_protocol::update_handles_from_db(db, count,
+              id(${prefix}_d5_handle), id(${prefix}_d6_handle), id(${prefix}_d7_handle));
           if (id(${prefix}_d5_handle) > 0) { id(${prefix}_subscribe).execute(); return; }
           ESP_LOGW("ble", "[${appliance_name}] No D5 after 20s. Reconnecting...");
           id(${prefix}_debug).publish_state("No D5 found. Reconnecting...");
@@ -806,7 +787,7 @@ script:
             id(${prefix}_debug).publish_state("Connected! Press 'Start Pairing', then enter PIN.");
             return;
           }
-          std::string cmd = "{\"cmd\":\"unlock_channel\",\"params\":{\"pin\":\"" + pin + "\"}}\n";
+          std::string cmd = esphome::subzero_protocol::build_unlock_channel(pin);
           // Unlock D5 (control channel) - the only channel we use today
           esp_err_t err5 = esp_ble_gattc_write_char(
             client->get_gattc_if(), client->get_conn_id(),
@@ -830,7 +811,7 @@ script:
           uint16_t d6 = id(${prefix}_d6_handle);
           if (d6 == 0) return;
           id(${prefix}_poll_ok) = false;
-          std::string cmd = "{\"cmd\":\"get_async\"}\n";
+          std::string cmd = esphome::subzero_protocol::build_get_async();
           esp_err_t err = esp_ble_gattc_write_char(
             client->get_gattc_if(), client->get_conn_id(),
             d6, cmd.size(), (uint8_t*)cmd.data(),

--- a/subzero_dishwasher.yaml
+++ b/subzero_dishwasher.yaml
@@ -30,6 +30,14 @@ substitutions:
 packages:
   base: !include subzero_base.yaml
 
+# Sensor-publishing bus for the dishwasher dispatcher. Pointers populated
+# in on_boot below; dispatch_dishwasher() in parse_json then routes every
+# parsed-state field to the right entity.
+globals:
+  - id: ${prefix}_bus
+    type: esphome::subzero_protocol::DishwasherBus
+    restore_value: false
+
 esphome:
   on_boot:
     - priority: -100
@@ -37,6 +45,37 @@ esphome:
         - lambda: |-
             id(${prefix}_wash_time_remaining).publish_state(0);
             id(${prefix}_wash_cycle_end_time).publish_state("");
+            auto& b = id(${prefix}_bus);
+            // Common (declared in subzero_base.yaml)
+            b.svc_required = id(${prefix}_svc_required);
+            b.model = id(${prefix}_model);
+            b.uptime = id(${prefix}_uptime);
+            b.serial = id(${prefix}_serial);
+            b.appliance_type = id(${prefix}_appliance_type);
+            b.diag_status = id(${prefix}_diag_status);
+            b.build_date = id(${prefix}_build_date);
+            b.fw_version = id(${prefix}_fw_version);
+            b.api_version = id(${prefix}_api_version);
+            b.bleapp_version = id(${prefix}_bleapp_version);
+            b.os_version = id(${prefix}_os_version);
+            b.rtapp_version = id(${prefix}_rtapp_version);
+            b.board_version = id(${prefix}_board_version);
+            b.door_ajar = id(${prefix}_door_ajar);
+            // Dishwasher-specific
+            b.wash_cycle_on = id(${prefix}_wash_cycle_on);
+            b.heated_dry = id(${prefix}_heated_dry);
+            b.extended_dry = id(${prefix}_extended_dry);
+            b.high_temp_wash = id(${prefix}_high_temp_wash);
+            b.sani_rinse = id(${prefix}_sani_rinse);
+            b.rinse_aid_low = id(${prefix}_rinse_aid_low);
+            b.softener_low = id(${prefix}_softener_low);
+            b.light_on = id(${prefix}_light_on);
+            b.remote_ready = id(${prefix}_remote_ready);
+            b.delay_start = id(${prefix}_delay_start);
+            b.wash_status = id(${prefix}_wash_status);
+            b.wash_cycle = id(${prefix}_wash_cycle);
+            b.wash_time_remaining = id(${prefix}_wash_time_remaining);
+            b.wash_cycle_end_time = id(${prefix}_wash_cycle_end_time);
 
 sensor:
   - platform: template
@@ -117,11 +156,6 @@ text_sensor:
     id: ${prefix}_wash_cycle_end_time
     icon: "mdi:clock-end"
 
-globals:
-  - id: ${prefix}_wash_end_time_str
-    type: std::string
-    restore_value: false
-
 script:
   - id: ${prefix}_parse_json
     mode: single
@@ -157,7 +191,8 @@ script:
             for (const auto &k : s.data_keys)
               ESP_LOGI("szg-debug", "[${appliance_name}] key=%s", k.c_str());
           }
-          // PIN confirmation (unlock_channel response)
+          // PIN confirmation (unlock_channel response). Stays in YAML -
+          // see subzero_fridge.yaml's parse_json comment.
           if (s.common.pin_confirmed) {
             const std::string &pin = *s.common.pin_confirmed;
             id(${prefix}_stored_pin) = pin;
@@ -166,48 +201,16 @@ script:
             ESP_LOGI("szg", "[${appliance_name}] PIN confirmed: %s", pin.c_str());
             id(${prefix}_debug).publish_state("PIN confirmed! Channel unlocked.");
           }
-          // --- Dishwasher sensors ---
-          if (s.door_ajar)                id(${prefix}_door_ajar).publish_state(*s.door_ajar);
-          if (s.wash_cycle_on)            id(${prefix}_wash_cycle_on).publish_state(*s.wash_cycle_on);
-          if (s.heated_dry_on)            id(${prefix}_heated_dry).publish_state(*s.heated_dry_on);
-          if (s.extended_dry_on)          id(${prefix}_extended_dry).publish_state(*s.extended_dry_on);
-          if (s.high_temp_wash_on)        id(${prefix}_high_temp_wash).publish_state(*s.high_temp_wash_on);
-          if (s.sani_rinse_on)            id(${prefix}_sani_rinse).publish_state(*s.sani_rinse_on);
-          if (s.rinse_aid_low)            id(${prefix}_rinse_aid_low).publish_state(*s.rinse_aid_low);
-          if (s.softener_low)             id(${prefix}_softener_low).publish_state(*s.softener_low);
-          if (s.light_on)                 id(${prefix}_light_on).publish_state(*s.light_on);
-          if (s.remote_ready)             id(${prefix}_remote_ready).publish_state(*s.remote_ready);
-          if (s.delay_start_timer_active) id(${prefix}_delay_start).publish_state(*s.delay_start_timer_active);
-          if (s.wash_status)              id(${prefix}_wash_status).publish_state(*s.wash_status);
-          if (s.wash_cycle)               id(${prefix}_wash_cycle).publish_state(*s.wash_cycle);
-          if (s.wash_cycle_end_time) {
-            id(${prefix}_wash_end_time_str) = *s.wash_cycle_end_time;
-            id(${prefix}_wash_cycle_end_time).publish_state(*s.wash_cycle_end_time);
-          }
+          // Human-friendly wash-status log; pre-dispatch so the values
+          // we log match what's about to land in HA.
           if (s.wash_time_remaining_min) {
-            id(${prefix}_wash_time_remaining).publish_state(*s.wash_time_remaining_min);
             ESP_LOGI("szg", "[${appliance_name}] Wash ends %s, ~%d min remaining",
                      s.wash_cycle_end_time ? s.wash_cycle_end_time->c_str() : "?",
                      *s.wash_time_remaining_min);
           }
-          // Clear remaining time when cycle ends (stateful - stays in lambda)
-          if (s.wash_cycle_on && !*s.wash_cycle_on) {
-            if (id(${prefix}_wash_time_remaining).state > 0)
-              id(${prefix}_wash_time_remaining).publish_state(0);
-          }
-          // --- Common ---
-          if (s.common.service_required)  id(${prefix}_svc_required).publish_state(*s.common.service_required);
-          if (s.common.appliance_model)   id(${prefix}_model).publish_state(*s.common.appliance_model);
-          if (s.common.uptime)            id(${prefix}_uptime).publish_state(*s.common.uptime);
-          if (s.common.appliance_serial)  id(${prefix}_serial).publish_state(*s.common.appliance_serial);
-          if (s.common.appliance_type)    id(${prefix}_appliance_type).publish_state(*s.common.appliance_type);
-          if (s.common.diagnostic_status) id(${prefix}_diag_status).publish_state(*s.common.diagnostic_status);
-          if (s.common.build_date)        id(${prefix}_build_date).publish_state(*s.common.build_date);
-          if (s.common.version.fw)        id(${prefix}_fw_version).publish_state(*s.common.version.fw);
-          if (s.common.version.api)       id(${prefix}_api_version).publish_state(*s.common.version.api);
-          if (s.common.version.bleapp)    id(${prefix}_bleapp_version).publish_state(*s.common.version.bleapp);
-          if (s.common.version.os)        id(${prefix}_os_version).publish_state(*s.common.version.os);
-          if (s.common.version.rtapp)     id(${prefix}_rtapp_version).publish_state(*s.common.version.rtapp);
-          if (s.common.version.appliance) id(${prefix}_board_version).publish_state(*s.common.version.appliance);
+          // Sensor publishes (including the "clear wash_time_remaining
+          // when cycle stops" stateful hook). See dispatch.h for the
+          // field-to-method mapping; bus pointers wired in on_boot.
+          esphome::subzero_protocol::dispatch_dishwasher(s, id(${prefix}_bus));
           id(${prefix}_poll_ok) = true;
           id(${prefix}_fast_retries) = 0;

--- a/subzero_fridge.yaml
+++ b/subzero_fridge.yaml
@@ -67,6 +67,58 @@ substitutions:
 packages:
   base: !include subzero_base.yaml
 
+# Sensor-publishing bus for the fridge dispatcher. Pointers are populated
+# once at boot (see on_boot below) and then dispatch_fridge() in parse_json
+# routes every parsed-state field to the right entity. Default-constructed
+# value is all-nullptr, which dispatch treats as "no such sensor on this
+# appliance" - safe even before on_boot fires.
+globals:
+  - id: ${prefix}_bus
+    type: esphome::subzero_protocol::FridgeBus
+    restore_value: false
+
+esphome:
+  on_boot:
+    - priority: -100
+      then:
+        - lambda: |-
+            auto& b = id(${prefix}_bus);
+            // Common (declared in subzero_base.yaml)
+            b.svc_required = id(${prefix}_svc_required);
+            b.model = id(${prefix}_model);
+            b.uptime = id(${prefix}_uptime);
+            b.serial = id(${prefix}_serial);
+            b.appliance_type = id(${prefix}_appliance_type);
+            b.diag_status = id(${prefix}_diag_status);
+            b.build_date = id(${prefix}_build_date);
+            b.fw_version = id(${prefix}_fw_version);
+            b.api_version = id(${prefix}_api_version);
+            b.bleapp_version = id(${prefix}_bleapp_version);
+            b.os_version = id(${prefix}_os_version);
+            b.rtapp_version = id(${prefix}_rtapp_version);
+            b.board_version = id(${prefix}_board_version);
+            b.door_ajar = id(${prefix}_door_ajar);
+            // Fridge / freezer
+            b.sabbath_on = id(${prefix}_sabbath_on);
+            b.set_temp = id(${prefix}_set_temp);
+            b.frz_set_temp = id(${prefix}_frz_set_temp);
+            b.frz_door_ajar = id(${prefix}_frz_door_ajar);
+            b.ice_maker = id(${prefix}_ice_maker);
+            // Refrigerator drawer
+            b.ref2_set_temp = id(${prefix}_ref2_set_temp);
+            b.ref2_door_ajar = id(${prefix}_ref2_door_ajar);
+            // Wine
+            b.wine_door_ajar = id(${prefix}_wine_door_ajar);
+            b.wine_set_temp = id(${prefix}_wine_set_temp);
+            b.wine2_set_temp = id(${prefix}_wine2_set_temp);
+            b.wine_temp_alert = id(${prefix}_wine_temp_alert);
+            // Crisper
+            b.crisp_set_temp = id(${prefix}_crisp_set_temp);
+            // Filters
+            b.air_filter_on = id(${prefix}_air_filter_on);
+            b.air_filter_pct = id(${prefix}_air_filter_pct);
+            b.water_filter_pct = id(${prefix}_water_filter_pct);
+
 sensor:
   - platform: template
     name: "${appliance_name} Set Temperature"
@@ -227,7 +279,10 @@ script:
             for (const auto &k : s.data_keys)
               ESP_LOGI("szg-debug", "[${appliance_name}] key=%s", k.c_str());
           }
-          // PIN confirmation (unlock_channel response)
+          // PIN confirmation (unlock_channel response). Stays in YAML
+          // because it touches multiple state-machine globals (stored_pin,
+          // pin_confirmed) plus the PIN text input - out of scope for the
+          // pure dispatch helper.
           if (s.common.pin_confirmed) {
             const std::string &pin = *s.common.pin_confirmed;
             id(${prefix}_stored_pin) = pin;
@@ -236,42 +291,10 @@ script:
             ESP_LOGI("szg", "[${appliance_name}] PIN confirmed: %s", pin.c_str());
             id(${prefix}_debug).publish_state("PIN confirmed! Channel unlocked.");
           }
-          // --- Fridge sensors ---
-          if (s.ref_set_temp) id(${prefix}_set_temp).publish_state(*s.ref_set_temp);
-          if (s.door_ajar)    id(${prefix}_door_ajar).publish_state(*s.door_ajar);
-          // --- Freezer sensors ---
-          if (s.frz_set_temp)  id(${prefix}_frz_set_temp).publish_state(*s.frz_set_temp);
-          if (s.frz_door_ajar) id(${prefix}_frz_door_ajar).publish_state(*s.frz_door_ajar);
-          if (s.ice_maker_on)  id(${prefix}_ice_maker).publish_state(*s.ice_maker_on);
-          // --- Refrigerator drawer sensors ---
-          if (s.ref2_set_temp)  id(${prefix}_ref2_set_temp).publish_state(*s.ref2_set_temp);
-          if (s.ref2_door_ajar) id(${prefix}_ref2_door_ajar).publish_state(*s.ref2_door_ajar);
-          // --- Wine sensors ---
-          if (s.wine_door_ajar)     id(${prefix}_wine_door_ajar).publish_state(*s.wine_door_ajar);
-          if (s.wine_set_temp)      id(${prefix}_wine_set_temp).publish_state(*s.wine_set_temp);
-          if (s.wine2_set_temp)     id(${prefix}_wine2_set_temp).publish_state(*s.wine2_set_temp);
-          if (s.wine_temp_alert_on) id(${prefix}_wine_temp_alert).publish_state(*s.wine_temp_alert_on);
-          // --- Crisper drawer sensors ---
-          if (s.crisp_set_temp) id(${prefix}_crisp_set_temp).publish_state(*s.crisp_set_temp);
-          // --- Filter sensors ---
-          if (s.air_filter_on)              id(${prefix}_air_filter_on).publish_state(*s.air_filter_on);
-          if (s.air_filter_pct_remaining)   id(${prefix}_air_filter_pct).publish_state(*s.air_filter_pct_remaining);
-          if (s.water_filter_pct_remaining) id(${prefix}_water_filter_pct).publish_state(*s.water_filter_pct_remaining);
-          // --- Common ---
-          if (s.common.sabbath_on)        id(${prefix}_sabbath_on).publish_state(*s.common.sabbath_on);
-          if (s.common.service_required)  id(${prefix}_svc_required).publish_state(*s.common.service_required);
-          if (s.common.appliance_model)   id(${prefix}_model).publish_state(*s.common.appliance_model);
-          if (s.common.uptime)            id(${prefix}_uptime).publish_state(*s.common.uptime);
-          if (s.common.appliance_serial)  id(${prefix}_serial).publish_state(*s.common.appliance_serial);
-          if (s.common.appliance_type)    id(${prefix}_appliance_type).publish_state(*s.common.appliance_type);
-          if (s.common.diagnostic_status) id(${prefix}_diag_status).publish_state(*s.common.diagnostic_status);
-          if (s.common.build_date)        id(${prefix}_build_date).publish_state(*s.common.build_date);
-          if (s.common.version.fw)        id(${prefix}_fw_version).publish_state(*s.common.version.fw);
-          if (s.common.version.api)       id(${prefix}_api_version).publish_state(*s.common.version.api);
-          if (s.common.version.bleapp)    id(${prefix}_bleapp_version).publish_state(*s.common.version.bleapp);
-          if (s.common.version.os)        id(${prefix}_os_version).publish_state(*s.common.version.os);
-          if (s.common.version.rtapp)     id(${prefix}_rtapp_version).publish_state(*s.common.version.rtapp);
-          if (s.common.version.appliance) id(${prefix}_board_version).publish_state(*s.common.version.appliance);
+          // Sensor publishes - every parser field is routed to its
+          // corresponding entity by dispatch_fridge. See dispatch.h for
+          // the field-to-method mapping; bus pointers wired in on_boot.
+          esphome::subzero_protocol::dispatch_fridge(s, id(${prefix}_bus));
           id(${prefix}_poll_ok) = true;
           // Any valid response means the connection is functional, so prior
           // fast-reconnect failures aren't relevant anymore.

--- a/subzero_range.yaml
+++ b/subzero_range.yaml
@@ -30,6 +30,14 @@ substitutions:
 packages:
   base: !include subzero_base.yaml
 
+# Sensor-publishing bus for the range dispatcher. Pointers populated in
+# on_boot below; dispatch_range() in parse_json then routes every parsed-
+# state field to the right entity.
+globals:
+  - id: ${prefix}_bus
+    type: esphome::subzero_protocol::RangeBus
+    restore_value: false
+
 esphome:
   on_boot:
     - priority: -100
@@ -37,6 +45,65 @@ esphome:
         - lambda: |-
             id(${prefix}_ktimer_end_time).publish_state("");
             id(${prefix}_ktimer2_end_time).publish_state("");
+            auto& b = id(${prefix}_bus);
+            // Common (declared in subzero_base.yaml)
+            b.svc_required = id(${prefix}_svc_required);
+            b.model = id(${prefix}_model);
+            b.uptime = id(${prefix}_uptime);
+            b.serial = id(${prefix}_serial);
+            b.appliance_type = id(${prefix}_appliance_type);
+            b.diag_status = id(${prefix}_diag_status);
+            b.build_date = id(${prefix}_build_date);
+            b.fw_version = id(${prefix}_fw_version);
+            b.api_version = id(${prefix}_api_version);
+            b.bleapp_version = id(${prefix}_bleapp_version);
+            b.os_version = id(${prefix}_os_version);
+            b.rtapp_version = id(${prefix}_rtapp_version);
+            b.board_version = id(${prefix}_board_version);
+            b.door_ajar = id(${prefix}_door_ajar);
+            b.sabbath_on = id(${prefix}_sabbath_on);
+            // Primary cavity
+            b.cav_unit_on = id(${prefix}_cav_unit_on);
+            b.cav_at_set_temp = id(${prefix}_cav_at_set_temp);
+            b.cav_light_on = id(${prefix}_cav_light_on);
+            b.cav_remote_ready = id(${prefix}_cav_remote_ready);
+            b.cav_probe_on = id(${prefix}_cav_probe_on);
+            b.cav_probe_at_temp = id(${prefix}_cav_probe_at_temp);
+            b.cav_probe_near = id(${prefix}_cav_probe_near);
+            b.cav_gourmet = id(${prefix}_cav_gourmet);
+            b.cook_timer_done = id(${prefix}_cook_timer_done);
+            b.cook_timer_near = id(${prefix}_cook_timer_near);
+            b.cav_temp = id(${prefix}_cav_temp);
+            b.cav_set_temp = id(${prefix}_cav_set_temp);
+            b.cav_cook_mode = id(${prefix}_cav_cook_mode);
+            b.cav_gourmet_recipe = id(${prefix}_cav_gourmet_recipe);
+            b.probe_temp = id(${prefix}_probe_temp);
+            b.probe_set_temp = id(${prefix}_probe_set_temp);
+            // Kitchen timers
+            b.ktimer_active = id(${prefix}_ktimer_active);
+            b.ktimer_done = id(${prefix}_ktimer_done);
+            b.ktimer_near = id(${prefix}_ktimer_near);
+            b.ktimer2_active = id(${prefix}_ktimer2_active);
+            b.ktimer2_done = id(${prefix}_ktimer2_done);
+            b.ktimer2_near = id(${prefix}_ktimer2_near);
+            b.ktimer_end_time = id(${prefix}_ktimer_end_time);
+            b.ktimer2_end_time = id(${prefix}_ktimer2_end_time);
+            // Secondary cavity (dual-oven; entities exist even when hidden)
+            b.cav2_unit_on = id(${prefix}_cav2_unit_on);
+            b.cav2_door_ajar = id(${prefix}_cav2_door_ajar);
+            b.cav2_at_set_temp = id(${prefix}_cav2_at_set_temp);
+            b.cav2_light_on = id(${prefix}_cav2_light_on);
+            b.cav2_remote_ready = id(${prefix}_cav2_remote_ready);
+            b.cav2_probe_on = id(${prefix}_cav2_probe_on);
+            b.cav2_probe_at_temp = id(${prefix}_cav2_probe_at_temp);
+            b.cav2_probe_near = id(${prefix}_cav2_probe_near);
+            b.cav2_gourmet = id(${prefix}_cav2_gourmet);
+            b.cav2_cook_timer_done = id(${prefix}_cav2_cook_timer_done);
+            b.cav2_temp = id(${prefix}_cav2_temp);
+            b.cav2_set_temp = id(${prefix}_cav2_set_temp);
+            b.cav2_cook_mode = id(${prefix}_cav2_cook_mode);
+            b.cav2_probe_temp = id(${prefix}_cav2_probe_temp);
+            b.cav2_probe_set_temp = id(${prefix}_cav2_probe_set_temp);
 sensor:
   - platform: template
     name: "${appliance_name} Oven Temperature"
@@ -325,7 +392,8 @@ script:
             for (const auto &k : s.data_keys)
               ESP_LOGI("szg-debug", "[${appliance_name}] key=%s", k.c_str());
           }
-          // PIN confirmation (unlock_channel response)
+          // PIN confirmation (unlock_channel response). Stays in YAML -
+          // see subzero_fridge.yaml's parse_json comment.
           if (s.common.pin_confirmed) {
             const std::string &pin = *s.common.pin_confirmed;
             id(${prefix}_stored_pin) = pin;
@@ -334,62 +402,9 @@ script:
             ESP_LOGI("szg", "[${appliance_name}] PIN confirmed: %s", pin.c_str());
             id(${prefix}_debug).publish_state("PIN confirmed! Channel unlocked.");
           }
-          if (s.door_ajar) id(${prefix}_door_ajar).publish_state(*s.door_ajar);
-          // --- Range / Oven sensors ---
-          if (s.cav_unit_on)                id(${prefix}_cav_unit_on).publish_state(*s.cav_unit_on);
-          if (s.cav_at_set_temp)            id(${prefix}_cav_at_set_temp).publish_state(*s.cav_at_set_temp);
-          if (s.cav_light_on)               id(${prefix}_cav_light_on).publish_state(*s.cav_light_on);
-          if (s.cav_remote_ready)           id(${prefix}_cav_remote_ready).publish_state(*s.cav_remote_ready);
-          if (s.cav_probe_on)               id(${prefix}_cav_probe_on).publish_state(*s.cav_probe_on);
-          if (s.cav_probe_at_set_temp)      id(${prefix}_cav_probe_at_temp).publish_state(*s.cav_probe_at_set_temp);
-          if (s.cav_probe_within_10deg)     id(${prefix}_cav_probe_near).publish_state(*s.cav_probe_within_10deg);
-          if (s.cav_gourmet_mode_on)        id(${prefix}_cav_gourmet).publish_state(*s.cav_gourmet_mode_on);
-          if (s.cav_gourmet_recipe)         id(${prefix}_cav_gourmet_recipe).publish_state(*s.cav_gourmet_recipe);
-          if (s.cav_cook_timer_complete)    id(${prefix}_cook_timer_done).publish_state(*s.cav_cook_timer_complete);
-          if (s.cav_cook_timer_within_1min) id(${prefix}_cook_timer_near).publish_state(*s.cav_cook_timer_within_1min);
-          if (s.kitchen_timer_active)       id(${prefix}_ktimer_active).publish_state(*s.kitchen_timer_active);
-          if (s.kitchen_timer_complete)     id(${prefix}_ktimer_done).publish_state(*s.kitchen_timer_complete);
-          if (s.kitchen_timer_within_1min)  id(${prefix}_ktimer_near).publish_state(*s.kitchen_timer_within_1min);
-          if (s.kitchen_timer_end_time)     id(${prefix}_ktimer_end_time).publish_state(*s.kitchen_timer_end_time);
-          if (s.kitchen_timer2_active)      id(${prefix}_ktimer2_active).publish_state(*s.kitchen_timer2_active);
-          if (s.kitchen_timer2_complete)    id(${prefix}_ktimer2_done).publish_state(*s.kitchen_timer2_complete);
-          if (s.kitchen_timer2_within_1min) id(${prefix}_ktimer2_near).publish_state(*s.kitchen_timer2_within_1min);
-          if (s.kitchen_timer2_end_time)    id(${prefix}_ktimer2_end_time).publish_state(*s.kitchen_timer2_end_time);
-          if (s.cav_temp)                   id(${prefix}_cav_temp).publish_state(*s.cav_temp);
-          if (s.cav_set_temp)               id(${prefix}_cav_set_temp).publish_state(*s.cav_set_temp);
-          if (s.cav_cook_mode)              id(${prefix}_cav_cook_mode).publish_state(*s.cav_cook_mode);
-          if (s.cav_probe_temp)             id(${prefix}_probe_temp).publish_state(*s.cav_probe_temp);
-          if (s.cav_probe_set_temp)         id(${prefix}_probe_set_temp).publish_state(*s.cav_probe_set_temp);
-          // --- Oven 2 (dual-oven ranges) ---
-          if (s.cav2_door_ajar)           id(${prefix}_cav2_door_ajar).publish_state(*s.cav2_door_ajar);
-          if (s.cav2_unit_on)             id(${prefix}_cav2_unit_on).publish_state(*s.cav2_unit_on);
-          if (s.cav2_at_set_temp)         id(${prefix}_cav2_at_set_temp).publish_state(*s.cav2_at_set_temp);
-          if (s.cav2_light_on)            id(${prefix}_cav2_light_on).publish_state(*s.cav2_light_on);
-          if (s.cav2_remote_ready)        id(${prefix}_cav2_remote_ready).publish_state(*s.cav2_remote_ready);
-          if (s.cav2_probe_on)            id(${prefix}_cav2_probe_on).publish_state(*s.cav2_probe_on);
-          if (s.cav2_probe_at_set_temp)   id(${prefix}_cav2_probe_at_temp).publish_state(*s.cav2_probe_at_set_temp);
-          if (s.cav2_probe_within_10deg)  id(${prefix}_cav2_probe_near).publish_state(*s.cav2_probe_within_10deg);
-          if (s.cav2_gourmet_mode_on)     id(${prefix}_cav2_gourmet).publish_state(*s.cav2_gourmet_mode_on);
-          if (s.cav2_cook_timer_complete) id(${prefix}_cav2_cook_timer_done).publish_state(*s.cav2_cook_timer_complete);
-          if (s.cav2_temp)                id(${prefix}_cav2_temp).publish_state(*s.cav2_temp);
-          if (s.cav2_set_temp)            id(${prefix}_cav2_set_temp).publish_state(*s.cav2_set_temp);
-          if (s.cav2_cook_mode)           id(${prefix}_cav2_cook_mode).publish_state(*s.cav2_cook_mode);
-          if (s.cav2_probe_temp)          id(${prefix}_cav2_probe_temp).publish_state(*s.cav2_probe_temp);
-          if (s.cav2_probe_set_temp)      id(${prefix}_cav2_probe_set_temp).publish_state(*s.cav2_probe_set_temp);
-          // --- Common ---
-          if (s.common.sabbath_on)        id(${prefix}_sabbath_on).publish_state(*s.common.sabbath_on);
-          if (s.common.service_required)  id(${prefix}_svc_required).publish_state(*s.common.service_required);
-          if (s.common.appliance_model)   id(${prefix}_model).publish_state(*s.common.appliance_model);
-          if (s.common.uptime)            id(${prefix}_uptime).publish_state(*s.common.uptime);
-          if (s.common.appliance_serial)  id(${prefix}_serial).publish_state(*s.common.appliance_serial);
-          if (s.common.appliance_type)    id(${prefix}_appliance_type).publish_state(*s.common.appliance_type);
-          if (s.common.diagnostic_status) id(${prefix}_diag_status).publish_state(*s.common.diagnostic_status);
-          if (s.common.build_date)        id(${prefix}_build_date).publish_state(*s.common.build_date);
-          if (s.common.version.fw)        id(${prefix}_fw_version).publish_state(*s.common.version.fw);
-          if (s.common.version.api)       id(${prefix}_api_version).publish_state(*s.common.version.api);
-          if (s.common.version.bleapp)    id(${prefix}_bleapp_version).publish_state(*s.common.version.bleapp);
-          if (s.common.version.os)        id(${prefix}_os_version).publish_state(*s.common.version.os);
-          if (s.common.version.rtapp)     id(${prefix}_rtapp_version).publish_state(*s.common.version.rtapp);
-          if (s.common.version.appliance) id(${prefix}_board_version).publish_state(*s.common.version.appliance);
+          // Sensor publishes - every parser field is routed to its
+          // corresponding entity by dispatch_range. See dispatch.h for
+          // the field-to-method mapping; bus pointers wired in on_boot.
+          esphome::subzero_protocol::dispatch_range(s, id(${prefix}_bus));
           id(${prefix}_poll_ok) = true;
           id(${prefix}_fast_retries) = 0;

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -54,6 +54,9 @@ add_executable(protocol_tests
   protocol_test.cpp
   buffer_test.cpp
   sanitize_test.cpp
+  commands_test.cpp
+  gatt_handles_test.cpp
+  dispatch_test.cpp
 )
 target_link_libraries(protocol_tests PRIVATE
   subzero_protocol

--- a/tests/cpp/buffer_test.cpp
+++ b/tests/cpp/buffer_test.cpp
@@ -16,7 +16,7 @@ bool feed_str(MessageBuffer &b, const char *s) {
   return b.feed(reinterpret_cast<const std::uint8_t *>(s), std::strlen(s));
 }
 
-}  // namespace
+} // namespace
 
 TEST(MessageBuffer, EmptyByDefault) {
   MessageBuffer b;
@@ -40,7 +40,7 @@ TEST(MessageBuffer, FragmentedDelivery) {
   MessageBuffer b;
   EXPECT_FALSE(feed_str(b, "{\"a"));
   EXPECT_FALSE(feed_str(b, "\":1,"));
-  EXPECT_FALSE(feed_str(b, "\"b\":{\"c\":2}"));  // nested {}: depth back to 1
+  EXPECT_FALSE(feed_str(b, "\"b\":{\"c\":2}")); // nested {}: depth back to 1
   EXPECT_FALSE(b.complete());
   EXPECT_TRUE(feed_str(b, "}"));
   ASSERT_TRUE(b.complete());
@@ -79,7 +79,8 @@ TEST(MessageBuffer, OverCapacityResetsOnNextFeed) {
   std::string huge(MessageBuffer::kMaxBytes + 100, 'x');
   // Prepend a `{` so depth goes to 1 (not complete).
   std::string bytes = "{" + huge;
-  EXPECT_FALSE(b.feed(reinterpret_cast<const std::uint8_t *>(bytes.data()), bytes.size()));
+  EXPECT_FALSE(b.feed(reinterpret_cast<const std::uint8_t *>(bytes.data()),
+                      bytes.size()));
   EXPECT_GT(b.size(), MessageBuffer::kMaxBytes);
 
   // Next feed: pre-emptive reset, then append the new fragment.
@@ -163,7 +164,7 @@ TEST(MessageBuffer, StickyCompleteThroughTrailingBytes) {
   // don't accumulate in practice — but verify the sticky property.
   MessageBuffer b;
   EXPECT_TRUE(feed_str(b, "{\"a\":1}"));
-  EXPECT_TRUE(feed_str(b, "extra"));  // doesn't affect completion
+  EXPECT_TRUE(feed_str(b, "extra")); // doesn't affect completion
   EXPECT_TRUE(b.complete());
   auto msg = b.take_message();
   ASSERT_TRUE(msg.has_value());
@@ -173,10 +174,11 @@ TEST(MessageBuffer, StickyCompleteThroughTrailingBytes) {
 TEST(MessageBuffer, RealWorldFridgePollResponse) {
   // Approximate a fragmented Sub-Zero poll response — small fragments
   // similar to default-MTU ACL chunks (~20-40 bytes).
-  static const char *kFull =
-      "{\"status\":0,\"resp\":{\"appliance_model\":\"BI36UFDID\",\"uptime\":\"1d2h\","
-      "\"version\":{\"fw\":\"2.27\",\"api\":\"4.0\"},\"ref_set_temp\":38,\"frz_set_temp\":-2,"
-      "\"door_ajar\":false,\"frz_door_ajar\":false}}";
+  static const char *kFull = "{\"status\":0,\"resp\":{\"appliance_model\":"
+                             "\"BI36UFDID\",\"uptime\":\"1d2h\","
+                             "\"version\":{\"fw\":\"2.27\",\"api\":\"4.0\"},"
+                             "\"ref_set_temp\":38,\"frz_set_temp\":-2,"
+                             "\"door_ajar\":false,\"frz_door_ajar\":false}}";
   MessageBuffer b;
   size_t total = std::strlen(kFull);
   size_t off = 0;

--- a/tests/cpp/commands_test.cpp
+++ b/tests/cpp/commands_test.cpp
@@ -1,0 +1,53 @@
+#include "commands.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+using esphome::subzero_protocol::build_display_pin;
+using esphome::subzero_protocol::build_get_async;
+using esphome::subzero_protocol::build_unlock_channel;
+
+TEST(Commands, GetAsyncIsExactWireFormat) {
+  EXPECT_EQ(build_get_async(), "{\"cmd\":\"get_async\"}\n");
+}
+
+TEST(Commands, GetAsyncTerminatesWithNewline) {
+  // The appliance's serial parser only emits a response after \n.
+  // Drop this test only if the protocol changes.
+  EXPECT_EQ(build_get_async().back(), '\n');
+}
+
+TEST(Commands, UnlockChannelInterpolatesPin) {
+  EXPECT_EQ(build_unlock_channel("12345"),
+            "{\"cmd\":\"unlock_channel\",\"params\":{\"pin\":\"12345\"}}\n");
+}
+
+TEST(Commands, UnlockChannelHandlesEmptyPin) {
+  // The YAML caller is supposed to guard against this (and does), but
+  // we should produce well-formed JSON regardless rather than corrupting
+  // the wire stream.
+  EXPECT_EQ(build_unlock_channel(""),
+            "{\"cmd\":\"unlock_channel\",\"params\":{\"pin\":\"\"}}\n");
+}
+
+TEST(Commands, UnlockChannelTerminatesWithNewline) {
+  EXPECT_EQ(build_unlock_channel("99999").back(), '\n');
+}
+
+TEST(Commands, DisplayPinDefaultDuration) {
+  EXPECT_EQ(build_display_pin(),
+            "{\"cmd\":\"display_pin\",\"params\":{\"duration\": 30}}\n");
+}
+
+TEST(Commands, DisplayPinCustomDuration) {
+  EXPECT_EQ(build_display_pin(5),
+            "{\"cmd\":\"display_pin\",\"params\":{\"duration\": 5}}\n");
+  EXPECT_EQ(build_display_pin(120),
+            "{\"cmd\":\"display_pin\",\"params\":{\"duration\": 120}}\n");
+}
+
+TEST(Commands, DisplayPinTerminatesWithNewline) {
+  EXPECT_EQ(build_display_pin().back(), '\n');
+  EXPECT_EQ(build_display_pin(60).back(), '\n');
+}

--- a/tests/cpp/commands_test.cpp
+++ b/tests/cpp/commands_test.cpp
@@ -35,6 +35,55 @@ TEST(Commands, UnlockChannelTerminatesWithNewline) {
   EXPECT_EQ(build_unlock_channel("99999").back(), '\n');
 }
 
+// Regression for CodeRabbit on PR #73: PINs must be JSON-escaped so a
+// hostile or accidental input can't break the wire format.
+TEST(Commands, UnlockChannelEscapesQuoteInPin) {
+  // Real PINs are 4-5 digit numeric, but the HA text input is mode:text
+  // and accepts arbitrary strings. A literal " in the PIN must not
+  // terminate the JSON value.
+  EXPECT_EQ(build_unlock_channel("ab\"cd"),
+            "{\"cmd\":\"unlock_channel\",\"params\":{\"pin\":\"ab\\\"cd\"}}\n");
+}
+
+TEST(Commands, UnlockChannelEscapesBackslashInPin) {
+  EXPECT_EQ(build_unlock_channel("ab\\cd"),
+            "{\"cmd\":\"unlock_channel\",\"params\":{\"pin\":\"ab\\\\cd\"}}\n");
+}
+
+TEST(Commands, UnlockChannelEscapesNamedControlChars) {
+  std::string pin = "a\b\f\n\r\tb";
+  EXPECT_EQ(build_unlock_channel(pin),
+            "{\"cmd\":\"unlock_channel\",\"params\":{\"pin\":\"a\\b\\f\\n\\r\\tb\"}}\n");
+}
+
+TEST(Commands, UnlockChannelEscapesOtherControlCharsAsUnicode) {
+  // 0x01 (SOH) and 0x1F (US) have no named escape; they become 
+  // and . Anything else under 0x20 takes the same path.
+  std::string pin;
+  pin.push_back(0x01);
+  pin.push_back(0x1F);
+  EXPECT_EQ(build_unlock_channel(pin),
+            "{\"cmd\":\"unlock_channel\",\"params\":{\"pin\":\"\\u0001\\u001F\"}}\n");
+}
+
+TEST(Commands, UnlockChannelPassesNumericPinThrough) {
+  // The common case must not be regressed by the escape pass.
+  EXPECT_EQ(build_unlock_channel("12345"),
+            "{\"cmd\":\"unlock_channel\",\"params\":{\"pin\":\"12345\"}}\n");
+}
+
+TEST(Commands, UnlockChannelPassesHighBitBytesThrough) {
+  // Allowing 0x80+ bytes through unmodified — the protocol is ASCII in
+  // practice and we don't want to re-encode arbitrary UTF-8 sequences.
+  // (HA's text input would normally reject these but we don't enforce.)
+  std::string pin;
+  pin.push_back(static_cast<char>(0xC3));
+  pin.push_back(static_cast<char>(0xA9));  // é in UTF-8
+  EXPECT_EQ(build_unlock_channel(pin),
+            std::string("{\"cmd\":\"unlock_channel\",\"params\":{\"pin\":\"") + pin +
+                "\"}}\n");
+}
+
 TEST(Commands, DisplayPinDefaultDuration) {
   EXPECT_EQ(build_display_pin(),
             "{\"cmd\":\"display_pin\",\"params\":{\"duration\": 30}}\n");

--- a/tests/cpp/commands_test.cpp
+++ b/tests/cpp/commands_test.cpp
@@ -52,8 +52,8 @@ TEST(Commands, UnlockChannelEscapesBackslashInPin) {
 
 TEST(Commands, UnlockChannelEscapesNamedControlChars) {
   std::string pin = "a\b\f\n\r\tb";
-  EXPECT_EQ(build_unlock_channel(pin),
-            "{\"cmd\":\"unlock_channel\",\"params\":{\"pin\":\"a\\b\\f\\n\\r\\tb\"}}\n");
+  EXPECT_EQ(build_unlock_channel(pin), "{\"cmd\":\"unlock_channel\",\"params\":"
+                                       "{\"pin\":\"a\\b\\f\\n\\r\\tb\"}}\n");
 }
 
 TEST(Commands, UnlockChannelEscapesOtherControlCharsAsUnicode) {
@@ -62,8 +62,9 @@ TEST(Commands, UnlockChannelEscapesOtherControlCharsAsUnicode) {
   std::string pin;
   pin.push_back(0x01);
   pin.push_back(0x1F);
-  EXPECT_EQ(build_unlock_channel(pin),
-            "{\"cmd\":\"unlock_channel\",\"params\":{\"pin\":\"\\u0001\\u001F\"}}\n");
+  EXPECT_EQ(
+      build_unlock_channel(pin),
+      "{\"cmd\":\"unlock_channel\",\"params\":{\"pin\":\"\\u0001\\u001F\"}}\n");
 }
 
 TEST(Commands, UnlockChannelPassesNumericPinThrough) {
@@ -78,10 +79,10 @@ TEST(Commands, UnlockChannelPassesHighBitBytesThrough) {
   // (HA's text input would normally reject these but we don't enforce.)
   std::string pin;
   pin.push_back(static_cast<char>(0xC3));
-  pin.push_back(static_cast<char>(0xA9));  // é in UTF-8
+  pin.push_back(static_cast<char>(0xA9)); // é in UTF-8
   EXPECT_EQ(build_unlock_channel(pin),
-            std::string("{\"cmd\":\"unlock_channel\",\"params\":{\"pin\":\"") + pin +
-                "\"}}\n");
+            std::string("{\"cmd\":\"unlock_channel\",\"params\":{\"pin\":\"") +
+                pin + "\"}}\n");
 }
 
 TEST(Commands, DisplayPinDefaultDuration) {

--- a/tests/cpp/dispatch_test.cpp
+++ b/tests/cpp/dispatch_test.cpp
@@ -1,0 +1,548 @@
+#include "dispatch.h"
+#include "protocol.h"
+
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <sstream>
+#include <string>
+
+namespace fs = std::filesystem;
+using json = nlohmann::json;
+using namespace esphome::subzero_protocol;
+
+namespace {
+
+// Recording bus — stores every publish_* call into typed maps so tests
+// can assert "method X was called with value Y" or "method X was never
+// called". Mirrors the production *Bus structs in dispatch_esphome.h
+// method-for-method; if dispatch.h gains a new bus call, both this
+// recorder AND the production bus must add the matching method or the
+// build fails.
+struct CommonRecorder {
+  std::map<std::string, bool> bools;
+  std::map<std::string, std::string> strings;
+  std::map<std::string, float> floats;
+  std::map<std::string, int> ints;
+
+  // The CommonFields publishers
+  void publish_sabbath_on(bool v) { bools["sabbath_on"] = v; }
+  void publish_svc_required(bool v) { bools["svc_required"] = v; }
+  void publish_model(const std::string &v) { strings["model"] = v; }
+  void publish_uptime(const std::string &v) { strings["uptime"] = v; }
+  void publish_serial(const std::string &v) { strings["serial"] = v; }
+  void publish_appliance_type(const std::string &v) { strings["appliance_type"] = v; }
+  void publish_diag_status(const std::string &v) { strings["diag_status"] = v; }
+  void publish_build_date(const std::string &v) { strings["build_date"] = v; }
+  void publish_fw_version(const std::string &v) { strings["fw_version"] = v; }
+  void publish_api_version(const std::string &v) { strings["api_version"] = v; }
+  void publish_bleapp_version(const std::string &v) { strings["bleapp_version"] = v; }
+  void publish_os_version(const std::string &v) { strings["os_version"] = v; }
+  void publish_rtapp_version(const std::string &v) { strings["rtapp_version"] = v; }
+  void publish_board_version(const std::string &v) { strings["board_version"] = v; }
+};
+
+struct FridgeRecorder : CommonRecorder {
+  void publish_door_ajar(bool v) { bools["door_ajar"] = v; }
+  void publish_frz_door_ajar(bool v) { bools["frz_door_ajar"] = v; }
+  void publish_ice_maker(bool v) { bools["ice_maker"] = v; }
+  void publish_ref2_door_ajar(bool v) { bools["ref2_door_ajar"] = v; }
+  void publish_wine_door_ajar(bool v) { bools["wine_door_ajar"] = v; }
+  void publish_wine_temp_alert(bool v) { bools["wine_temp_alert"] = v; }
+  void publish_air_filter_on(bool v) { bools["air_filter_on"] = v; }
+
+  void publish_set_temp(float v) { floats["set_temp"] = v; }
+  void publish_frz_set_temp(float v) { floats["frz_set_temp"] = v; }
+  void publish_ref2_set_temp(float v) { floats["ref2_set_temp"] = v; }
+  void publish_wine_set_temp(float v) { floats["wine_set_temp"] = v; }
+  void publish_wine2_set_temp(float v) { floats["wine2_set_temp"] = v; }
+  void publish_crisp_set_temp(float v) { floats["crisp_set_temp"] = v; }
+  void publish_air_filter_pct(float v) { floats["air_filter_pct"] = v; }
+  void publish_water_filter_pct(float v) { floats["water_filter_pct"] = v; }
+};
+
+struct DishwasherRecorder : CommonRecorder {
+  bool clear_wash_time_remaining_called = false;
+
+  void publish_door_ajar(bool v) { bools["door_ajar"] = v; }
+  void publish_wash_cycle_on(bool v) { bools["wash_cycle_on"] = v; }
+  void publish_heated_dry(bool v) { bools["heated_dry"] = v; }
+  void publish_extended_dry(bool v) { bools["extended_dry"] = v; }
+  void publish_high_temp_wash(bool v) { bools["high_temp_wash"] = v; }
+  void publish_sani_rinse(bool v) { bools["sani_rinse"] = v; }
+  void publish_rinse_aid_low(bool v) { bools["rinse_aid_low"] = v; }
+  void publish_softener_low(bool v) { bools["softener_low"] = v; }
+  void publish_light_on(bool v) { bools["light_on"] = v; }
+  void publish_remote_ready(bool v) { bools["remote_ready"] = v; }
+  void publish_delay_start(bool v) { bools["delay_start"] = v; }
+  void publish_wash_status(int v) { ints["wash_status"] = v; }
+  void publish_wash_cycle(int v) { ints["wash_cycle"] = v; }
+  void publish_wash_time_remaining(int v) { ints["wash_time_remaining"] = v; }
+  void publish_wash_cycle_end_time(const std::string &v) {
+    strings["wash_cycle_end_time"] = v;
+  }
+
+  void clear_wash_time_remaining_if_running() { clear_wash_time_remaining_called = true; }
+};
+
+struct RangeRecorder : CommonRecorder {
+  void publish_door_ajar(bool v) { bools["door_ajar"] = v; }
+  void publish_cav_unit_on(bool v) { bools["cav_unit_on"] = v; }
+  void publish_cav_at_set_temp(bool v) { bools["cav_at_set_temp"] = v; }
+  void publish_cav_light_on(bool v) { bools["cav_light_on"] = v; }
+  void publish_cav_remote_ready(bool v) { bools["cav_remote_ready"] = v; }
+  void publish_cav_probe_on(bool v) { bools["cav_probe_on"] = v; }
+  void publish_cav_probe_at_temp(bool v) { bools["cav_probe_at_temp"] = v; }
+  void publish_cav_probe_near(bool v) { bools["cav_probe_near"] = v; }
+  void publish_cav_gourmet(bool v) { bools["cav_gourmet"] = v; }
+  void publish_cook_timer_done(bool v) { bools["cook_timer_done"] = v; }
+  void publish_cook_timer_near(bool v) { bools["cook_timer_near"] = v; }
+
+  void publish_cav_temp(float v) { floats["cav_temp"] = v; }
+  void publish_cav_set_temp(float v) { floats["cav_set_temp"] = v; }
+  void publish_cav_cook_mode(int v) { ints["cav_cook_mode"] = v; }
+  void publish_cav_gourmet_recipe(int v) { ints["cav_gourmet_recipe"] = v; }
+  void publish_probe_temp(float v) { floats["probe_temp"] = v; }
+  void publish_probe_set_temp(float v) { floats["probe_set_temp"] = v; }
+
+  void publish_ktimer_active(bool v) { bools["ktimer_active"] = v; }
+  void publish_ktimer_done(bool v) { bools["ktimer_done"] = v; }
+  void publish_ktimer_near(bool v) { bools["ktimer_near"] = v; }
+  void publish_ktimer2_active(bool v) { bools["ktimer2_active"] = v; }
+  void publish_ktimer2_done(bool v) { bools["ktimer2_done"] = v; }
+  void publish_ktimer2_near(bool v) { bools["ktimer2_near"] = v; }
+  void publish_ktimer_end_time(const std::string &v) { strings["ktimer_end_time"] = v; }
+  void publish_ktimer2_end_time(const std::string &v) { strings["ktimer2_end_time"] = v; }
+
+  void publish_cav2_unit_on(bool v) { bools["cav2_unit_on"] = v; }
+  void publish_cav2_door_ajar(bool v) { bools["cav2_door_ajar"] = v; }
+  void publish_cav2_at_set_temp(bool v) { bools["cav2_at_set_temp"] = v; }
+  void publish_cav2_light_on(bool v) { bools["cav2_light_on"] = v; }
+  void publish_cav2_remote_ready(bool v) { bools["cav2_remote_ready"] = v; }
+  void publish_cav2_probe_on(bool v) { bools["cav2_probe_on"] = v; }
+  void publish_cav2_probe_at_temp(bool v) { bools["cav2_probe_at_temp"] = v; }
+  void publish_cav2_probe_near(bool v) { bools["cav2_probe_near"] = v; }
+  void publish_cav2_gourmet(bool v) { bools["cav2_gourmet"] = v; }
+  void publish_cav2_cook_timer_done(bool v) { bools["cav2_cook_timer_done"] = v; }
+
+  void publish_cav2_temp(float v) { floats["cav2_temp"] = v; }
+  void publish_cav2_set_temp(float v) { floats["cav2_set_temp"] = v; }
+  void publish_cav2_cook_mode(int v) { ints["cav2_cook_mode"] = v; }
+  void publish_cav2_probe_temp(float v) { floats["cav2_probe_temp"] = v; }
+  void publish_cav2_probe_set_temp(float v) { floats["cav2_probe_set_temp"] = v; }
+};
+
+std::string read_file(const fs::path &p) {
+  std::ifstream in(p);
+  std::stringstream ss;
+  ss << in.rdbuf();
+  return ss.str();
+}
+
+}  // namespace
+
+// =============================================================================
+// Empty-state behavior — no fields → no calls. Catches dispatchers that
+// publish a default value (e.g. zero) when the underlying optional is unset.
+// =============================================================================
+
+TEST(Dispatch, FridgeEmptyStateNoCalls) {
+  FridgeState s;  // all optionals nullopt
+  FridgeRecorder rec;
+  dispatch_fridge(s, rec);
+  EXPECT_TRUE(rec.bools.empty());
+  EXPECT_TRUE(rec.floats.empty());
+  EXPECT_TRUE(rec.strings.empty());
+  EXPECT_TRUE(rec.ints.empty());
+}
+
+TEST(Dispatch, DishwasherEmptyStateNoCalls) {
+  DishwasherState s;
+  DishwasherRecorder rec;
+  dispatch_dishwasher(s, rec);
+  EXPECT_TRUE(rec.bools.empty());
+  EXPECT_TRUE(rec.ints.empty());
+  EXPECT_TRUE(rec.strings.empty());
+  EXPECT_FALSE(rec.clear_wash_time_remaining_called);
+}
+
+TEST(Dispatch, RangeEmptyStateNoCalls) {
+  RangeState s;
+  RangeRecorder rec;
+  dispatch_range(s, rec);
+  EXPECT_TRUE(rec.bools.empty());
+  EXPECT_TRUE(rec.floats.empty());
+  EXPECT_TRUE(rec.ints.empty());
+  EXPECT_TRUE(rec.strings.empty());
+}
+
+// =============================================================================
+// CommonFields dispatch — every CommonFields field must reach its bus method.
+// One test per field; each catches "added a new common field but forgot to
+// wire it up in dispatch_common".
+// =============================================================================
+
+TEST(Dispatch, CommonFieldsAllRouted) {
+  FridgeState s;
+  s.common.sabbath_on = true;
+  s.common.service_required = false;
+  s.common.appliance_model = std::string("BI36UFDID");
+  s.common.uptime = std::string("1d2h");
+  s.common.appliance_serial = std::string("0123456789");
+  s.common.appliance_type = std::string("fridge");
+  s.common.diagnostic_status = std::string("ok");
+  s.common.build_date = std::string("2025-01-01");
+  s.common.version.fw = std::string("2.27");
+  s.common.version.api = std::string("4.0");
+  s.common.version.bleapp = std::string("1.5");
+  s.common.version.os = std::string("Linux");
+  s.common.version.rtapp = std::string("3.1");
+  s.common.version.appliance = std::string("BoardA");
+
+  FridgeRecorder rec;
+  dispatch_fridge(s, rec);
+
+  EXPECT_EQ(rec.bools["sabbath_on"], true);
+  EXPECT_EQ(rec.bools["svc_required"], false);
+  EXPECT_EQ(rec.strings["model"], "BI36UFDID");
+  EXPECT_EQ(rec.strings["uptime"], "1d2h");
+  EXPECT_EQ(rec.strings["serial"], "0123456789");
+  EXPECT_EQ(rec.strings["appliance_type"], "fridge");
+  EXPECT_EQ(rec.strings["diag_status"], "ok");
+  EXPECT_EQ(rec.strings["build_date"], "2025-01-01");
+  EXPECT_EQ(rec.strings["fw_version"], "2.27");
+  EXPECT_EQ(rec.strings["api_version"], "4.0");
+  EXPECT_EQ(rec.strings["bleapp_version"], "1.5");
+  EXPECT_EQ(rec.strings["os_version"], "Linux");
+  EXPECT_EQ(rec.strings["rtapp_version"], "3.1");
+  EXPECT_EQ(rec.strings["board_version"], "BoardA");
+}
+
+// =============================================================================
+// Fridge-specific field-to-method mapping. One assertion per field.
+// =============================================================================
+
+TEST(Dispatch, FridgeFieldsRouted) {
+  FridgeState s;
+  s.ref_set_temp = 38.0f;
+  s.door_ajar = true;
+  s.frz_set_temp = -2.0f;
+  s.frz_door_ajar = false;
+  s.ice_maker_on = true;
+  s.ref2_set_temp = 40.0f;
+  s.ref2_door_ajar = true;
+  s.wine_door_ajar = false;
+  s.wine_set_temp = 55.0f;
+  s.wine2_set_temp = 65.0f;
+  s.wine_temp_alert_on = false;
+  s.crisp_set_temp = 33.0f;
+  s.air_filter_on = true;
+  s.air_filter_pct_remaining = 80.0f;
+  s.water_filter_pct_remaining = 50.0f;
+
+  FridgeRecorder rec;
+  dispatch_fridge(s, rec);
+
+  EXPECT_FLOAT_EQ(rec.floats["set_temp"], 38.0f);
+  EXPECT_EQ(rec.bools["door_ajar"], true);
+  EXPECT_FLOAT_EQ(rec.floats["frz_set_temp"], -2.0f);
+  EXPECT_EQ(rec.bools["frz_door_ajar"], false);
+  EXPECT_EQ(rec.bools["ice_maker"], true);
+  EXPECT_FLOAT_EQ(rec.floats["ref2_set_temp"], 40.0f);
+  EXPECT_EQ(rec.bools["ref2_door_ajar"], true);
+  EXPECT_EQ(rec.bools["wine_door_ajar"], false);
+  EXPECT_FLOAT_EQ(rec.floats["wine_set_temp"], 55.0f);
+  EXPECT_FLOAT_EQ(rec.floats["wine2_set_temp"], 65.0f);
+  EXPECT_EQ(rec.bools["wine_temp_alert"], false);
+  EXPECT_FLOAT_EQ(rec.floats["crisp_set_temp"], 33.0f);
+  EXPECT_EQ(rec.bools["air_filter_on"], true);
+  EXPECT_FLOAT_EQ(rec.floats["air_filter_pct"], 80.0f);
+  EXPECT_FLOAT_EQ(rec.floats["water_filter_pct"], 50.0f);
+}
+
+// =============================================================================
+// Dishwasher dispatch: includes the stateful "clear remaining time when
+// cycle ends" hook which is special-cased in dispatch_dishwasher.
+// =============================================================================
+
+TEST(Dispatch, DishwasherFieldsRouted) {
+  DishwasherState s;
+  s.door_ajar = false;
+  s.wash_cycle_on = true;
+  s.heated_dry_on = true;
+  s.extended_dry_on = false;
+  s.high_temp_wash_on = true;
+  s.sani_rinse_on = false;
+  s.rinse_aid_low = true;
+  s.softener_low = false;
+  s.light_on = true;
+  s.remote_ready = false;
+  s.delay_start_timer_active = false;
+  s.wash_status = 7;
+  s.wash_cycle = 3;
+  s.wash_time_remaining_min = 42;
+  s.wash_cycle_end_time = std::string("2026-04-25T08:42");
+
+  DishwasherRecorder rec;
+  dispatch_dishwasher(s, rec);
+
+  EXPECT_EQ(rec.bools["door_ajar"], false);
+  EXPECT_EQ(rec.bools["wash_cycle_on"], true);
+  EXPECT_EQ(rec.bools["heated_dry"], true);
+  EXPECT_EQ(rec.bools["extended_dry"], false);
+  EXPECT_EQ(rec.bools["high_temp_wash"], true);
+  EXPECT_EQ(rec.bools["sani_rinse"], false);
+  EXPECT_EQ(rec.bools["rinse_aid_low"], true);
+  EXPECT_EQ(rec.bools["softener_low"], false);
+  EXPECT_EQ(rec.bools["light_on"], true);
+  EXPECT_EQ(rec.bools["remote_ready"], false);
+  EXPECT_EQ(rec.bools["delay_start"], false);
+  EXPECT_EQ(rec.ints["wash_status"], 7);
+  EXPECT_EQ(rec.ints["wash_cycle"], 3);
+  EXPECT_EQ(rec.ints["wash_time_remaining"], 42);
+  EXPECT_EQ(rec.strings["wash_cycle_end_time"], "2026-04-25T08:42");
+  // wash_cycle_on was true, so the clear-on-stop hook is NOT triggered
+  EXPECT_FALSE(rec.clear_wash_time_remaining_called);
+}
+
+TEST(Dispatch, DishwasherCycleEndsTriggersClear) {
+  DishwasherState s;
+  s.wash_cycle_on = false;
+  DishwasherRecorder rec;
+  dispatch_dishwasher(s, rec);
+  EXPECT_EQ(rec.bools["wash_cycle_on"], false);
+  EXPECT_TRUE(rec.clear_wash_time_remaining_called);
+}
+
+TEST(Dispatch, DishwasherClearOnlyWhenCycleOnFlipsFalse) {
+  // Absent wash_cycle_on must NOT trigger the clear (push notification
+  // about an unrelated field shouldn't reset wash_time_remaining).
+  DishwasherState s;
+  s.heated_dry_on = true;
+  DishwasherRecorder rec;
+  dispatch_dishwasher(s, rec);
+  EXPECT_FALSE(rec.clear_wash_time_remaining_called);
+}
+
+// =============================================================================
+// Range dispatch — covers primary cavity, kitchen timers, secondary cavity.
+// =============================================================================
+
+TEST(Dispatch, RangeFieldsRouted_PrimaryCavity) {
+  RangeState s;
+  s.door_ajar = false;
+  s.cav_unit_on = true;
+  s.cav_at_set_temp = false;
+  s.cav_light_on = true;
+  s.cav_remote_ready = false;
+  s.cav_probe_on = true;
+  s.cav_probe_at_set_temp = false;
+  s.cav_probe_within_10deg = true;
+  s.cav_gourmet_mode_on = false;
+  s.cav_gourmet_recipe = 12;
+  s.cav_cook_timer_complete = false;
+  s.cav_cook_timer_within_1min = true;
+  s.cav_temp = 350.0f;
+  s.cav_set_temp = 375.0f;
+  s.cav_cook_mode = 5;
+  s.cav_probe_temp = 165.0f;
+  s.cav_probe_set_temp = 180.0f;
+
+  RangeRecorder rec;
+  dispatch_range(s, rec);
+
+  EXPECT_EQ(rec.bools["door_ajar"], false);
+  EXPECT_EQ(rec.bools["cav_unit_on"], true);
+  EXPECT_EQ(rec.bools["cav_at_set_temp"], false);
+  EXPECT_EQ(rec.bools["cav_light_on"], true);
+  EXPECT_EQ(rec.bools["cav_remote_ready"], false);
+  EXPECT_EQ(rec.bools["cav_probe_on"], true);
+  EXPECT_EQ(rec.bools["cav_probe_at_temp"], false);
+  EXPECT_EQ(rec.bools["cav_probe_near"], true);
+  EXPECT_EQ(rec.bools["cav_gourmet"], false);
+  EXPECT_EQ(rec.ints["cav_gourmet_recipe"], 12);
+  EXPECT_EQ(rec.bools["cook_timer_done"], false);
+  EXPECT_EQ(rec.bools["cook_timer_near"], true);
+  EXPECT_FLOAT_EQ(rec.floats["cav_temp"], 350.0f);
+  EXPECT_FLOAT_EQ(rec.floats["cav_set_temp"], 375.0f);
+  EXPECT_EQ(rec.ints["cav_cook_mode"], 5);
+  EXPECT_FLOAT_EQ(rec.floats["probe_temp"], 165.0f);
+  EXPECT_FLOAT_EQ(rec.floats["probe_set_temp"], 180.0f);
+}
+
+TEST(Dispatch, RangeFieldsRouted_KitchenTimers) {
+  RangeState s;
+  s.kitchen_timer_active = true;
+  s.kitchen_timer_complete = false;
+  s.kitchen_timer_within_1min = true;
+  s.kitchen_timer_end_time = std::string("2026-04-25T07:30");
+  s.kitchen_timer2_active = false;
+  s.kitchen_timer2_complete = true;
+  s.kitchen_timer2_within_1min = false;
+  s.kitchen_timer2_end_time = std::string("2026-04-25T08:00");
+
+  RangeRecorder rec;
+  dispatch_range(s, rec);
+
+  EXPECT_EQ(rec.bools["ktimer_active"], true);
+  EXPECT_EQ(rec.bools["ktimer_done"], false);
+  EXPECT_EQ(rec.bools["ktimer_near"], true);
+  EXPECT_EQ(rec.strings["ktimer_end_time"], "2026-04-25T07:30");
+  EXPECT_EQ(rec.bools["ktimer2_active"], false);
+  EXPECT_EQ(rec.bools["ktimer2_done"], true);
+  EXPECT_EQ(rec.bools["ktimer2_near"], false);
+  EXPECT_EQ(rec.strings["ktimer2_end_time"], "2026-04-25T08:00");
+}
+
+TEST(Dispatch, RangeFieldsRouted_SecondaryCavity) {
+  RangeState s;
+  s.cav2_unit_on = true;
+  s.cav2_door_ajar = false;
+  s.cav2_at_set_temp = true;
+  s.cav2_light_on = false;
+  s.cav2_remote_ready = true;
+  s.cav2_probe_on = false;
+  s.cav2_probe_at_set_temp = true;
+  s.cav2_probe_within_10deg = false;
+  s.cav2_gourmet_mode_on = true;
+  s.cav2_cook_timer_complete = false;
+  s.cav2_temp = 300.0f;
+  s.cav2_set_temp = 325.0f;
+  s.cav2_cook_mode = 2;
+  s.cav2_probe_temp = 140.0f;
+  s.cav2_probe_set_temp = 155.0f;
+
+  RangeRecorder rec;
+  dispatch_range(s, rec);
+
+  EXPECT_EQ(rec.bools["cav2_unit_on"], true);
+  EXPECT_EQ(rec.bools["cav2_door_ajar"], false);
+  EXPECT_EQ(rec.bools["cav2_at_set_temp"], true);
+  EXPECT_EQ(rec.bools["cav2_light_on"], false);
+  EXPECT_EQ(rec.bools["cav2_remote_ready"], true);
+  EXPECT_EQ(rec.bools["cav2_probe_on"], false);
+  EXPECT_EQ(rec.bools["cav2_probe_at_temp"], true);
+  EXPECT_EQ(rec.bools["cav2_probe_near"], false);
+  EXPECT_EQ(rec.bools["cav2_gourmet"], true);
+  EXPECT_EQ(rec.bools["cav2_cook_timer_done"], false);
+  EXPECT_FLOAT_EQ(rec.floats["cav2_temp"], 300.0f);
+  EXPECT_FLOAT_EQ(rec.floats["cav2_set_temp"], 325.0f);
+  EXPECT_EQ(rec.ints["cav2_cook_mode"], 2);
+  EXPECT_FLOAT_EQ(rec.floats["cav2_probe_temp"], 140.0f);
+  EXPECT_FLOAT_EQ(rec.floats["cav2_probe_set_temp"], 155.0f);
+}
+
+// =============================================================================
+// End-to-end fixture replay — parses real captured payloads, dispatches,
+// and asserts a few high-signal sensor publishes match. Catches "parser
+// produced expected struct, but dispatch didn't wire X to Y."
+// =============================================================================
+
+TEST(Dispatch, FixtureFridgeFullPoll) {
+  std::string raw = read_file(fs::path(FIXTURES_DIR) / "fridge_back_2028_d5_full.json");
+  ASSERT_FALSE(raw.empty());
+  auto s = parse_fridge(raw);
+  ASSERT_TRUE(s.valid);
+  ASSERT_TRUE(s.is_poll);
+
+  FridgeRecorder rec;
+  dispatch_fridge(s, rec);
+
+  // Sample of fields we know are present in the fixture (verified from
+  // tests/fixtures/fridge_back_2028_d5_full.expected.json):
+  EXPECT_FALSE(rec.strings["model"].empty());
+  EXPECT_FALSE(rec.strings["serial"].empty());
+  EXPECT_FALSE(rec.strings["fw_version"].empty());
+  // The fridge has a setpoint and door state.
+  EXPECT_NE(rec.floats.find("set_temp"), rec.floats.end());
+  EXPECT_NE(rec.bools.find("door_ajar"), rec.bools.end());
+}
+
+TEST(Dispatch, FixtureFridgePushDoor) {
+  std::string raw = read_file(fs::path(FIXTURES_DIR) / "fridge_push_ref_door_true.json");
+  ASSERT_FALSE(raw.empty());
+  auto s = parse_fridge(raw);
+  ASSERT_TRUE(s.valid);
+  EXPECT_FALSE(s.is_poll);  // push notification
+
+  FridgeRecorder rec;
+  dispatch_fridge(s, rec);
+
+  // Push for a door event should publish the door state and not much else.
+  ASSERT_NE(rec.bools.find("door_ajar"), rec.bools.end());
+  EXPECT_EQ(rec.bools["door_ajar"], true);
+  // No firmware version in a push notification.
+  EXPECT_TRUE(rec.strings["fw_version"].empty());
+}
+
+TEST(Dispatch, FixtureDishwasherFullPoll) {
+  std::string raw = read_file(fs::path(FIXTURES_DIR) / "dishwasher_dw2450_d5_full.json");
+  ASSERT_FALSE(raw.empty());
+  auto s = parse_dishwasher(raw);
+  ASSERT_TRUE(s.valid);
+
+  DishwasherRecorder rec;
+  dispatch_dishwasher(s, rec);
+
+  EXPECT_FALSE(rec.strings["model"].empty());
+  // The fixture should populate at least one wash-related field.
+  bool has_wash_field = rec.bools.count("wash_cycle_on") > 0 ||
+                       rec.ints.count("wash_status") > 0 ||
+                       rec.ints.count("wash_cycle") > 0;
+  EXPECT_TRUE(has_wash_field);
+}
+
+TEST(Dispatch, FixtureRangeFullPoll) {
+  std::string raw = read_file(fs::path(FIXTURES_DIR) / "range_df36450_d5_full.json");
+  ASSERT_FALSE(raw.empty());
+  auto s = parse_range(raw);
+  ASSERT_TRUE(s.valid);
+
+  RangeRecorder rec;
+  dispatch_range(s, rec);
+
+  EXPECT_FALSE(rec.strings["model"].empty());
+  EXPECT_FALSE(rec.strings["fw_version"].empty());
+}
+
+TEST(Dispatch, FixtureRangePushLightOn) {
+  std::string raw = read_file(fs::path(FIXTURES_DIR) / "range_push_light_on.json");
+  ASSERT_FALSE(raw.empty());
+  auto s = parse_range(raw);
+  ASSERT_TRUE(s.valid);
+  EXPECT_FALSE(s.is_poll);
+
+  RangeRecorder rec;
+  dispatch_range(s, rec);
+
+  ASSERT_NE(rec.bools.find("cav_light_on"), rec.bools.end());
+  EXPECT_EQ(rec.bools["cav_light_on"], true);
+}
+
+TEST(Dispatch, FixtureWallovenPushSetTemp) {
+  std::string raw = read_file(fs::path(FIXTURES_DIR) / "walloven_push_set_temp.json");
+  ASSERT_FALSE(raw.empty());
+  auto s = parse_range(raw);
+  ASSERT_TRUE(s.valid);
+
+  RangeRecorder rec;
+  dispatch_range(s, rec);
+
+  ASSERT_NE(rec.floats.find("cav_set_temp"), rec.floats.end());
+}
+
+TEST(Dispatch, InvalidParseProducesNoCalls) {
+  // dispatch_* assumes valid==true; the YAML caller already guards. But
+  // verify dispatching a struct with all-nullopt optionals (the shape of
+  // an "invalid" parse result) doesn't accidentally call anything.
+  FridgeState s;
+  s.valid = false;  // dispatch doesn't check this — fields are still empty
+  FridgeRecorder rec;
+  dispatch_fridge(s, rec);
+  EXPECT_TRUE(rec.bools.empty());
+  EXPECT_TRUE(rec.floats.empty());
+  EXPECT_TRUE(rec.strings.empty());
+}

--- a/tests/cpp/dispatch_test.cpp
+++ b/tests/cpp/dispatch_test.cpp
@@ -34,15 +34,23 @@ struct CommonRecorder {
   void publish_model(const std::string &v) { strings["model"] = v; }
   void publish_uptime(const std::string &v) { strings["uptime"] = v; }
   void publish_serial(const std::string &v) { strings["serial"] = v; }
-  void publish_appliance_type(const std::string &v) { strings["appliance_type"] = v; }
+  void publish_appliance_type(const std::string &v) {
+    strings["appliance_type"] = v;
+  }
   void publish_diag_status(const std::string &v) { strings["diag_status"] = v; }
   void publish_build_date(const std::string &v) { strings["build_date"] = v; }
   void publish_fw_version(const std::string &v) { strings["fw_version"] = v; }
   void publish_api_version(const std::string &v) { strings["api_version"] = v; }
-  void publish_bleapp_version(const std::string &v) { strings["bleapp_version"] = v; }
+  void publish_bleapp_version(const std::string &v) {
+    strings["bleapp_version"] = v;
+  }
   void publish_os_version(const std::string &v) { strings["os_version"] = v; }
-  void publish_rtapp_version(const std::string &v) { strings["rtapp_version"] = v; }
-  void publish_board_version(const std::string &v) { strings["board_version"] = v; }
+  void publish_rtapp_version(const std::string &v) {
+    strings["rtapp_version"] = v;
+  }
+  void publish_board_version(const std::string &v) {
+    strings["board_version"] = v;
+  }
 };
 
 struct FridgeRecorder : CommonRecorder {
@@ -85,7 +93,9 @@ struct DishwasherRecorder : CommonRecorder {
     strings["wash_cycle_end_time"] = v;
   }
 
-  void clear_wash_time_remaining_if_running() { clear_wash_time_remaining_called = true; }
+  void clear_wash_time_remaining_if_running() {
+    clear_wash_time_remaining_called = true;
+  }
 };
 
 struct RangeRecorder : CommonRecorder {
@@ -114,8 +124,12 @@ struct RangeRecorder : CommonRecorder {
   void publish_ktimer2_active(bool v) { bools["ktimer2_active"] = v; }
   void publish_ktimer2_done(bool v) { bools["ktimer2_done"] = v; }
   void publish_ktimer2_near(bool v) { bools["ktimer2_near"] = v; }
-  void publish_ktimer_end_time(const std::string &v) { strings["ktimer_end_time"] = v; }
-  void publish_ktimer2_end_time(const std::string &v) { strings["ktimer2_end_time"] = v; }
+  void publish_ktimer_end_time(const std::string &v) {
+    strings["ktimer_end_time"] = v;
+  }
+  void publish_ktimer2_end_time(const std::string &v) {
+    strings["ktimer2_end_time"] = v;
+  }
 
   void publish_cav2_unit_on(bool v) { bools["cav2_unit_on"] = v; }
   void publish_cav2_door_ajar(bool v) { bools["cav2_door_ajar"] = v; }
@@ -126,13 +140,17 @@ struct RangeRecorder : CommonRecorder {
   void publish_cav2_probe_at_temp(bool v) { bools["cav2_probe_at_temp"] = v; }
   void publish_cav2_probe_near(bool v) { bools["cav2_probe_near"] = v; }
   void publish_cav2_gourmet(bool v) { bools["cav2_gourmet"] = v; }
-  void publish_cav2_cook_timer_done(bool v) { bools["cav2_cook_timer_done"] = v; }
+  void publish_cav2_cook_timer_done(bool v) {
+    bools["cav2_cook_timer_done"] = v;
+  }
 
   void publish_cav2_temp(float v) { floats["cav2_temp"] = v; }
   void publish_cav2_set_temp(float v) { floats["cav2_set_temp"] = v; }
   void publish_cav2_cook_mode(int v) { ints["cav2_cook_mode"] = v; }
   void publish_cav2_probe_temp(float v) { floats["cav2_probe_temp"] = v; }
-  void publish_cav2_probe_set_temp(float v) { floats["cav2_probe_set_temp"] = v; }
+  void publish_cav2_probe_set_temp(float v) {
+    floats["cav2_probe_set_temp"] = v;
+  }
 };
 
 std::string read_file(const fs::path &p) {
@@ -142,7 +160,7 @@ std::string read_file(const fs::path &p) {
   return ss.str();
 }
 
-}  // namespace
+} // namespace
 
 // =============================================================================
 // Empty-state behavior — no fields → no calls. Catches dispatchers that
@@ -150,7 +168,7 @@ std::string read_file(const fs::path &p) {
 // =============================================================================
 
 TEST(Dispatch, FridgeEmptyStateNoCalls) {
-  FridgeState s;  // all optionals nullopt
+  FridgeState s; // all optionals nullopt
   FridgeRecorder rec;
   dispatch_fridge(s, rec);
   EXPECT_TRUE(rec.bools.empty());
@@ -442,7 +460,8 @@ TEST(Dispatch, RangeFieldsRouted_SecondaryCavity) {
 // =============================================================================
 
 TEST(Dispatch, FixtureFridgeFullPoll) {
-  std::string raw = read_file(fs::path(FIXTURES_DIR) / "fridge_back_2028_d5_full.json");
+  std::string raw =
+      read_file(fs::path(FIXTURES_DIR) / "fridge_back_2028_d5_full.json");
   ASSERT_FALSE(raw.empty());
   auto s = parse_fridge(raw);
   ASSERT_TRUE(s.valid);
@@ -462,11 +481,12 @@ TEST(Dispatch, FixtureFridgeFullPoll) {
 }
 
 TEST(Dispatch, FixtureFridgePushDoor) {
-  std::string raw = read_file(fs::path(FIXTURES_DIR) / "fridge_push_ref_door_true.json");
+  std::string raw =
+      read_file(fs::path(FIXTURES_DIR) / "fridge_push_ref_door_true.json");
   ASSERT_FALSE(raw.empty());
   auto s = parse_fridge(raw);
   ASSERT_TRUE(s.valid);
-  EXPECT_FALSE(s.is_poll);  // push notification
+  EXPECT_FALSE(s.is_poll); // push notification
 
   FridgeRecorder rec;
   dispatch_fridge(s, rec);
@@ -479,7 +499,8 @@ TEST(Dispatch, FixtureFridgePushDoor) {
 }
 
 TEST(Dispatch, FixtureDishwasherFullPoll) {
-  std::string raw = read_file(fs::path(FIXTURES_DIR) / "dishwasher_dw2450_d5_full.json");
+  std::string raw =
+      read_file(fs::path(FIXTURES_DIR) / "dishwasher_dw2450_d5_full.json");
   ASSERT_FALSE(raw.empty());
   auto s = parse_dishwasher(raw);
   ASSERT_TRUE(s.valid);
@@ -490,13 +511,14 @@ TEST(Dispatch, FixtureDishwasherFullPoll) {
   EXPECT_FALSE(rec.strings["model"].empty());
   // The fixture should populate at least one wash-related field.
   bool has_wash_field = rec.bools.count("wash_cycle_on") > 0 ||
-                       rec.ints.count("wash_status") > 0 ||
-                       rec.ints.count("wash_cycle") > 0;
+                        rec.ints.count("wash_status") > 0 ||
+                        rec.ints.count("wash_cycle") > 0;
   EXPECT_TRUE(has_wash_field);
 }
 
 TEST(Dispatch, FixtureRangeFullPoll) {
-  std::string raw = read_file(fs::path(FIXTURES_DIR) / "range_df36450_d5_full.json");
+  std::string raw =
+      read_file(fs::path(FIXTURES_DIR) / "range_df36450_d5_full.json");
   ASSERT_FALSE(raw.empty());
   auto s = parse_range(raw);
   ASSERT_TRUE(s.valid);
@@ -509,7 +531,8 @@ TEST(Dispatch, FixtureRangeFullPoll) {
 }
 
 TEST(Dispatch, FixtureRangePushLightOn) {
-  std::string raw = read_file(fs::path(FIXTURES_DIR) / "range_push_light_on.json");
+  std::string raw =
+      read_file(fs::path(FIXTURES_DIR) / "range_push_light_on.json");
   ASSERT_FALSE(raw.empty());
   auto s = parse_range(raw);
   ASSERT_TRUE(s.valid);
@@ -523,7 +546,8 @@ TEST(Dispatch, FixtureRangePushLightOn) {
 }
 
 TEST(Dispatch, FixtureWallovenPushSetTemp) {
-  std::string raw = read_file(fs::path(FIXTURES_DIR) / "walloven_push_set_temp.json");
+  std::string raw =
+      read_file(fs::path(FIXTURES_DIR) / "walloven_push_set_temp.json");
   ASSERT_FALSE(raw.empty());
   auto s = parse_range(raw);
   ASSERT_TRUE(s.valid);
@@ -539,7 +563,7 @@ TEST(Dispatch, InvalidParseProducesNoCalls) {
   // verify dispatching a struct with all-nullopt optionals (the shape of
   // an "invalid" parse result) doesn't accidentally call anything.
   FridgeState s;
-  s.valid = false;  // dispatch doesn't check this — fields are still empty
+  s.valid = false; // dispatch doesn't check this — fields are still empty
   FridgeRecorder rec;
   dispatch_fridge(s, rec);
   EXPECT_TRUE(rec.bools.empty());

--- a/tests/cpp/gatt_handles_test.cpp
+++ b/tests/cpp/gatt_handles_test.cpp
@@ -11,11 +11,11 @@ using esphome::subzero_protocol::GattEntry;
 namespace {
 
 GattEntry make_char(std::uint8_t uuid_first, std::uint16_t handle) {
-  return GattEntry{/*is_characteristic=*/true, /*is_uuid128=*/true,
-                   uuid_first, handle};
+  return GattEntry{/*is_characteristic=*/true, /*is_uuid128=*/true, uuid_first,
+                   handle};
 }
 
-}  // namespace
+} // namespace
 
 TEST(AppHandles, EmptyByDefault) {
   AppHandles h;
@@ -52,11 +52,9 @@ TEST(ExtractHandles, EmptyInputLeavesOutputUntouched) {
 
 TEST(ExtractHandles, FullDiscoveryPicksUpAllThree) {
   std::vector<GattEntry> entries{
-      make_char(0xD4, 0x10),  // ignored: D4 unused post-PR-#72
-      make_char(0xD5, 0x12),
-      make_char(0xD6, 0x14),
-      make_char(0xD7, 0x16),
-      make_char(0xD8, 0x18),  // ignored: D8 unused post-PR-#72
+      make_char(0xD4, 0x10), // ignored: D4 unused post-PR-#72
+      make_char(0xD5, 0x12), make_char(0xD6, 0x14), make_char(0xD7, 0x16),
+      make_char(0xD8, 0x18), // ignored: D8 unused post-PR-#72
   };
   AppHandles h;
   extract_handles(entries, h);
@@ -110,14 +108,14 @@ TEST(ExtractHandles, DoesNotOverwriteAlreadyFoundHandles) {
   h.d5 = 0x12;
   h.d6 = 0x14;
   std::vector<GattEntry> later_pass{
-      make_char(0xD5, 0xAA),  // would-be replacement
+      make_char(0xD5, 0xAA), // would-be replacement
       make_char(0xD6, 0xBB),
       make_char(0xD7, 0x16),
   };
   extract_handles(later_pass, h);
-  EXPECT_EQ(h.d5, 0x12);  // preserved
-  EXPECT_EQ(h.d6, 0x14);  // preserved
-  EXPECT_EQ(h.d7, 0x16);  // newly found
+  EXPECT_EQ(h.d5, 0x12); // preserved
+  EXPECT_EQ(h.d6, 0x14); // preserved
+  EXPECT_EQ(h.d7, 0x16); // newly found
 }
 
 TEST(ExtractHandles, IgnoresDescriptorsAndServices) {

--- a/tests/cpp/gatt_handles_test.cpp
+++ b/tests/cpp/gatt_handles_test.cpp
@@ -1,0 +1,171 @@
+#include "gatt_handles.h"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+using esphome::subzero_protocol::AppHandles;
+using esphome::subzero_protocol::extract_handles;
+using esphome::subzero_protocol::GattEntry;
+
+namespace {
+
+GattEntry make_char(std::uint8_t uuid_first, std::uint16_t handle) {
+  return GattEntry{/*is_characteristic=*/true, /*is_uuid128=*/true,
+                   uuid_first, handle};
+}
+
+}  // namespace
+
+TEST(AppHandles, EmptyByDefault) {
+  AppHandles h;
+  EXPECT_EQ(h.d5, 0);
+  EXPECT_EQ(h.d6, 0);
+  EXPECT_EQ(h.d7, 0);
+  EXPECT_FALSE(h.has_d5());
+  EXPECT_FALSE(h.has_d6());
+  EXPECT_FALSE(h.has_d7());
+  EXPECT_FALSE(h.ready());
+}
+
+TEST(AppHandles, ReadyWantsBothD5AndD6) {
+  AppHandles h;
+  EXPECT_FALSE(h.ready());
+  h.d5 = 0x10;
+  EXPECT_FALSE(h.ready());
+  h.d6 = 0x20;
+  EXPECT_TRUE(h.ready());
+  // D7 is optional for ready-state.
+  AppHandles h2;
+  h2.d7 = 0x30;
+  EXPECT_FALSE(h2.ready());
+}
+
+TEST(ExtractHandles, EmptyInputLeavesOutputUntouched) {
+  std::vector<GattEntry> entries;
+  AppHandles h;
+  extract_handles(entries, h);
+  EXPECT_EQ(h.d5, 0);
+  EXPECT_EQ(h.d6, 0);
+  EXPECT_EQ(h.d7, 0);
+}
+
+TEST(ExtractHandles, FullDiscoveryPicksUpAllThree) {
+  std::vector<GattEntry> entries{
+      make_char(0xD4, 0x10),  // ignored: D4 unused post-PR-#72
+      make_char(0xD5, 0x12),
+      make_char(0xD6, 0x14),
+      make_char(0xD7, 0x16),
+      make_char(0xD8, 0x18),  // ignored: D8 unused post-PR-#72
+  };
+  AppHandles h;
+  extract_handles(entries, h);
+  EXPECT_EQ(h.d5, 0x12);
+  EXPECT_EQ(h.d6, 0x14);
+  EXPECT_EQ(h.d7, 0x16);
+}
+
+TEST(ExtractHandles, FridgeStylePartialFirstPass) {
+  // On fridges, D5 is not visible until after bonding + cache refresh.
+  // The first GATT db dump returns only the services / 16-bit-UUID
+  // characteristics; D5/D6/D7 land in a later pass.
+  std::vector<GattEntry> entries{
+      // Service entries (not characteristics): ignored.
+      GattEntry{/*char=*/false, /*128=*/false, 0xD5, 0x99},
+      // 16-bit UUID characteristic: ignored even if first byte matches.
+      GattEntry{/*char=*/true, /*128=*/false, 0xD5, 0x99},
+  };
+  AppHandles h;
+  extract_handles(entries, h);
+  EXPECT_FALSE(h.ready());
+}
+
+TEST(ExtractHandles, IsAdditiveAcrossPasses) {
+  AppHandles h;
+  // Pass 1: only D7 visible (open pre-auth channel).
+  std::vector<GattEntry> pass1{make_char(0xD7, 0x16)};
+  extract_handles(pass1, h);
+  EXPECT_EQ(h.d5, 0);
+  EXPECT_EQ(h.d6, 0);
+  EXPECT_EQ(h.d7, 0x16);
+
+  // Pass 2: D5 and D6 now visible (post-encryption).
+  std::vector<GattEntry> pass2{
+      make_char(0xD5, 0x12),
+      make_char(0xD6, 0x14),
+  };
+  extract_handles(pass2, h);
+  EXPECT_EQ(h.d5, 0x12);
+  EXPECT_EQ(h.d6, 0x14);
+  EXPECT_EQ(h.d7, 0x16);
+  EXPECT_TRUE(h.ready());
+}
+
+TEST(ExtractHandles, DoesNotOverwriteAlreadyFoundHandles) {
+  // Some appliances re-emit characteristic entries with different
+  // attribute_handles after a cache refresh (Bluedroid quirk). Once we
+  // have a handle, keep it — re-subscribing on a different handle would
+  // confuse the existing notify wiring.
+  AppHandles h;
+  h.d5 = 0x12;
+  h.d6 = 0x14;
+  std::vector<GattEntry> later_pass{
+      make_char(0xD5, 0xAA),  // would-be replacement
+      make_char(0xD6, 0xBB),
+      make_char(0xD7, 0x16),
+  };
+  extract_handles(later_pass, h);
+  EXPECT_EQ(h.d5, 0x12);  // preserved
+  EXPECT_EQ(h.d6, 0x14);  // preserved
+  EXPECT_EQ(h.d7, 0x16);  // newly found
+}
+
+TEST(ExtractHandles, IgnoresDescriptorsAndServices) {
+  std::vector<GattEntry> entries{
+      // Service entry shaped like D5 — must not be picked up.
+      GattEntry{/*char=*/false, /*128=*/true, 0xD5, 0x10},
+      // Real D5 characteristic.
+      make_char(0xD5, 0x12),
+  };
+  AppHandles h;
+  extract_handles(entries, h);
+  EXPECT_EQ(h.d5, 0x12);
+}
+
+TEST(ExtractHandles, IgnoresUnknownUuidFirstBytes) {
+  std::vector<GattEntry> entries{
+      make_char(0x00, 0x10),
+      make_char(0x42, 0x12),
+      make_char(0xFF, 0x14),
+  };
+  AppHandles h;
+  extract_handles(entries, h);
+  EXPECT_EQ(h.d5, 0);
+  EXPECT_EQ(h.d6, 0);
+  EXPECT_EQ(h.d7, 0);
+}
+
+TEST(ExtractHandles, RealisticDualOvenRange) {
+  // Reflects what we observed on the Wolf SO3050PESP wall oven during
+  // a successful discovery pass.
+  std::vector<GattEntry> entries{
+      // Generic Access Profile (1800) primary service entries...
+      GattEntry{/*char=*/false, /*128=*/false, 0x00, 0x0001},
+      // Device Name characteristic (16-bit UUID 2A00) — ignored.
+      GattEntry{/*char=*/true, /*128=*/false, 0x00, 0x0003},
+      // Sub-Zero proprietary service entry (128-bit but not a char).
+      GattEntry{/*char=*/false, /*128=*/true, 0xF4, 0x000A},
+      // The five characteristics, only D5/D6/D7 picked up.
+      make_char(0xD4, 0x000C),
+      make_char(0xD5, 0x000F),
+      make_char(0xD6, 0x0012),
+      make_char(0xD7, 0x0015),
+      make_char(0xD8, 0x0018),
+  };
+  AppHandles h;
+  extract_handles(entries, h);
+  EXPECT_EQ(h.d5, 0x000F);
+  EXPECT_EQ(h.d6, 0x0012);
+  EXPECT_EQ(h.d7, 0x0015);
+  EXPECT_TRUE(h.ready());
+}

--- a/tests/cpp/protocol_test.cpp
+++ b/tests/cpp/protocol_test.cpp
@@ -14,409 +14,374 @@ namespace fs = std::filesystem;
 using json = nlohmann::json;
 using namespace esphome::subzero_protocol;
 
-namespace
-{
-  std::string read_file(const fs::path &p)
-  {
-    std::ifstream in(p);
-    std::stringstream ss;
-    ss << in.rdbuf();
-    return ss.str();
-  }
+namespace {
+std::string read_file(const fs::path &p) {
+  std::ifstream in(p);
+  std::stringstream ss;
+  ss << in.rdbuf();
+  return ss.str();
+}
 
-  // Numeric-tolerant deep equality: treats int 38 == float 38.0.
-  bool json_equal(const json &a, const json &b)
-  {
-    if (a.is_number() && b.is_number())
-    {
-      return a.get<double>() == b.get<double>();
-    }
-    if (a.type() != b.type())
+// Numeric-tolerant deep equality: treats int 38 == float 38.0.
+bool json_equal(const json &a, const json &b) {
+  if (a.is_number() && b.is_number()) {
+    return a.get<double>() == b.get<double>();
+  }
+  if (a.type() != b.type())
+    return false;
+  if (a.is_object()) {
+    if (a.size() != b.size())
       return false;
-    if (a.is_object())
-    {
-      if (a.size() != b.size())
+    for (auto it = a.begin(); it != a.end(); ++it) {
+      auto bi = b.find(it.key());
+      if (bi == b.end())
         return false;
-      for (auto it = a.begin(); it != a.end(); ++it)
-      {
-        auto bi = b.find(it.key());
-        if (bi == b.end())
-          return false;
-        if (!json_equal(it.value(), *bi))
-          return false;
-      }
-      return true;
-    }
-    if (a.is_array())
-    {
-      if (a.size() != b.size())
+      if (!json_equal(it.value(), *bi))
         return false;
-      for (size_t i = 0; i < a.size(); i++)
-      {
-        if (!json_equal(a[i], b[i]))
-          return false;
-      }
-      return true;
     }
-    return a == b;
+    return true;
   }
+  if (a.is_array()) {
+    if (a.size() != b.size())
+      return false;
+    for (size_t i = 0; i < a.size(); i++) {
+      if (!json_equal(a[i], b[i]))
+        return false;
+    }
+    return true;
+  }
+  return a == b;
+}
 
-#define OPT_PUT(obj, s, field) \
-  if ((s).field)               \
+#define OPT_PUT(obj, s, field)                                                 \
+  if ((s).field)                                                               \
   (obj)[#field] = *(s).field
 
-  json version_to_json(const Version &v)
-  {
-    json o = json::object();
-    OPT_PUT(o, v, fw);
-    OPT_PUT(o, v, api);
-    OPT_PUT(o, v, bleapp);
-    OPT_PUT(o, v, os);
-    OPT_PUT(o, v, rtapp);
-    OPT_PUT(o, v, appliance);
+json version_to_json(const Version &v) {
+  json o = json::object();
+  OPT_PUT(o, v, fw);
+  OPT_PUT(o, v, api);
+  OPT_PUT(o, v, bleapp);
+  OPT_PUT(o, v, os);
+  OPT_PUT(o, v, rtapp);
+  OPT_PUT(o, v, appliance);
+  return o;
+}
+
+json common_to_json(const CommonFields &c) {
+  json o = json::object();
+  OPT_PUT(o, c, pin_confirmed);
+  OPT_PUT(o, c, sabbath_on);
+  OPT_PUT(o, c, service_required);
+  OPT_PUT(o, c, appliance_model);
+  OPT_PUT(o, c, uptime);
+  OPT_PUT(o, c, appliance_serial);
+  OPT_PUT(o, c, appliance_type);
+  OPT_PUT(o, c, diagnostic_status);
+  OPT_PUT(o, c, build_date);
+  json v = version_to_json(c.version);
+  if (!v.empty())
+    o["version"] = v;
+  return o;
+}
+
+json fridge_to_json(const FridgeState &s) {
+  json o = json::object();
+  o["valid"] = s.valid;
+  if (!s.valid)
     return o;
-  }
+  json c = common_to_json(s.common);
+  if (!c.empty())
+    o["common"] = c;
+  OPT_PUT(o, s, ref_set_temp);
+  OPT_PUT(o, s, door_ajar);
+  OPT_PUT(o, s, frz_set_temp);
+  OPT_PUT(o, s, frz_door_ajar);
+  OPT_PUT(o, s, ice_maker_on);
+  OPT_PUT(o, s, ref2_set_temp);
+  OPT_PUT(o, s, ref2_door_ajar);
+  OPT_PUT(o, s, wine_door_ajar);
+  OPT_PUT(o, s, wine_set_temp);
+  OPT_PUT(o, s, wine2_set_temp);
+  OPT_PUT(o, s, wine_temp_alert_on);
+  OPT_PUT(o, s, crisp_set_temp);
+  OPT_PUT(o, s, air_filter_on);
+  OPT_PUT(o, s, air_filter_pct_remaining);
+  OPT_PUT(o, s, water_filter_pct_remaining);
+  return o;
+}
 
-  json common_to_json(const CommonFields &c)
-  {
-    json o = json::object();
-    OPT_PUT(o, c, pin_confirmed);
-    OPT_PUT(o, c, sabbath_on);
-    OPT_PUT(o, c, service_required);
-    OPT_PUT(o, c, appliance_model);
-    OPT_PUT(o, c, uptime);
-    OPT_PUT(o, c, appliance_serial);
-    OPT_PUT(o, c, appliance_type);
-    OPT_PUT(o, c, diagnostic_status);
-    OPT_PUT(o, c, build_date);
-    json v = version_to_json(c.version);
-    if (!v.empty())
-      o["version"] = v;
+json dishwasher_to_json(const DishwasherState &s) {
+  json o = json::object();
+  o["valid"] = s.valid;
+  if (!s.valid)
     return o;
-  }
+  json c = common_to_json(s.common);
+  if (!c.empty())
+    o["common"] = c;
+  OPT_PUT(o, s, door_ajar);
+  OPT_PUT(o, s, wash_cycle_on);
+  OPT_PUT(o, s, heated_dry_on);
+  OPT_PUT(o, s, extended_dry_on);
+  OPT_PUT(o, s, high_temp_wash_on);
+  OPT_PUT(o, s, sani_rinse_on);
+  OPT_PUT(o, s, rinse_aid_low);
+  OPT_PUT(o, s, softener_low);
+  OPT_PUT(o, s, light_on);
+  OPT_PUT(o, s, remote_ready);
+  OPT_PUT(o, s, delay_start_timer_active);
+  OPT_PUT(o, s, wash_status);
+  OPT_PUT(o, s, wash_cycle);
+  OPT_PUT(o, s, wash_cycle_end_time);
+  OPT_PUT(o, s, wash_time_remaining_min);
+  return o;
+}
 
-  json fridge_to_json(const FridgeState &s)
-  {
-    json o = json::object();
-    o["valid"] = s.valid;
-    if (!s.valid)
-      return o;
-    json c = common_to_json(s.common);
-    if (!c.empty())
-      o["common"] = c;
-    OPT_PUT(o, s, ref_set_temp);
-    OPT_PUT(o, s, door_ajar);
-    OPT_PUT(o, s, frz_set_temp);
-    OPT_PUT(o, s, frz_door_ajar);
-    OPT_PUT(o, s, ice_maker_on);
-    OPT_PUT(o, s, ref2_set_temp);
-    OPT_PUT(o, s, ref2_door_ajar);
-    OPT_PUT(o, s, wine_door_ajar);
-    OPT_PUT(o, s, wine_set_temp);
-    OPT_PUT(o, s, wine2_set_temp);
-    OPT_PUT(o, s, wine_temp_alert_on);
-    OPT_PUT(o, s, crisp_set_temp);
-    OPT_PUT(o, s, air_filter_on);
-    OPT_PUT(o, s, air_filter_pct_remaining);
-    OPT_PUT(o, s, water_filter_pct_remaining);
+json range_to_json(const RangeState &s) {
+  json o = json::object();
+  o["valid"] = s.valid;
+  if (!s.valid)
     return o;
+  json c = common_to_json(s.common);
+  if (!c.empty())
+    o["common"] = c;
+  OPT_PUT(o, s, door_ajar);
+  OPT_PUT(o, s, cav_unit_on);
+  OPT_PUT(o, s, cav_at_set_temp);
+  OPT_PUT(o, s, cav_light_on);
+  OPT_PUT(o, s, cav_remote_ready);
+  OPT_PUT(o, s, cav_probe_on);
+  OPT_PUT(o, s, cav_probe_at_set_temp);
+  OPT_PUT(o, s, cav_probe_within_10deg);
+  OPT_PUT(o, s, cav_gourmet_mode_on);
+  OPT_PUT(o, s, cav_gourmet_recipe);
+  OPT_PUT(o, s, cav_cook_timer_complete);
+  OPT_PUT(o, s, cav_cook_timer_within_1min);
+  OPT_PUT(o, s, cav_temp);
+  OPT_PUT(o, s, cav_set_temp);
+  OPT_PUT(o, s, cav_cook_mode);
+  OPT_PUT(o, s, cav_probe_temp);
+  OPT_PUT(o, s, cav_probe_set_temp);
+  OPT_PUT(o, s, kitchen_timer_active);
+  OPT_PUT(o, s, kitchen_timer_complete);
+  OPT_PUT(o, s, kitchen_timer_within_1min);
+  OPT_PUT(o, s, kitchen_timer_end_time);
+  OPT_PUT(o, s, kitchen_timer2_active);
+  OPT_PUT(o, s, kitchen_timer2_complete);
+  OPT_PUT(o, s, kitchen_timer2_within_1min);
+  OPT_PUT(o, s, kitchen_timer2_end_time);
+  OPT_PUT(o, s, cav2_unit_on);
+  OPT_PUT(o, s, cav2_door_ajar);
+  OPT_PUT(o, s, cav2_at_set_temp);
+  OPT_PUT(o, s, cav2_light_on);
+  OPT_PUT(o, s, cav2_remote_ready);
+  OPT_PUT(o, s, cav2_probe_on);
+  OPT_PUT(o, s, cav2_probe_at_set_temp);
+  OPT_PUT(o, s, cav2_probe_within_10deg);
+  OPT_PUT(o, s, cav2_gourmet_mode_on);
+  OPT_PUT(o, s, cav2_cook_timer_complete);
+  OPT_PUT(o, s, cav2_temp);
+  OPT_PUT(o, s, cav2_set_temp);
+  OPT_PUT(o, s, cav2_cook_mode);
+  OPT_PUT(o, s, cav2_probe_temp);
+  OPT_PUT(o, s, cav2_probe_set_temp);
+  return o;
+}
+
+enum class Parser { Fridge, Dishwasher, Range };
+
+Parser dispatch(const std::string &stem) {
+  if (stem.rfind("dishwasher_", 0) == 0)
+    return Parser::Dishwasher;
+  if (stem.rfind("range_", 0) == 0 || stem.rfind("walloven_", 0) == 0)
+    return Parser::Range;
+  // fridge_*, error_*, pin_*: all use parse_fridge (PIN & error paths are
+  // identical across the three parsers, so fridge is the representative).
+  return Parser::Fridge;
+}
+
+json run_parser(Parser p, const std::string &input) {
+  switch (p) {
+  case Parser::Fridge:
+    return fridge_to_json(parse_fridge(input));
+  case Parser::Dishwasher:
+    return dishwasher_to_json(parse_dishwasher(input));
+  case Parser::Range:
+    return range_to_json(parse_range(input));
   }
+  return {};
+}
 
-  json dishwasher_to_json(const DishwasherState &s)
-  {
-    json o = json::object();
-    o["valid"] = s.valid;
-    if (!s.valid)
-      return o;
-    json c = common_to_json(s.common);
-    if (!c.empty())
-      o["common"] = c;
-    OPT_PUT(o, s, door_ajar);
-    OPT_PUT(o, s, wash_cycle_on);
-    OPT_PUT(o, s, heated_dry_on);
-    OPT_PUT(o, s, extended_dry_on);
-    OPT_PUT(o, s, high_temp_wash_on);
-    OPT_PUT(o, s, sani_rinse_on);
-    OPT_PUT(o, s, rinse_aid_low);
-    OPT_PUT(o, s, softener_low);
-    OPT_PUT(o, s, light_on);
-    OPT_PUT(o, s, remote_ready);
-    OPT_PUT(o, s, delay_start_timer_active);
-    OPT_PUT(o, s, wash_status);
-    OPT_PUT(o, s, wash_cycle);
-    OPT_PUT(o, s, wash_cycle_end_time);
-    OPT_PUT(o, s, wash_time_remaining_min);
-    return o;
+struct Fixture {
+  std::string name;
+  fs::path input_path;
+  fs::path expected_path;
+};
+
+std::vector<Fixture> discover_fixtures() {
+  std::vector<Fixture> out;
+  fs::path dir(FIXTURES_DIR);
+  for (auto &entry : fs::directory_iterator(dir)) {
+    if (!entry.is_regular_file())
+      continue;
+    auto &p = entry.path();
+    if (p.extension() != ".json")
+      continue;
+    std::string stem = p.stem().string();
+    // Skip expected files — those end with ".expected"
+    if (stem.size() >= 9 && stem.compare(stem.size() - 9, 9, ".expected") == 0)
+      continue;
+    fs::path expected = dir / (stem + ".expected.json");
+    if (!fs::exists(expected))
+      continue;
+    out.push_back({stem, p, expected});
   }
+  std::sort(out.begin(), out.end(),
+            [](auto &a, auto &b) { return a.name < b.name; });
+  return out;
+}
 
-  json range_to_json(const RangeState &s)
-  {
-    json o = json::object();
-    o["valid"] = s.valid;
-    if (!s.valid)
-      return o;
-    json c = common_to_json(s.common);
-    if (!c.empty())
-      o["common"] = c;
-    OPT_PUT(o, s, door_ajar);
-    OPT_PUT(o, s, cav_unit_on);
-    OPT_PUT(o, s, cav_at_set_temp);
-    OPT_PUT(o, s, cav_light_on);
-    OPT_PUT(o, s, cav_remote_ready);
-    OPT_PUT(o, s, cav_probe_on);
-    OPT_PUT(o, s, cav_probe_at_set_temp);
-    OPT_PUT(o, s, cav_probe_within_10deg);
-    OPT_PUT(o, s, cav_gourmet_mode_on);
-    OPT_PUT(o, s, cav_gourmet_recipe);
-    OPT_PUT(o, s, cav_cook_timer_complete);
-    OPT_PUT(o, s, cav_cook_timer_within_1min);
-    OPT_PUT(o, s, cav_temp);
-    OPT_PUT(o, s, cav_set_temp);
-    OPT_PUT(o, s, cav_cook_mode);
-    OPT_PUT(o, s, cav_probe_temp);
-    OPT_PUT(o, s, cav_probe_set_temp);
-    OPT_PUT(o, s, kitchen_timer_active);
-    OPT_PUT(o, s, kitchen_timer_complete);
-    OPT_PUT(o, s, kitchen_timer_within_1min);
-    OPT_PUT(o, s, kitchen_timer_end_time);
-    OPT_PUT(o, s, kitchen_timer2_active);
-    OPT_PUT(o, s, kitchen_timer2_complete);
-    OPT_PUT(o, s, kitchen_timer2_within_1min);
-    OPT_PUT(o, s, kitchen_timer2_end_time);
-    OPT_PUT(o, s, cav2_unit_on);
-    OPT_PUT(o, s, cav2_door_ajar);
-    OPT_PUT(o, s, cav2_at_set_temp);
-    OPT_PUT(o, s, cav2_light_on);
-    OPT_PUT(o, s, cav2_remote_ready);
-    OPT_PUT(o, s, cav2_probe_on);
-    OPT_PUT(o, s, cav2_probe_at_set_temp);
-    OPT_PUT(o, s, cav2_probe_within_10deg);
-    OPT_PUT(o, s, cav2_gourmet_mode_on);
-    OPT_PUT(o, s, cav2_cook_timer_complete);
-    OPT_PUT(o, s, cav2_temp);
-    OPT_PUT(o, s, cav2_set_temp);
-    OPT_PUT(o, s, cav2_cook_mode);
-    OPT_PUT(o, s, cav2_probe_temp);
-    OPT_PUT(o, s, cav2_probe_set_temp);
-    return o;
-  }
+class FixtureTest : public ::testing::TestWithParam<Fixture> {};
 
-  enum class Parser
-  {
-    Fridge,
-    Dishwasher,
-    Range
-  };
+TEST_P(FixtureTest, Parses) {
+  const auto &fx = GetParam();
+  std::string input = read_file(fx.input_path);
+  json expected = json::parse(read_file(fx.expected_path));
+  json actual = run_parser(dispatch(fx.name), input);
+  EXPECT_TRUE(json_equal(actual, expected))
+      << "Fixture: " << fx.name << "\n"
+      << "Expected: " << expected.dump(2) << "\n"
+      << "Actual:   " << actual.dump(2);
+}
 
-  Parser dispatch(const std::string &stem)
-  {
-    if (stem.rfind("dishwasher_", 0) == 0)
-      return Parser::Dishwasher;
-    if (stem.rfind("range_", 0) == 0 || stem.rfind("walloven_", 0) == 0)
-      return Parser::Range;
-    // fridge_*, error_*, pin_*: all use parse_fridge (PIN & error paths are
-    // identical across the three parsers, so fridge is the representative).
-    return Parser::Fridge;
-  }
+INSTANTIATE_TEST_SUITE_P(AllFixtures, FixtureTest,
+                         ::testing::ValuesIn(discover_fixtures()),
+                         [](const ::testing::TestParamInfo<Fixture> &info) {
+                           return info.param.name;
+                         });
 
-  json run_parser(Parser p, const std::string &input)
-  {
-    switch (p)
-    {
-    case Parser::Fridge:
-      return fridge_to_json(parse_fridge(input));
-    case Parser::Dishwasher:
-      return dishwasher_to_json(parse_dishwasher(input));
-    case Parser::Range:
-      return range_to_json(parse_range(input));
-    }
-    return {};
-  }
+// A handful of targeted tests for protocol behaviors that deserve explicit
+// naming (rather than just fixture diffs).
 
-  struct Fixture
-  {
-    std::string name;
-    fs::path input_path;
-    fs::path expected_path;
-  };
+TEST(ProtocolTest, EmptyStringIsInvalid) {
+  auto f = parse_fridge("");
+  EXPECT_FALSE(f.valid);
+}
 
-  std::vector<Fixture> discover_fixtures()
-  {
-    std::vector<Fixture> out;
-    fs::path dir(FIXTURES_DIR);
-    for (auto &entry : fs::directory_iterator(dir))
-    {
-      if (!entry.is_regular_file())
-        continue;
-      auto &p = entry.path();
-      if (p.extension() != ".json")
-        continue;
-      std::string stem = p.stem().string();
-      // Skip expected files — those end with ".expected"
-      if (stem.size() >= 9 && stem.compare(stem.size() - 9, 9, ".expected") == 0)
-        continue;
-      fs::path expected = dir / (stem + ".expected.json");
-      if (!fs::exists(expected))
-        continue;
-      out.push_back({stem, p, expected});
-    }
-    std::sort(out.begin(), out.end(),
-              [](auto &a, auto &b)
-              { return a.name < b.name; });
-    return out;
-  }
+TEST(ProtocolTest, PinConfirmationPopulatesCommon) {
+  auto f = parse_fridge(R"({"status":0,"resp":{"pin":"654321"}})");
+  ASSERT_TRUE(f.valid);
+  ASSERT_TRUE(f.common.pin_confirmed.has_value());
+  EXPECT_EQ(*f.common.pin_confirmed, "654321");
+}
 
-  class FixtureTest : public ::testing::TestWithParam<Fixture>
-  {
-  };
+TEST(ProtocolTest, PinTooLongIsIgnored) {
+  auto f = parse_fridge(R"({"status":0,"resp":{"pin":"12345678901"}})");
+  ASSERT_TRUE(f.valid);
+  EXPECT_FALSE(f.common.pin_confirmed.has_value());
+}
 
-  TEST_P(FixtureTest, Parses)
-  {
-    const auto &fx = GetParam();
-    std::string input = read_file(fx.input_path);
-    json expected = json::parse(read_file(fx.expected_path));
-    json actual = run_parser(dispatch(fx.name), input);
-    EXPECT_TRUE(json_equal(actual, expected))
-        << "Fixture: " << fx.name << "\n"
-        << "Expected: " << expected.dump(2) << "\n"
-        << "Actual:   " << actual.dump(2);
-  }
+TEST(ProtocolTest, StatusNonZeroIsInvalid) {
+  auto f = parse_fridge(R"({"status":1,"resp":{"ref_set_temp":38}})");
+  EXPECT_FALSE(f.valid);
+}
 
-  INSTANTIATE_TEST_SUITE_P(
-      AllFixtures, FixtureTest, ::testing::ValuesIn(discover_fixtures()),
-      [](const ::testing::TestParamInfo<Fixture> &info)
-      { return info.param.name; });
+TEST(ProtocolTest, FridgeDoorFallsBackToGenericDoor) {
+  auto f =
+      parse_fridge(R"({"seq":1,"props":{"door_ajar":true},"msg_types":2})");
+  ASSERT_TRUE(f.valid);
+  ASSERT_TRUE(f.door_ajar.has_value());
+  EXPECT_TRUE(*f.door_ajar);
+}
 
-  // A handful of targeted tests for protocol behaviors that deserve explicit
-  // naming (rather than just fixture diffs).
+TEST(ProtocolTest, FridgeSetpointFallsBackToFreezer) {
+  auto f = parse_fridge(R"({"status":0,"resp":{"frz_set_temp":-5}})");
+  ASSERT_TRUE(f.valid);
+  ASSERT_TRUE(f.ref_set_temp.has_value());
+  EXPECT_FLOAT_EQ(*f.ref_set_temp, -5.0f);
+  ASSERT_TRUE(f.frz_set_temp.has_value());
+  EXPECT_FLOAT_EQ(*f.frz_set_temp, -5.0f);
+}
 
-  TEST(ProtocolTest, EmptyStringIsInvalid)
-  {
-    auto f = parse_fridge("");
-    EXPECT_FALSE(f.valid);
-  }
+TEST(ProtocolTest, RangeDoorPrefersCavDoor) {
+  auto r = parse_range(
+      R"({"status":0,"resp":{"cav_door_ajar":true,"door_ajar":false}})");
+  ASSERT_TRUE(r.valid);
+  ASSERT_TRUE(r.door_ajar.has_value());
+  EXPECT_TRUE(*r.door_ajar);
+}
 
-  TEST(ProtocolTest, PinConfirmationPopulatesCommon)
-  {
-    auto f = parse_fridge(R"({"status":0,"resp":{"pin":"654321"}})");
-    ASSERT_TRUE(f.valid);
-    ASSERT_TRUE(f.common.pin_confirmed.has_value());
-    EXPECT_EQ(*f.common.pin_confirmed, "654321");
-  }
+TEST(ProtocolTest, DishwasherSerialIsTrimmed) {
+  auto d = parse_dishwasher(
+      R"({"status":0,"resp":{"appliance_serial":"  12345  "}})");
+  ASSERT_TRUE(d.valid);
+  ASSERT_TRUE(d.common.appliance_serial.has_value());
+  EXPECT_EQ(*d.common.appliance_serial, "12345");
+}
 
-  TEST(ProtocolTest, PinTooLongIsIgnored)
-  {
-    auto f = parse_fridge(R"({"status":0,"resp":{"pin":"12345678901"}})");
-    ASSERT_TRUE(f.valid);
-    EXPECT_FALSE(f.common.pin_confirmed.has_value());
-  }
-
-  TEST(ProtocolTest, StatusNonZeroIsInvalid)
-  {
-    auto f = parse_fridge(R"({"status":1,"resp":{"ref_set_temp":38}})");
-    EXPECT_FALSE(f.valid);
-  }
-
-  TEST(ProtocolTest, FridgeDoorFallsBackToGenericDoor)
-  {
-    auto f = parse_fridge(R"({"seq":1,"props":{"door_ajar":true},"msg_types":2})");
-    ASSERT_TRUE(f.valid);
-    ASSERT_TRUE(f.door_ajar.has_value());
-    EXPECT_TRUE(*f.door_ajar);
-  }
-
-  TEST(ProtocolTest, FridgeSetpointFallsBackToFreezer)
-  {
-    auto f = parse_fridge(R"({"status":0,"resp":{"frz_set_temp":-5}})");
-    ASSERT_TRUE(f.valid);
-    ASSERT_TRUE(f.ref_set_temp.has_value());
-    EXPECT_FLOAT_EQ(*f.ref_set_temp, -5.0f);
-    ASSERT_TRUE(f.frz_set_temp.has_value());
-    EXPECT_FLOAT_EQ(*f.frz_set_temp, -5.0f);
-  }
-
-  TEST(ProtocolTest, RangeDoorPrefersCavDoor)
-  {
-    auto r = parse_range(R"({"status":0,"resp":{"cav_door_ajar":true,"door_ajar":false}})");
-    ASSERT_TRUE(r.valid);
-    ASSERT_TRUE(r.door_ajar.has_value());
-    EXPECT_TRUE(*r.door_ajar);
-  }
-
-  TEST(ProtocolTest, DishwasherSerialIsTrimmed)
-  {
-    auto d = parse_dishwasher(R"({"status":0,"resp":{"appliance_serial":"  12345  "}})");
-    ASSERT_TRUE(d.valid);
-    ASSERT_TRUE(d.common.appliance_serial.has_value());
-    EXPECT_EQ(*d.common.appliance_serial, "12345");
-  }
-
-  TEST(ProtocolTest, DishwasherComputesTimeRemaining)
-  {
-    // End time is 45 minutes after root timestamp.
-    auto d = parse_dishwasher(R"({
+TEST(ProtocolTest, DishwasherComputesTimeRemaining) {
+  // End time is 45 minutes after root timestamp.
+  auto d = parse_dishwasher(R"({
     "seq": 1, "msg_types": 2,
     "timestamp": "2026-04-24T14:00:00.000",
     "props": {"wash_cycle_end_time": "2026-04-24T14:45"}
   })");
-    ASSERT_TRUE(d.valid);
-    ASSERT_TRUE(d.wash_time_remaining_min.has_value());
-    EXPECT_EQ(*d.wash_time_remaining_min, 45);
-  }
+  ASSERT_TRUE(d.valid);
+  ASSERT_TRUE(d.wash_time_remaining_min.has_value());
+  EXPECT_EQ(*d.wash_time_remaining_min, 45);
+}
 
-  TEST(ProtocolTest, IsPollTrueForFullResponse)
-  {
-    auto f = parse_fridge(R"({"status":0,"resp":{"ref_set_temp":38}})");
-    ASSERT_TRUE(f.valid);
-    EXPECT_TRUE(f.is_poll);
-  }
+TEST(ProtocolTest, IsPollTrueForFullResponse) {
+  auto f = parse_fridge(R"({"status":0,"resp":{"ref_set_temp":38}})");
+  ASSERT_TRUE(f.valid);
+  EXPECT_TRUE(f.is_poll);
+}
 
-  TEST(ProtocolTest, IsPollFalseForPushNotification)
-  {
-    auto f = parse_fridge(R"({"seq":1,"msg_types":2,"props":{"ref_door_ajar":true}})");
-    ASSERT_TRUE(f.valid);
-    EXPECT_FALSE(f.is_poll);
-  }
+TEST(ProtocolTest, IsPollFalseForPushNotification) {
+  auto f =
+      parse_fridge(R"({"seq":1,"msg_types":2,"props":{"ref_door_ajar":true}})");
+  ASSERT_TRUE(f.valid);
+  EXPECT_FALSE(f.is_poll);
+}
 
-  TEST(ProtocolTest, IsPollAcrossAllThreeParsers)
-  {
-    EXPECT_TRUE(parse_fridge(R"({"status":0,"resp":{}})").is_poll);
-    EXPECT_TRUE(parse_dishwasher(R"({"status":0,"resp":{}})").is_poll);
-    EXPECT_TRUE(parse_range(R"({"status":0,"resp":{}})").is_poll);
-    EXPECT_FALSE(parse_fridge(R"({"seq":1,"props":{},"msg_types":2})").is_poll);
-    EXPECT_FALSE(parse_dishwasher(R"({"seq":1,"props":{},"msg_types":2})").is_poll);
-    EXPECT_FALSE(parse_range(R"({"seq":1,"props":{},"msg_types":2})").is_poll);
-  }
+TEST(ProtocolTest, IsPollAcrossAllThreeParsers) {
+  EXPECT_TRUE(parse_fridge(R"({"status":0,"resp":{}})").is_poll);
+  EXPECT_TRUE(parse_dishwasher(R"({"status":0,"resp":{}})").is_poll);
+  EXPECT_TRUE(parse_range(R"({"status":0,"resp":{}})").is_poll);
+  EXPECT_FALSE(parse_fridge(R"({"seq":1,"props":{},"msg_types":2})").is_poll);
+  EXPECT_FALSE(
+      parse_dishwasher(R"({"seq":1,"props":{},"msg_types":2})").is_poll);
+  EXPECT_FALSE(parse_range(R"({"seq":1,"props":{},"msg_types":2})").is_poll);
+}
 
-  TEST(ProtocolTest, DataKeysCapturedInOrder)
-  {
-    auto f = parse_fridge(R"({"status":0,"resp":{"ref_set_temp":38,"ice_maker_on":true,"appliance_model":"2028"}})");
-    ASSERT_TRUE(f.valid);
-    ASSERT_EQ(f.data_keys.size(), 3u);
-    EXPECT_EQ(f.data_keys[0], "ref_set_temp");
-    EXPECT_EQ(f.data_keys[1], "ice_maker_on");
-    EXPECT_EQ(f.data_keys[2], "appliance_model");
-  }
+TEST(ProtocolTest, DataKeysCapturedInOrder) {
+  auto f = parse_fridge(
+      R"({"status":0,"resp":{"ref_set_temp":38,"ice_maker_on":true,"appliance_model":"2028"}})");
+  ASSERT_TRUE(f.valid);
+  ASSERT_EQ(f.data_keys.size(), 3u);
+  EXPECT_EQ(f.data_keys[0], "ref_set_temp");
+  EXPECT_EQ(f.data_keys[1], "ice_maker_on");
+  EXPECT_EQ(f.data_keys[2], "appliance_model");
+}
 
-  TEST(ProtocolTest, DataKeysPopulatedForPushMessages)
-  {
-    auto r = parse_range(R"({"seq":1,"msg_types":2,"props":{"cav_temp":350,"cav_unit_on":true}})");
-    ASSERT_TRUE(r.valid);
-    ASSERT_EQ(r.data_keys.size(), 2u);
-    EXPECT_EQ(r.data_keys[0], "cav_temp");
-    EXPECT_EQ(r.data_keys[1], "cav_unit_on");
-  }
+TEST(ProtocolTest, DataKeysPopulatedForPushMessages) {
+  auto r = parse_range(
+      R"({"seq":1,"msg_types":2,"props":{"cav_temp":350,"cav_unit_on":true}})");
+  ASSERT_TRUE(r.valid);
+  ASSERT_EQ(r.data_keys.size(), 2u);
+  EXPECT_EQ(r.data_keys[0], "cav_temp");
+  EXPECT_EQ(r.data_keys[1], "cav_unit_on");
+}
 
-  TEST(ProtocolTest, DishwasherNegativeRemainingClampsToZero)
-  {
-    auto d = parse_dishwasher(R"({
+TEST(ProtocolTest, DishwasherNegativeRemainingClampsToZero) {
+  auto d = parse_dishwasher(R"({
     "seq": 1, "msg_types": 2,
     "timestamp": "2026-04-24T15:00:00.000",
     "props": {"wash_cycle_end_time": "2026-04-24T14:45"}
   })");
-    ASSERT_TRUE(d.valid);
-    ASSERT_TRUE(d.wash_time_remaining_min.has_value());
-    EXPECT_EQ(*d.wash_time_remaining_min, 0);
-  }
-
+  ASSERT_TRUE(d.valid);
+  ASSERT_TRUE(d.wash_time_remaining_min.has_value());
+  EXPECT_EQ(*d.wash_time_remaining_min, 0);
 }
+
+} // namespace

--- a/tests/cpp/sanitize_test.cpp
+++ b/tests/cpp/sanitize_test.cpp
@@ -34,10 +34,10 @@ TEST(Sanitize, WhitespaceAllowed) {
 
 TEST(Sanitize, ControlCharsBecomeQuestionMark) {
   std::string s;
-  s.push_back(0x01);  // SOH
+  s.push_back(0x01); // SOH
   s.push_back('a');
-  s.push_back(0x1F);  // US (just below 0x20)
-  s.push_back(0x7F);  // DEL (just above 0x7E)
+  s.push_back(0x1F); // US (just below 0x20)
+  s.push_back(0x7F); // DEL (just above 0x7E)
   EXPECT_EQ(sanitize_for_log(s, 0, s.size()), "?a??");
 }
 
@@ -80,15 +80,14 @@ struct Recorded {
   std::string chunk;
 };
 
-}  // namespace
+} // namespace
 
 TEST(ChunkForLog, SingleChunkBelowSize) {
   std::vector<Recorded> calls;
   std::string msg = "small";
-  chunk_for_log(msg,
-                [&](std::size_t i, std::size_t t, const std::string &c) {
-                  calls.push_back({i, t, c});
-                });
+  chunk_for_log(msg, [&](std::size_t i, std::size_t t, const std::string &c) {
+    calls.push_back({i, t, c});
+  });
   ASSERT_EQ(calls.size(), 1u);
   EXPECT_EQ(calls[0].idx, 1u);
   EXPECT_EQ(calls[0].total, 1u);
@@ -97,11 +96,10 @@ TEST(ChunkForLog, SingleChunkBelowSize) {
 
 TEST(ChunkForLog, ExactBoundary) {
   std::vector<Recorded> calls;
-  std::string msg(800, 'x');  // exactly 2 chunks at 400
-  chunk_for_log(msg,
-                [&](std::size_t i, std::size_t t, const std::string &c) {
-                  calls.push_back({i, t, c});
-                });
+  std::string msg(800, 'x'); // exactly 2 chunks at 400
+  chunk_for_log(msg, [&](std::size_t i, std::size_t t, const std::string &c) {
+    calls.push_back({i, t, c});
+  });
   ASSERT_EQ(calls.size(), 2u);
   EXPECT_EQ(calls[0].idx, 1u);
   EXPECT_EQ(calls[0].total, 2u);
@@ -113,11 +111,10 @@ TEST(ChunkForLog, ExactBoundary) {
 
 TEST(ChunkForLog, TrailingPartial) {
   std::vector<Recorded> calls;
-  std::string msg(950, 'x');  // 2.375 chunks → 3 chunks (400, 400, 150)
-  chunk_for_log(msg,
-                [&](std::size_t i, std::size_t t, const std::string &c) {
-                  calls.push_back({i, t, c});
-                });
+  std::string msg(950, 'x'); // 2.375 chunks → 3 chunks (400, 400, 150)
+  chunk_for_log(msg, [&](std::size_t i, std::size_t t, const std::string &c) {
+    calls.push_back({i, t, c});
+  });
   ASSERT_EQ(calls.size(), 3u);
   EXPECT_EQ(calls[0].chunk.size(), 400u);
   EXPECT_EQ(calls[1].chunk.size(), 400u);
@@ -127,7 +124,8 @@ TEST(ChunkForLog, TrailingPartial) {
 
 TEST(ChunkForLog, EmptyMessageNoCalls) {
   int calls = 0;
-  chunk_for_log("", [&](std::size_t, std::size_t, const std::string &) { calls++; });
+  chunk_for_log(
+      "", [&](std::size_t, std::size_t, const std::string &) { calls++; });
   EXPECT_EQ(calls, 0);
 }
 
@@ -138,10 +136,9 @@ TEST(ChunkForLog, SanitizesEachChunk) {
   msg.push_back(static_cast<char>(0xFF));
   msg.append(std::string(50, 'b'));
   std::vector<Recorded> calls;
-  chunk_for_log(msg,
-                [&](std::size_t i, std::size_t t, const std::string &c) {
-                  calls.push_back({i, t, c});
-                });
+  chunk_for_log(msg, [&](std::size_t i, std::size_t t, const std::string &c) {
+    calls.push_back({i, t, c});
+  });
   ASSERT_EQ(calls.size(), 2u);
   EXPECT_EQ(calls[0].chunk, std::string(400, 'a'));
   EXPECT_EQ(calls[1].chunk, "?" + std::string(50, 'b'));
@@ -149,11 +146,12 @@ TEST(ChunkForLog, SanitizesEachChunk) {
 
 TEST(ChunkForLog, CustomChunkSize) {
   std::vector<Recorded> calls;
-  chunk_for_log("abcdef",
-                [&](std::size_t i, std::size_t t, const std::string &c) {
-                  calls.push_back({i, t, c});
-                },
-                2);
+  chunk_for_log(
+      "abcdef",
+      [&](std::size_t i, std::size_t t, const std::string &c) {
+        calls.push_back({i, t, c});
+      },
+      2);
   ASSERT_EQ(calls.size(), 3u);
   EXPECT_EQ(calls[0].chunk, "ab");
   EXPECT_EQ(calls[1].chunk, "cd");


### PR DESCRIPTION
## Summary

Phase 2 of the YAML-to-C++ refactor (PR #71 = Phase 1; PR #72 happened in between and dropped a bunch of fw 8.5 workarounds). This PR pulls three more pieces of pure logic out of YAML lambdas into host-tested C++:

- **Command builders** ([commands.h](components/subzero_protocol/commands.h)) — `build_unlock_channel(pin)` / `build_get_async()` / `build_display_pin(duration=30)`. Replaces five inline `std::string` concatenations across `periodic_poll`, `subscribe`, and three buttons. Each helper has a unit test pinning the exact wire format including the trailing `\n` that the appliance's serial parser requires.

- **GATT handle extraction** ([gatt_handles.h](components/subzero_protocol/gatt_handles.h), [gatt_handles_esphome.h](components/subzero_protocol/gatt_handles_esphome.h)) — the "scan db, find characteristic by 128-bit UUID first byte, store attribute_handle" loop was duplicated **4×** in the `post_bond` discovery ladder (initial dump + 3 retry passes 5s apart). Now a single `update_handles_from_db(db, count, d5_handle, d6_handle, d7_handle)` call. Tests cover empty input, partial discovery, idempotent additive passes (handles aren't overwritten), descriptors and services correctly ignored, and a realistic dual-oven range fixture.

- **Sensor dispatch** ([dispatch.h](components/subzero_protocol/dispatch.h), [dispatch_esphome.h](components/subzero_protocol/dispatch_esphome.h)) — the ~50-line block of `if (s.field) id(...).publish_state(*s.field);` boilerplate at the bottom of every `parse_json` script. Now each appliance has a typed `Bus` struct (`FridgeBus` / `DishwasherBus` / `RangeBus`) holding raw sensor pointers, populated once in `on_boot`, then `dispatch_X(s, bus)` routes every parsed-state field to the right entity. **The dispatch templates are host-buildable**, so tests can replay through a recording bus and assert the exact `(method, value)` tuples for every fixture. Catches \"added a new field to FridgeState but forgot to wire it in YAML\" — a bug class that was previously invisible until a user noticed missing data in HA.

  Range/oven secondary cavity is dispatched too, and the dishwasher's stateful \"publish 0 to wash_time_remaining when cycle stops\" hook moved into the bus as `clear_wash_time_remaining_if_running()`.

**Drive-by:** dropped the dead `${prefix}_wash_end_time_str` global from `subzero_dishwasher.yaml` — declared and written but never read.

## Test wins

- 36 new gtest cases (103 total, all green): 8 commands + 10 gatt_handles + 18 dispatch
- Dispatch tests include: empty-state-no-calls per appliance, every common field routed, every appliance-specific field routed, dishwasher's wash-cycle-end clear hook, and end-to-end fixture replays for fridge full poll, fridge push, dishwasher full poll, range full poll, and three Wolf range push notifications.

## YAML changes

Net **+25 lines** across the four YAML files. The dispatch boilerplate (~50 lines × 3 appliances) was replaced by per-appliance bus `on_boot` setup (~30 lines × 3 appliances) and one-line dispatch calls. Modest growth, but the dispatch logic is now compile-time-checked and unit-tested instead of hand-written per appliance.

## Future phases

- Phase 3 (separate PR): `SubzeroHub` C++ class subclassing `BLEClientNode + Component` that owns the BLE state machine, behind a `BleTransport` interface so the connection-state machine, GATT discovery ladder, and zombie detection can be tested with a mock BLE transport.
- Phase 4: native `subzero_appliance:` config schema replacing the package YAMLs.

## Test plan

Host-side already verified:
- [x] `cd tests/cpp/build && ctest` — 103/103 passed
- [x] `esphome config` — all 6 entry-point YAMLs valid
- [x] `esphome compile` — `wolf-minimal-fridge`, `cove-minimal-dishwasher`, `wolf-minimal-range` all build to firmware

On-device verification needed before merge:
- [ ] Flash a fridge and confirm normal poll cycle in logs (`Response[N/M]` chunks visible with debug switch on); verify all sensors continue to publish (compare to pre-PR state in HA).
- [ ] Flash a dishwasher; run a wash cycle to verify the stateful `clear_wash_time_remaining_if_running` hook fires correctly when the cycle ends (`wash_time_remaining` should drop to 0).
- [ ] Flash a range; if dual-oven, verify both cavity dispatchers publish; trigger kitchen timers to see push-driven state changes.
- [ ] Watch GATT discovery on a cold boot; confirm the new `update_handles_from_db` call still picks up D5/D6/D7 handles correctly across the retry passes.
- [ ] Trigger Start Pairing / Submit PIN / Poll buttons; confirm they still construct correct command payloads (now via the helpers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Sub-Zero BLE protocol command builders for appliance operations (unlock, state requests, PIN display)
  * Implemented centralized sensor dispatch system for improved appliance state management
  * Enhanced GATT characteristic discovery and handle extraction for Sub-Zero devices

* **Tests**
  * Added comprehensive test suites for protocol commands, GATT discovery, and sensor state dispatching

<!-- end of auto-generated comment: release notes by coderabbit.ai -->