### PR TITLE
feat(set): writable Switches/Numbers + Clear Cloud Token + doc cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -35,17 +35,17 @@ pip install esphome
 
 === 2. Create Your Config
 
-Create a YAML file (e.g. `subzero.yaml`). The `packages:` block pulls the appliance package directly from this GitHub repo at compile time - no cloning required.
+Create a YAML file (e.g. `subzero.yaml`). The `external_components:` block pulls the native `subzero_appliance` component directly from this GitHub repo at compile time - no cloning required. Each appliance is then declared as a single `subzero_appliance:` entry that creates its full set of sensors, switches, numbers, buttons, and the diagnostic Status text sensor.
 
-Choose the package file for your appliance type:
+Pick the appropriate `type:` for your appliance:
 
 [cols="1,1"]
 |===
-| Appliance Type | Package File
+| Appliance | type:
 
-| Sub-Zero refrigerator/freezer | `subzero_fridge.yaml`
-| Cove dishwasher | `subzero_dishwasher.yaml`
-| Wolf range/oven | `subzero_range.yaml`
+| Sub-Zero refrigerator/freezer | `fridge`
+| Cove dishwasher | `dishwasher`
+| Wolf range/oven | `range`
 |===
 
 .Sub-Zero Refrigerator (complete example)
@@ -55,19 +55,8 @@ external_components:                          # <1>
   - source:
       type: git
       url: https://github.com/JonGilmore/esphome-subzero-ble
-      ref: v3.0.0
-    components: [patch_acl_reassembly, subzero_protocol]
-
-packages:
-  - url: https://github.com/JonGilmore/esphome-subzero-ble
-    ref: v3.0.0 # use latest tag, or main
-    files:
-      - path: subzero_fridge.yaml
-        vars:
-          prefix: "szg"
-          appliance_name: "Kitchen Fridge"
-          appliance_mac: "00:06:80:XX:XX:XX"  # <2>
-          appliance_pin: "123456"             # <3>
+      ref: v3.0.0 # use latest tag, or main
+    components: [patch_acl_reassembly, subzero_protocol, subzero_appliance]
 
 esphome:
   name: my-subzero
@@ -102,153 +91,170 @@ wifi:
   fast_connect: true
   power_save_mode: none
 
+esp32_ble:
+  io_capability: keyboard_only
+  max_connections: 5
+
 esp32_ble_tracker:
-----
-<1> Pulls the C++ parser and ACL-reassembly patch components. Keep the `ref:` matching the one in `packages:` below so the components and YAML come from the same release.
-<2> Your appliance's BLE MAC address (Sub-Zero MACs typically start with `00:06:80`)
-<3> The 6-digit PIN from your appliance (see <<pairing>> below)
+  scan_parameters:
+    active: false
 
-.Cove Dishwasher (external_components + packages blocks)
+ble_client:                                   # <2>
+  - mac_address: "00:06:80:XX:XX:XX"
+    id: kitchen_fridge_ble
+    name: "SZG Kitchen Fridge"
+    auto_connect: true
+
+subzero_appliance:                            # <3>
+  - type: fridge
+    id: kitchen_fridge
+    ble_client_id: kitchen_fridge_ble
+    name: "Kitchen Fridge"
+    pin: "123456"                             # <4>
+----
+<1> Pulls the C++ parser, ACL-reassembly patch, and the `subzero_appliance` native component. All three must be loaded.
+<2> One `ble_client` per appliance, with the appliance's BLE MAC address (Sub-Zero MACs typically start with `00:06:80`). `auto_connect: true` keeps reconnecting on failure.
+<3> The native `subzero_appliance` component creates ~30 read-only sensors plus writable Numbers (set temps), Switches (lights), and 8 control/diagnostic buttons.
+<4> The 6-digit PIN from your appliance (see <<pairing>> below). `mode: password` masks it in the HA UI.
+
+.Cove Dishwasher (subzero_appliance + ble_client blocks)
 [source,yaml]
 ----
-external_components:
-  - source:
-      type: git
-      url: https://github.com/JonGilmore/esphome-subzero-ble
-      ref: v3.0.0
-    components: [patch_acl_reassembly, subzero_protocol]
+ble_client:
+  - mac_address: "00:06:80:XX:XX:XX"
+    id: dishwasher_ble
+    name: "SZG Dishwasher"
+    auto_connect: true
 
-packages:
-  - url: https://github.com/JonGilmore/esphome-subzero-ble
-    ref: v3.0.0 # use latest tag, or main
-    files:
-      - path: subzero_dishwasher.yaml
-        vars:
-          prefix: "szg"
-          appliance_name: "Dishwasher"
-          appliance_mac: "00:06:80:XX:XX:XX"
-          appliance_pin: "123456"
+subzero_appliance:
+  - type: dishwasher
+    id: dishwasher
+    ble_client_id: dishwasher_ble
+    name: "Dishwasher"
+    pin: "123456"
 ----
 
-.Wolf Range (external_components + packages blocks)
+.Wolf Range (subzero_appliance + ble_client blocks)
 [source,yaml]
 ----
-external_components:
-  - source:
-      type: git
-      url: https://github.com/JonGilmore/esphome-subzero-ble
-      ref: v3.0.0
-    components: [patch_acl_reassembly, subzero_protocol]
+ble_client:
+  - mac_address: "00:06:80:XX:XX:XX"
+    id: kitchen_range_ble
+    name: "SZG Kitchen Range"
+    auto_connect: true
 
-packages:
-  - url: https://github.com/JonGilmore/esphome-subzero-ble
-    ref: v3.0.0 # use latest tag, or main
-    files:
-      - path: subzero_range.yaml
-        vars:
-          prefix: "szg"
-          appliance_name: "Kitchen Range"
-          appliance_mac: "00:06:80:XX:XX:XX"
-          appliance_pin: "123456"
+subzero_appliance:
+  - type: range
+    id: kitchen_range
+    ble_client_id: kitchen_range_ble
+    name: "Kitchen Range"
+    pin: "123456"
+    # hide_oven2: false  # uncomment for dual-oven appliances
 ----
 
 .Multiple Appliances
 [source,yaml]
 ----
-external_components:
-  - source:
-      type: git
-      url: https://github.com/JonGilmore/esphome-subzero-ble
-      ref: v3.0.0
-    components: [patch_acl_reassembly, subzero_protocol]
+ble_client:
+  - mac_address: "00:06:80:XX:XX:XX"
+    id: main_fridge_ble
+    name: "SZG Main Fridge"
+    auto_connect: true
+  - mac_address: "00:06:80:YY:YY:YY"
+    id: kitchen_range_ble
+    name: "SZG Kitchen Range"
+    auto_connect: true
 
-packages:
-  - url: https://github.com/JonGilmore/esphome-subzero-ble
-    ref: v3.0.0 # use latest tag, or main
-    files:
-      - path: subzero_fridge.yaml
-        vars:
-          prefix: "szg"
-          appliance_name: "Main Fridge"
-          appliance_mac: "00:06:80:XX:XX:XX"
-          appliance_pin: "123456"
-      - path: subzero_range.yaml
-        vars:
-          prefix: "szg2"
-          appliance_name: "Kitchen Range"
-          appliance_mac: "00:06:80:YY:YY:YY"
-          appliance_pin: "654321"
+subzero_appliance:
+  - type: fridge
+    id: main_fridge
+    ble_client_id: main_fridge_ble
+    name: "Main Fridge"
+    pin: "123456"
+    poll_offset: 0s                # <1>
+  - type: range
+    id: kitchen_range
+    ble_client_id: kitchen_range_ble
+    name: "Kitchen Range"
+    pin: "654321"
+    poll_offset: 5s                # <1>
 ----
+<1> When running multiple appliances on one ESP32, stagger their poll cycles with `poll_offset` (default `0s`) - e.g. `0s / 5s / 10s` - to avoid concurrent-bonding races on the shared BLE radio. See link:docs/advanced.adoc#reconnect-logic[Reconnect Logic].
 
-NOTE: Use a unique `prefix` for each appliance (e.g. `szg`, `szg2`, `szg3`). The base package sets `max_connections: 5` in `esp32_ble`, which supports up to 5 appliances on one ESP32. If you need more, add `esp32_ble: max_connections: 6` (or higher) to your device YAML. See link:docs/advanced.adoc#ble-stack-tuning[BLE Stack Tuning] for additional `sdkconfig_options` when running 2+ concurrent connections.
+NOTE: `esp32_ble: max_connections: 5` supports up to 5 concurrent appliances on one ESP32. Bump it (and see link:docs/advanced.adoc#ble-stack-tuning[BLE Stack Tuning] for additional `sdkconfig_options`) if you need more.
 
-TIP: Pin to a release tag (e.g. `ref: v3.0.0`) for stability, or use `ref: main` to track the latest changes
+TIP: Pin to a release tag (e.g. `ref: v3.0.0`) for stability, or use `ref: main` to track the latest changes. The minimal copy-paste examples in `wolf-minimal-fridge.yaml`, `wolf-minimal-range.yaml`, and `cove-minimal-dishwasher.yaml` in the repo root track `main` and are a known-good starting point.
 
 ==== Fridge-Only Options
 
-For units without a freezer or ice maker, you can hide irrelevant sensors:
+For units without a freezer or ice maker, you can hide irrelevant sensors. The `hide_X` flags are inline options on the `subzero_appliance:` entry:
 
 [source,yaml]
 ----
-vars:
-  prefix: "szg"
-  appliance_name: "Basement Fridge"
-  appliance_mac: "00:06:80:XX:XX:XX"
-  appliance_pin: "123456"
-  hide_freezer: "true"
-  hide_ice_maker: "true"
+subzero_appliance:
+  - type: fridge
+    id: basement_fridge
+    ble_client_id: basement_fridge_ble
+    name: "Basement Fridge"
+    pin: "123456"
+    hide_freezer: true
+    hide_ice_maker: true
 ----
 
 [cols="1,1,2"]
 |===
 | Option | Default | Hides
 
-| `hide_freezer` | `"false"` | Freezer Set Temperature, Freezer Door
-| `hide_ice_maker` | `"false"` | Ice Maker
-| `hide_sabbath` | `"false"` | Sabbath Mode
-| `hide_wine` | `"true"` | Wine Door, Wine Zone Upper Set Temperature, Wine Zone Lower Set Temperature, Wine Temperature Alert
-| `hide_ref_drawer` | `"true"` | Refrigerator Drawer Set Temperature, Refrigerator Drawer Door
-| `hide_crisper` | `"true"` | Crisper Drawer Set Temperature
-| `hide_air_filter` | `"true"` | Air Filter, Air Filter Remaining
-| `hide_water_filter` | `"true"` | Water Filter Remaining
-| `hide_softener` | `"true"` | Water softener on a dishwasher
+| `hide_freezer` | `false` | Freezer Set Temperature, Freezer Door
+| `hide_ice_maker` | `false` | Ice Maker
+| `hide_sabbath` | `false` | Sabbath Mode
+| `hide_wine` | `true` | Wine Door, Wine Zone Upper/Lower Set Temperature, Wine Temperature Alert
+| `hide_ref_drawer` | `true` | Refrigerator Drawer Set Temperature, Refrigerator Drawer Door
+| `hide_crisper` | `true` | Crisper Drawer Set Temperature
+| `hide_air_filter` | `true` | Air Filter, Air Filter Remaining
+| `hide_water_filter` | `true` | Water Filter Remaining
+| `hide_softener` | `true` | Water Softener Low (dishwasher only)
+| `hide_oven2` | `true` | All Oven 2 sensors (range only - for dual-oven)
 |===
 
 .Fridge with Refrigerator Drawer (e.g. PRO3650G)
 [source,yaml]
 ----
-vars:
-  prefix: "szg"
-  appliance_name: "Fridge"
-  appliance_mac: "00:06:80:XX:XX:XX"
-  appliance_pin: "123456"
-  hide_ref_drawer: "false"
+subzero_appliance:
+  - type: fridge
+    id: fridge
+    ble_client_id: fridge_ble
+    name: "Fridge"
+    pin: "123456"
+    hide_ref_drawer: false
 ----
 
 .Fridge with Crisper & Filters (e.g. DEC3650RID)
 [source,yaml]
 ----
-vars:
-  prefix: "szg"
-  appliance_name: "Fridge"
-  appliance_mac: "00:06:80:XX:XX:XX"
-  appliance_pin: "123456"
-  hide_crisper: "false"
-  hide_air_filter: "false"
-  hide_water_filter: "false"
+subzero_appliance:
+  - type: fridge
+    id: fridge
+    ble_client_id: fridge_ble
+    name: "Fridge"
+    pin: "123456"
+    hide_crisper: false
+    hide_air_filter: false
+    hide_water_filter: false
 ----
 
 .Wine Fridge (dual-zone, no freezer or ice maker)
 [source,yaml]
 ----
-vars:
-  prefix: "szg"
-  appliance_name: "Wine Fridge"
-  appliance_mac: "00:06:80:XX:XX:XX"
-  appliance_pin: "123456"
-  hide_freezer: "true"
-  hide_ice_maker: "true"
-  hide_wine: "false"
+subzero_appliance:
+  - type: fridge
+    id: wine_fridge
+    ble_client_id: wine_fridge_ble
+    name: "Wine Fridge"
+    pin: "123456"
+    hide_freezer: true
+    hide_ice_maker: true
+    hide_wine: false
 ----
 
 === 3. Compile and Flash
@@ -300,8 +306,8 @@ TIP: Sub-Zero appliance BLE MAC addresses typically start with `00:06:80`. You c
 | *Most sensors stuck at "unknown" / Status sensor reads "Pairing required"*
 | The appliance returned `status: 302` to the unlock attempt. This usually means its PIN rotated - some appliances assign a new pairing key after a power cycle, factory reset, or when the official app re-pairs. Press the *Start Pairing* button for that appliance in HA, watch the appliance display for the new 6-digit PIN, then enter it into the appliance's *PIN* text input in HA. The next poll cycle will pick up full state. (You'll also see `[szg:###]: [Appliance] Pairing rejected (status 302)` in the ESPHome logs.)
 
-| *Sensors stop updating on a fridge or wall oven after ~20-25 min*
-| The BLE unlock session on fw 8.5 appliances expires after ~20-25 min. Poll responses stop, but push notifications continue. Zombie detection kicks in after 15 minutes of total silence (no polls AND no pushes) and forces a reconnect. If only polls fall silent while pushes keep arriving, the integration waits for the next state change to land, then catches up on the following reconnect cycle. See link:docs/advanced.adoc#reconnect-logic[Reconnect Logic].
+| *Poll-only sensors (model, uptime, version, diagnostic_status) only refresh every few minutes on a fridge or wall oven*
+| Normal for fw 8.5 appliances. After the first poll on each connection, repeat polls go silent within the same BLE session, so the integration's zombie detector forces a reconnect every ~3 missed cycles (~3 min). Each reconnect lands a fresh full-state poll which refreshes those fields. Push notifications (door, light, setpoint changes, etc.) continue between cycles, so live state stays current. See link:docs/advanced.adoc#reconnect-logic[Reconnect Logic].
 
 | *Dishwasher disconnects after ~10 seconds*
 | Normal for Cove dishwashers. The integration uses a fast reconnect path with cached GATT handles to complete polling within the connection window.
@@ -431,6 +437,45 @@ For ranges with two ovens, enable the second oven sensors using `hide_oven2: "fa
 
 | `hide_oven2` | `"true"` | All Oven 2 sensors (temperature, door, light, probe, cook mode, etc.)
 |===
+
+=== Writable Entities
+
+In addition to the read-only sensors above, several properties are exposed as **writable** entities - HA's Number entity for setpoints (with up/down controls and an input field) and HA's Switch entity for toggleable booleans. Writing to one of these sends a `set` command to the appliance over BLE; the appliance acks and pushes the new value back, which keeps the entity state in sync if the value is also changed from the appliance's front panel or the official Sub-Zero app.
+
+[cols="1,1,2"]
+|===
+| Appliance | Entity | Property
+
+| Fridge
+| Set Temperature, Freezer Set Temperature, Wine Zone Upper/Lower Set Temperature, Refrigerator Drawer Set Temperature, Crisper Drawer Set Temperature
+| Whichever zones your model exposes (gated by the same `hide_X` flags as the read sensors)
+
+| Range
+| Oven Light, Oven Set Temperature, Probe Set Temperature
+| Toggle the oven cavity light, set the oven target temperature (100-550°F), set the meat probe target temperature (100-200°F)
+
+| Range (Oven 2)
+| Oven 2 Light, Oven 2 Set Temperature, Oven 2 Probe Set Temperature
+| Same as above for the second cavity (gated by `hide_oven2`)
+
+| Dishwasher
+| Light
+| Toggle the interior light
+|===
+
+NOTE: Writes go to the **D5** control channel (the same one used for unlocking and pairing). The appliance must be connected and paired - if the connection is down or the pairing window is closed (status 302), writes are dropped silently and the entity reverts on the next poll. The standard pairing flow is unchanged.
+
+=== "Clear Cloud Token" Diagnostic Button
+
+A diagnostic button per appliance (hidden by default in the HA UI under "Diagnostic") sends `set remote_svc_reg_token=""` to the appliance, which deregisters it from the official Sub-Zero Azure IoT Hub. After pressing this button:
+
+* The official Sub-Zero/Wolf/Cove mobile app will no longer be able to reach the appliance over the cloud
+* The app will fall back to attempting BLE connections, which will fail because this integration's ESP32 owns the single BLE connection slot
+* In effect, the appliance becomes "owned" by HA - useful if you want to fully decouple from the manufacturer's cloud
+
+This is reversible: the official app can re-register the appliance with cloud during a normal pairing flow.
+
+WARNING: Pressing this button will break any existing automations or shortcuts that the user (or their family members) have set up in the official app. Only do this if you understand the trade-off.
 
 === Diagnostics (All Appliances)
 

--- a/README.adoc
+++ b/README.adoc
@@ -446,13 +446,9 @@ In addition to the read-only sensors above, several properties are exposed as **
 |===
 | Appliance | Entity | Property
 
-| Fridge
-| Set Temperature, Freezer Set Temperature, Wine Zone Upper/Lower Set Temperature, Refrigerator Drawer Set Temperature, Crisper Drawer Set Temperature
-| Whichever zones your model exposes (gated by the same `hide_X` flags as the read sensors)
-
 | Range
 | Oven Light, Oven Set Temperature, Probe Set Temperature
-| Toggle the oven cavity light, set the oven target temperature (100-550°F), set the meat probe target temperature (100-200°F)
+| Toggle the oven cavity light, adjust the oven target temperature (100-550°F), adjust the meat probe target temperature (100-200°F)
 
 | Range (Oven 2)
 | Oven 2 Light, Oven 2 Set Temperature, Oven 2 Probe Set Temperature
@@ -462,6 +458,10 @@ In addition to the read-only sensors above, several properties are exposed as **
 | Light
 | Toggle the interior light
 |===
+
+IMPORTANT: **Oven Set Temperature only adjusts an already-running cycle.** The appliance silently ignores writes to `cav_set_temp` / `cav2_set_temp` when the cavity is off. To use this entity, first start a cook mode (Bake, Roast, etc.) at the appliance's front panel - once the oven is actively heating, HA can adjust the target temperature from there. Writing it from the off state does **not** turn the oven on. Probe Set Temperature behaves the same way (probe must be inserted with the appliance running in a probe-aware mode). This is an appliance-side restriction, not a limitation of the integration.
+
+NOTE: **Fridge / freezer / wine / drawer / crisper set temperatures are intentionally read-only for now.** The appliance acks `set` writes on those properties (status:0) but the setpoint never actually changes - likely an appliance-side guard mode similar to the oven's "must be in a cook mode" behavior. Until that's understood, the fridge set-temp entities stay as read-only sensors so a misclick can't risk altering a running zone.
 
 NOTE: Writes go to the **D5** control channel (the same one used for unlocking and pairing). The appliance must be connected and paired - if the connection is down or the pairing window is closed (status 302), writes are dropped silently and the entity reverts on the next poll. The standard pairing flow is unchanged.
 

--- a/README.adoc
+++ b/README.adoc
@@ -453,15 +453,11 @@ In addition to the read-only sensors above, several properties are exposed as **
 | Range (Oven 2)
 | Oven 2 Light, Oven 2 Set Temperature, Oven 2 Probe Set Temperature
 | Same as above for the second cavity (gated by `hide_oven2`)
-
-| Dishwasher
-| Light
-| Toggle the interior light
 |===
 
 IMPORTANT: **Oven Set Temperature only adjusts an already-running cycle.** The appliance silently ignores writes to `cav_set_temp` / `cav2_set_temp` when the cavity is off. To use this entity, first start a cook mode (Bake, Roast, etc.) at the appliance's front panel - once the oven is actively heating, HA can adjust the target temperature from there. Writing it from the off state does **not** turn the oven on. Probe Set Temperature behaves the same way (probe must be inserted with the appliance running in a probe-aware mode). This is an appliance-side restriction, not a limitation of the integration.
 
-NOTE: **Fridge / freezer / wine / drawer / crisper set temperatures are intentionally read-only for now.** The appliance acks `set` writes on those properties (status:0) but the setpoint never actually changes - likely an appliance-side guard mode similar to the oven's "must be in a cook mode" behavior. Until that's understood, the fridge set-temp entities stay as read-only sensors so a misclick can't risk altering a running zone.
+NOTE: **Fridge set temperatures and dishwasher light are intentionally read-only for now.** The appliance acks `set` writes on those properties (status:0) but the actual state never changes - likely the same appliance-side guard mode as the oven's "must be in a cook mode" requirement, applied more broadly. Until that's understood, those entities stay as read-only sensors so a misclick can't risk altering a running appliance.
 
 NOTE: Writes go to the **D5** control channel (the same one used for unlocking and pairing). The appliance must be connected and paired - if the connection is down or the pairing window is closed (status 302), writes are dropped silently and the entity reverts on the next poll. The standard pairing flow is unchanged.
 

--- a/README.adoc
+++ b/README.adoc
@@ -106,51 +106,17 @@ ble_client:                                   # <2>
     auto_connect: true
 
 subzero_appliance:                            # <3>
-  - type: fridge
+  - type: fridge # or `dishwasher` or `range` # <4>
     id: kitchen_fridge
     ble_client_id: kitchen_fridge_ble
     name: "Kitchen Fridge"
-    pin: "123456"                             # <4>
+    pin: "123456"                             # <5>
 ----
 <1> Pulls the C++ parser, ACL-reassembly patch, and the `subzero_appliance` native component. All three must be loaded.
 <2> One `ble_client` per appliance, with the appliance's BLE MAC address (Sub-Zero MACs typically start with `00:06:80`). `auto_connect: true` keeps reconnecting on failure.
 <3> The native `subzero_appliance` component creates ~30 read-only sensors plus writable Numbers (set temps), Switches (lights), and 8 control/diagnostic buttons.
-<4> The 6-digit PIN from your appliance (see <<pairing>> below). `mode: password` masks it in the HA UI.
-
-.Cove Dishwasher (subzero_appliance + ble_client blocks)
-[source,yaml]
-----
-ble_client:
-  - mac_address: "00:06:80:XX:XX:XX"
-    id: dishwasher_ble
-    name: "SZG Dishwasher"
-    auto_connect: true
-
-subzero_appliance:
-  - type: dishwasher
-    id: dishwasher
-    ble_client_id: dishwasher_ble
-    name: "Dishwasher"
-    pin: "123456"
-----
-
-.Wolf Range (subzero_appliance + ble_client blocks)
-[source,yaml]
-----
-ble_client:
-  - mac_address: "00:06:80:XX:XX:XX"
-    id: kitchen_range_ble
-    name: "SZG Kitchen Range"
-    auto_connect: true
-
-subzero_appliance:
-  - type: range
-    id: kitchen_range
-    ble_client_id: kitchen_range_ble
-    name: "Kitchen Range"
-    pin: "123456"
-    # hide_oven2: false  # uncomment for dual-oven appliances
-----
+<4> The type of appliance - valid types are fridge, dishwasher, range
+<5> The 6-digit PIN from your appliance (see <<pairing>> below). `mode: password` masks it in the HA UI.
 
 .Multiple Appliances
 [source,yaml]

--- a/README.adoc
+++ b/README.adoc
@@ -448,7 +448,7 @@ In addition to the read-only sensors above, several properties are exposed as **
 
 | Range
 | Oven Light, Oven Set Temperature, Probe Set Temperature
-| Toggle the oven cavity light, adjust the oven target temperature (100-550°F), adjust the meat probe target temperature (100-200°F)
+| Toggle the oven cavity light, adjust the oven target temperature (200-550°F - the appliance won't accept lower), adjust the meat probe target temperature (100-200°F)
 
 | Range (Oven 2)
 | Oven 2 Light, Oven 2 Set Temperature, Oven 2 Probe Set Temperature

--- a/components/subzero_appliance/__init__.py
+++ b/components/subzero_appliance/__init__.py
@@ -257,17 +257,15 @@ DISHWASHER_BINARY_SENSORS = [
      {CONF_DEVICE_CLASS: DEVICE_CLASS_PROBLEM}, None),
     ("softener_low", "Softener Low", "set_softener_low_sensor",
      {CONF_DEVICE_CLASS: DEVICE_CLASS_PROBLEM}, "hide_softener"),
-    # light_on moved to DISHWASHER_WRITABLE_SWITCHES — it's a Switch now.
+    # Read-only: writing `set light_on` on dishwashers acks (status:0)
+    # but the appliance does not actually toggle the light. Same guard
+    # behavior as fridge set-temps — see FRIDGE_SENSORS comment above.
+    ("light_on", "Light", "set_light_on_sensor", {CONF_ICON: "mdi:lightbulb"}, None),
     ("remote_ready", "Remote Ready", "set_remote_ready_sensor", {CONF_ICON: "mdi:remote"}, None),
     ("delay_start", "Delay Start", "set_delay_start_sensor", {CONF_ICON: "mdi:timer-sand"}, None),
 ]
 
-DISHWASHER_WRITABLE_SWITCHES = [
-    # (suffix, name_suffix, setter, property_key, kwargs, hide_key)
-    ("light_on", "Light", "set_light_on_switch", "light_on",
-     {CONF_ICON: "mdi:lightbulb"}, None),
-]
-
+DISHWASHER_WRITABLE_SWITCHES: list = []
 DISHWASHER_WRITABLE_NUMBERS: list = []
 
 DISHWASHER_SENSORS = [

--- a/components/subzero_appliance/__init__.py
+++ b/components/subzero_appliance/__init__.py
@@ -197,11 +197,29 @@ TEMP_KWARGS = {
 }
 
 FRIDGE_SENSORS = [
-    # Note: set_temp / frz_set_temp / wine_set_temp / wine2_set_temp /
-    # ref2_set_temp / crisp_set_temp moved to FRIDGE_WRITABLE_NUMBERS —
-    # they're now Number entities (HA can both read AND write the
-    # setpoint). The publish-back path to keep HA in sync after pushes
-    # is identical; only the entity type changed.
+    # Set-temps are read-only Sensors. Writing them via `set` does NOT
+    # appear to work on the fridges we've tested — the appliance accepts
+    # the write (status:0) but never actually changes the setpoint, and
+    # the user has no recourse if a typo'd value somehow does take. Until
+    # we understand the appliance's set-temp guard mode (suspect: needs
+    # some "edit mode" enabled at the front panel first, similar to oven
+    # cav_set_temp requiring an active cook mode), keep these read-only.
+    ("set_temp", "Set Temperature", "set_set_temp_sensor",
+     {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer"}, None),
+    ("frz_set_temp", "Freezer Set Temperature", "set_frz_set_temp_sensor",
+     {**TEMP_KWARGS, CONF_ICON: "mdi:snowflake-thermometer"}, "hide_freezer"),
+    ("wine_set_temp", "Wine Zone Upper Set Temperature",
+     "set_wine_set_temp_sensor",
+     {**TEMP_KWARGS, CONF_ICON: "mdi:glass-wine"}, "hide_wine"),
+    ("wine2_set_temp", "Wine Zone Lower Set Temperature",
+     "set_wine2_set_temp_sensor",
+     {**TEMP_KWARGS, CONF_ICON: "mdi:glass-wine"}, "hide_wine"),
+    ("ref2_set_temp", "Refrigerator Drawer Set Temperature",
+     "set_ref2_set_temp_sensor",
+     {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer"}, "hide_ref_drawer"),
+    ("crisp_set_temp", "Crisper Drawer Set Temperature",
+     "set_crisp_set_temp_sensor",
+     {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer"}, "hide_crisper"),
     ("air_filter_pct", "Air Filter Remaining", "set_air_filter_pct_sensor",
      {CONF_UNIT_OF_MEASUREMENT: UNIT_PERCENT, "state_class": STATE_CLASS_MEASUREMENT,
       "accuracy_decimals": 0, CONF_ICON: "mdi:air-filter"}, "hide_air_filter"),
@@ -222,28 +240,9 @@ NUMBER_KWARGS = {
     CONF_MODE: "box",
 }
 
-FRIDGE_WRITABLE_NUMBERS = [
-    # Fresh food zone — the always-present setpoint on every fridge.
-    ("set_temp", "Set Temperature", "set_set_temp_number", "set_temp",
-     34, 45, 1, {**NUMBER_KWARGS, CONF_ICON: "mdi:thermometer"}, None),
-    ("frz_set_temp", "Freezer Set Temperature", "set_frz_set_temp_number",
-     "frz_set_temp", -10, 5, 1,
-     {**NUMBER_KWARGS, CONF_ICON: "mdi:snowflake-thermometer"}, "hide_freezer"),
-    ("wine_set_temp", "Wine Zone Upper Set Temperature",
-     "set_wine_set_temp_number", "wine_set_temp", 40, 65, 1,
-     {**NUMBER_KWARGS, CONF_ICON: "mdi:glass-wine"}, "hide_wine"),
-    ("wine2_set_temp", "Wine Zone Lower Set Temperature",
-     "set_wine2_set_temp_number", "wine2_set_temp", 40, 65, 1,
-     {**NUMBER_KWARGS, CONF_ICON: "mdi:glass-wine"}, "hide_wine"),
-    ("ref2_set_temp", "Refrigerator Drawer Set Temperature",
-     "set_ref2_set_temp_number", "ref2_set_temp", 33, 45, 1,
-     {**NUMBER_KWARGS, CONF_ICON: "mdi:thermometer"}, "hide_ref_drawer"),
-    ("crisp_set_temp", "Crisper Drawer Set Temperature",
-     "set_crisp_set_temp_number", "crisp_set_temp", 30, 45, 1,
-     {**NUMBER_KWARGS, CONF_ICON: "mdi:thermometer"}, "hide_crisper"),
-]
-
-FRIDGE_WRITABLE_SWITCHES: list = []  # none yet — sabbath_on writability unconfirmed
+# Fridge has no writable numbers yet — see comment on FRIDGE_SENSORS above.
+FRIDGE_WRITABLE_NUMBERS: list = []
+FRIDGE_WRITABLE_SWITCHES: list = []  # sabbath_on writability also unconfirmed
 
 DISHWASHER_BINARY_SENSORS = [
     ("door_ajar", "Door", "set_door_ajar_sensor", {CONF_DEVICE_CLASS: DEVICE_CLASS_DOOR}, None),

--- a/components/subzero_appliance/__init__.py
+++ b/components/subzero_appliance/__init__.py
@@ -364,19 +364,22 @@ RANGE_WRITABLE_SWITCHES = [
      {CONF_ICON: "mdi:lightbulb"}, "hide_oven2"),
 ]
 
-# Range temp ranges: most Wolf ovens go 100-550°F, probe target 100-200°F.
-# Step is 1°F to allow precise setpoints (the appliance UI typically rounds
-# to 5° but we let the user pick whatever).
+# Wolf ovens (both wall and range cavities) won't accept a target below
+# 200°F - confirmed on the SO3050PESP wall oven, and consistent with the
+# minimum settable temperature on every Wolf oven manual we've checked.
+# Upper bound 550°F covers the Roast/Broil ranges. Probe targets go
+# 100-200°F (food internal temp). Step is 1°F so the user can pick any
+# value the appliance accepts; the front panel typically rounds to 5°.
 RANGE_WRITABLE_NUMBERS = [
     # (suffix, name_suffix, setter, property_key, min, max, step, kwargs, hide_key)
     ("cav_set_temp", "Oven Set Temperature", "set_cav_set_temp_number",
-     "cav_set_temp", 100, 550, 1,
+     "cav_set_temp", 200, 550, 1,
      {**NUMBER_KWARGS, CONF_ICON: "mdi:thermometer-check"}, None),
     ("probe_set_temp", "Probe Set Temperature", "set_probe_set_temp_number",
      "cav_probe_set_temp", 100, 200, 1,
      {**NUMBER_KWARGS, CONF_ICON: "mdi:thermometer-probe-off"}, None),
     ("cav2_set_temp", "Oven 2 Set Temperature", "set_cav2_set_temp_number",
-     "cav2_set_temp", 100, 550, 1,
+     "cav2_set_temp", 200, 550, 1,
      {**NUMBER_KWARGS, CONF_ICON: "mdi:thermometer-check"}, "hide_oven2"),
     ("cav2_probe_set_temp", "Oven 2 Probe Set Temperature",
      "set_cav2_probe_set_temp_number", "cav2_probe_set_temp", 100, 200, 1,

--- a/components/subzero_appliance/__init__.py
+++ b/components/subzero_appliance/__init__.py
@@ -377,13 +377,13 @@ RANGE_WRITABLE_NUMBERS = [
      {**NUMBER_KWARGS, CONF_ICON: "mdi:thermometer-check"}, None),
     ("probe_set_temp", "Probe Set Temperature", "set_probe_set_temp_number",
      "cav_probe_set_temp", 100, 200, 1,
-     {**NUMBER_KWARGS, CONF_ICON: "mdi:thermometer-probe-off"}, None),
+     {**NUMBER_KWARGS, CONF_ICON: "mdi:thermometer-probe"}, None),
     ("cav2_set_temp", "Oven 2 Set Temperature", "set_cav2_set_temp_number",
      "cav2_set_temp", 200, 550, 1,
      {**NUMBER_KWARGS, CONF_ICON: "mdi:thermometer-check"}, "hide_oven2"),
     ("cav2_probe_set_temp", "Oven 2 Probe Set Temperature",
      "set_cav2_probe_set_temp_number", "cav2_probe_set_temp", 100, 200, 1,
-     {**NUMBER_KWARGS, CONF_ICON: "mdi:thermometer-probe-off"}, "hide_oven2"),
+     {**NUMBER_KWARGS, CONF_ICON: "mdi:thermometer-probe"}, "hide_oven2"),
 ]
 
 RANGE_TEXT_SENSORS = [

--- a/components/subzero_appliance/__init__.py
+++ b/components/subzero_appliance/__init__.py
@@ -39,6 +39,7 @@ from esphome.components import (
     binary_sensor,
     ble_client,
     button,
+    number,
     sensor,
     switch,
     text,
@@ -71,6 +72,7 @@ AUTO_LOAD = [
     "binary_sensor",
     "button",
     "json",
+    "number",
     "sensor",
     "subzero_protocol",
     "switch",
@@ -92,6 +94,8 @@ ApplianceButton = subzero_appliance_ns.class_("ApplianceButton", button.Button)
 ApplianceDebugSwitch = subzero_appliance_ns.class_(
     "ApplianceDebugSwitch", switch.Switch
 )
+ApplianceSetSwitch = subzero_appliance_ns.class_("ApplianceSetSwitch", switch.Switch)
+ApplianceSetNumber = subzero_appliance_ns.class_("ApplianceSetNumber", number.Number)
 AppliancePinText = subzero_appliance_ns.class_("AppliancePinText", text.Text)
 ApplianceButtonKind = subzero_appliance_ns.enum("ApplianceButtonKind", is_class=True)
 
@@ -153,6 +157,13 @@ BUTTON_DEFINITIONS = [
     ("kLogDebugInfo", "{name} Log Debug Info", "mdi:bug-play", ENTITY_CATEGORY_DIAGNOSTIC),
     ("kDisconnect", "Disconnect {name}", "mdi:bluetooth-off", None),
     ("kResetPairing", "Reset {name} Pairing", "mdi:bluetooth-settings", ENTITY_CATEGORY_CONFIG),
+    # Diagnostic: deregister the appliance from Azure IoT Hub by sending
+    # `set remote_svc_reg_token=""`. After that, the official app can no
+    # longer reach the appliance over cloud — it will fall back to BLE
+    # and fight us for the single connection slot. Useful only if you
+    # specifically want to disable the cloud path.
+    ("kClearCloudToken", "{name} Clear Cloud Token (BT-Only)",
+     "mdi:cloud-off-outline", ENTITY_CATEGORY_DIAGNOSTIC),
 ]
 
 # Per-type sensor descriptors. Each entry: (suffix, name_suffix, setter, kwargs, hide_key_or_None).
@@ -186,18 +197,11 @@ TEMP_KWARGS = {
 }
 
 FRIDGE_SENSORS = [
-    ("set_temp", "Set Temperature", "set_set_temp_sensor",
-     {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer"}, None),
-    ("frz_set_temp", "Freezer Set Temperature", "set_frz_set_temp_sensor",
-     {**TEMP_KWARGS, CONF_ICON: "mdi:snowflake-thermometer"}, "hide_freezer"),
-    ("wine_set_temp", "Wine Zone Upper Set Temperature", "set_wine_set_temp_sensor",
-     {**TEMP_KWARGS, CONF_ICON: "mdi:glass-wine"}, "hide_wine"),
-    ("wine2_set_temp", "Wine Zone Lower Set Temperature", "set_wine2_set_temp_sensor",
-     {**TEMP_KWARGS, CONF_ICON: "mdi:glass-wine"}, "hide_wine"),
-    ("ref2_set_temp", "Refrigerator Drawer Set Temperature", "set_ref2_set_temp_sensor",
-     {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer"}, "hide_ref_drawer"),
-    ("crisp_set_temp", "Crisper Drawer Set Temperature", "set_crisp_set_temp_sensor",
-     {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer"}, "hide_crisper"),
+    # Note: set_temp / frz_set_temp / wine_set_temp / wine2_set_temp /
+    # ref2_set_temp / crisp_set_temp moved to FRIDGE_WRITABLE_NUMBERS —
+    # they're now Number entities (HA can both read AND write the
+    # setpoint). The publish-back path to keep HA in sync after pushes
+    # is identical; only the entity type changed.
     ("air_filter_pct", "Air Filter Remaining", "set_air_filter_pct_sensor",
      {CONF_UNIT_OF_MEASUREMENT: UNIT_PERCENT, "state_class": STATE_CLASS_MEASUREMENT,
       "accuracy_decimals": 0, CONF_ICON: "mdi:air-filter"}, "hide_air_filter"),
@@ -205,6 +209,41 @@ FRIDGE_SENSORS = [
      {CONF_UNIT_OF_MEASUREMENT: UNIT_PERCENT, "state_class": STATE_CLASS_MEASUREMENT,
       "accuracy_decimals": 0, CONF_ICON: "mdi:water-percent"}, "hide_water_filter"),
 ]
+
+# Writable numbers — entry shape: (suffix, name_suffix, setter, property_key,
+# min, max, step, kwargs, hide_key). Default min/max are conservative ranges
+# from typical Sub-Zero appliance manuals; user can tweak via HA's UI by
+# selecting whatever value they want within the range. The appliance is
+# the ultimate source of truth and will reject out-of-range writes (which
+# would surface as `status:N` parse failures, logged but not crash).
+NUMBER_KWARGS = {
+    CONF_UNIT_OF_MEASUREMENT: UNIT_FAHRENHEIT,
+    CONF_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
+    CONF_MODE: "box",
+}
+
+FRIDGE_WRITABLE_NUMBERS = [
+    # Fresh food zone — the always-present setpoint on every fridge.
+    ("set_temp", "Set Temperature", "set_set_temp_number", "set_temp",
+     34, 45, 1, {**NUMBER_KWARGS, CONF_ICON: "mdi:thermometer"}, None),
+    ("frz_set_temp", "Freezer Set Temperature", "set_frz_set_temp_number",
+     "frz_set_temp", -10, 5, 1,
+     {**NUMBER_KWARGS, CONF_ICON: "mdi:snowflake-thermometer"}, "hide_freezer"),
+    ("wine_set_temp", "Wine Zone Upper Set Temperature",
+     "set_wine_set_temp_number", "wine_set_temp", 40, 65, 1,
+     {**NUMBER_KWARGS, CONF_ICON: "mdi:glass-wine"}, "hide_wine"),
+    ("wine2_set_temp", "Wine Zone Lower Set Temperature",
+     "set_wine2_set_temp_number", "wine2_set_temp", 40, 65, 1,
+     {**NUMBER_KWARGS, CONF_ICON: "mdi:glass-wine"}, "hide_wine"),
+    ("ref2_set_temp", "Refrigerator Drawer Set Temperature",
+     "set_ref2_set_temp_number", "ref2_set_temp", 33, 45, 1,
+     {**NUMBER_KWARGS, CONF_ICON: "mdi:thermometer"}, "hide_ref_drawer"),
+    ("crisp_set_temp", "Crisper Drawer Set Temperature",
+     "set_crisp_set_temp_number", "crisp_set_temp", 30, 45, 1,
+     {**NUMBER_KWARGS, CONF_ICON: "mdi:thermometer"}, "hide_crisper"),
+]
+
+FRIDGE_WRITABLE_SWITCHES: list = []  # none yet — sabbath_on writability unconfirmed
 
 DISHWASHER_BINARY_SENSORS = [
     ("door_ajar", "Door", "set_door_ajar_sensor", {CONF_DEVICE_CLASS: DEVICE_CLASS_DOOR}, None),
@@ -219,10 +258,18 @@ DISHWASHER_BINARY_SENSORS = [
      {CONF_DEVICE_CLASS: DEVICE_CLASS_PROBLEM}, None),
     ("softener_low", "Softener Low", "set_softener_low_sensor",
      {CONF_DEVICE_CLASS: DEVICE_CLASS_PROBLEM}, "hide_softener"),
-    ("light_on", "Light", "set_light_on_sensor", {CONF_ICON: "mdi:lightbulb"}, None),
+    # light_on moved to DISHWASHER_WRITABLE_SWITCHES — it's a Switch now.
     ("remote_ready", "Remote Ready", "set_remote_ready_sensor", {CONF_ICON: "mdi:remote"}, None),
     ("delay_start", "Delay Start", "set_delay_start_sensor", {CONF_ICON: "mdi:timer-sand"}, None),
 ]
+
+DISHWASHER_WRITABLE_SWITCHES = [
+    # (suffix, name_suffix, setter, property_key, kwargs, hide_key)
+    ("light_on", "Light", "set_light_on_switch", "light_on",
+     {CONF_ICON: "mdi:lightbulb"}, None),
+]
+
+DISHWASHER_WRITABLE_NUMBERS: list = []
 
 DISHWASHER_SENSORS = [
     ("wash_status", "Wash Status", "set_wash_status_sensor",
@@ -245,7 +292,7 @@ RANGE_BINARY_SENSORS = [
     ("cav_unit_on", "Oven", "set_cav_unit_on_sensor", {CONF_ICON: "mdi:stove"}, None),
     ("cav_at_set_temp", "Oven At Temperature", "set_cav_at_set_temp_sensor",
      {CONF_ICON: "mdi:thermometer-check"}, None),
-    ("cav_light_on", "Oven Light", "set_cav_light_on_sensor", {CONF_ICON: "mdi:lightbulb"}, None),
+    # cav_light_on moved to RANGE_WRITABLE_SWITCHES.
     ("cav_remote_ready", "Oven Remote Ready", "set_cav_remote_ready_sensor",
      {CONF_ICON: "mdi:remote"}, None),
     ("cav_probe_on", "Probe Inserted", "set_cav_probe_on_sensor",
@@ -278,8 +325,7 @@ RANGE_BINARY_SENSORS = [
      {CONF_DEVICE_CLASS: DEVICE_CLASS_DOOR}, "hide_oven2"),
     ("cav2_at_set_temp", "Oven 2 At Temperature", "set_cav2_at_set_temp_sensor",
      {CONF_ICON: "mdi:thermometer-check"}, "hide_oven2"),
-    ("cav2_light_on", "Oven 2 Light", "set_cav2_light_on_sensor",
-     {CONF_ICON: "mdi:lightbulb"}, "hide_oven2"),
+    # cav2_light_on moved to RANGE_WRITABLE_SWITCHES.
     ("cav2_remote_ready", "Oven 2 Remote Ready", "set_cav2_remote_ready_sensor",
      {CONF_ICON: "mdi:remote"}, "hide_oven2"),
     ("cav2_probe_on", "Oven 2 Probe Inserted", "set_cav2_probe_on_sensor",
@@ -297,26 +343,47 @@ RANGE_BINARY_SENSORS = [
 RANGE_SENSORS = [
     ("cav_temp", "Oven Temperature", "set_cav_temp_sensor",
      {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer"}, None),
-    ("cav_set_temp", "Oven Set Temperature", "set_cav_set_temp_sensor",
-     {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer-check"}, None),
+    # cav_set_temp / probe_set_temp / cav2_set_temp / cav2_probe_set_temp
+    # moved to RANGE_WRITABLE_NUMBERS.
     ("cav_cook_mode", "Cook Mode", "set_cav_cook_mode_sensor",
      {CONF_ICON: "mdi:stove", "accuracy_decimals": 0}, None),
     ("cav_gourmet_recipe", "Gourmet Recipe", "set_cav_gourmet_recipe_sensor",
      {CONF_ICON: "mdi:chef-hat", "accuracy_decimals": 0}, None),
     ("probe_temp", "Probe Temperature", "set_probe_temp_sensor",
      {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer-probe"}, None),
-    ("probe_set_temp", "Probe Set Temperature", "set_probe_set_temp_sensor",
-     {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer-probe-off"}, None),
     ("cav2_temp", "Oven 2 Temperature", "set_cav2_temp_sensor",
      {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer"}, "hide_oven2"),
-    ("cav2_set_temp", "Oven 2 Set Temperature", "set_cav2_set_temp_sensor",
-     {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer-check"}, "hide_oven2"),
     ("cav2_cook_mode", "Oven 2 Cook Mode", "set_cav2_cook_mode_sensor",
      {CONF_ICON: "mdi:stove", "accuracy_decimals": 0}, "hide_oven2"),
     ("cav2_probe_temp", "Oven 2 Probe Temperature", "set_cav2_probe_temp_sensor",
      {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer-probe"}, "hide_oven2"),
-    ("cav2_probe_set_temp", "Oven 2 Probe Set Temperature", "set_cav2_probe_set_temp_sensor",
-     {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer-probe-off"}, "hide_oven2"),
+]
+
+RANGE_WRITABLE_SWITCHES = [
+    # (suffix, name_suffix, setter, property_key, kwargs, hide_key)
+    ("cav_light_on", "Oven Light", "set_cav_light_on_switch", "cav_light_on",
+     {CONF_ICON: "mdi:lightbulb"}, None),
+    ("cav2_light_on", "Oven 2 Light", "set_cav2_light_on_switch", "cav2_light_on",
+     {CONF_ICON: "mdi:lightbulb"}, "hide_oven2"),
+]
+
+# Range temp ranges: most Wolf ovens go 100-550°F, probe target 100-200°F.
+# Step is 1°F to allow precise setpoints (the appliance UI typically rounds
+# to 5° but we let the user pick whatever).
+RANGE_WRITABLE_NUMBERS = [
+    # (suffix, name_suffix, setter, property_key, min, max, step, kwargs, hide_key)
+    ("cav_set_temp", "Oven Set Temperature", "set_cav_set_temp_number",
+     "cav_set_temp", 100, 550, 1,
+     {**NUMBER_KWARGS, CONF_ICON: "mdi:thermometer-check"}, None),
+    ("probe_set_temp", "Probe Set Temperature", "set_probe_set_temp_number",
+     "cav_probe_set_temp", 100, 200, 1,
+     {**NUMBER_KWARGS, CONF_ICON: "mdi:thermometer-probe-off"}, None),
+    ("cav2_set_temp", "Oven 2 Set Temperature", "set_cav2_set_temp_number",
+     "cav2_set_temp", 100, 550, 1,
+     {**NUMBER_KWARGS, CONF_ICON: "mdi:thermometer-check"}, "hide_oven2"),
+    ("cav2_probe_set_temp", "Oven 2 Probe Set Temperature",
+     "set_cav2_probe_set_temp_number", "cav2_probe_set_temp", 100, 200, 1,
+     {**NUMBER_KWARGS, CONF_ICON: "mdi:thermometer-probe-off"}, "hide_oven2"),
 ]
 
 RANGE_TEXT_SENSORS = [
@@ -448,6 +515,47 @@ def _resolve_hidden(config, hide_key):
     return bool(config.get(hide_key, False))
 
 
+async def _build_set_switch(parent_id, parent_var, suffix, name_suffix,
+                            property_key, kwargs, hidden):
+    """Instantiates an ApplianceSetSwitch HA entity, wires the parent +
+    property_key, and registers it. Caller binds the bus pointer via the
+    setter on `parent_var` (e.g. `parent_var.set_cav_light_on_switch(s)`).
+    """
+    cfg_raw = {
+        CONF_ID: _entity_id(parent_id, suffix, ApplianceSetSwitch),
+        CONF_NAME: name_suffix,
+    }
+    cfg_raw.update(kwargs)
+    if hidden:
+        cfg_raw[CONF_INTERNAL] = True
+    cfg = switch.switch_schema(ApplianceSetSwitch)(cfg_raw)
+    sw = await switch.new_switch(cfg)
+    cg.add(sw.set_parent(parent_var))
+    cg.add(sw.set_property_key(property_key))
+    return sw
+
+
+async def _build_set_number(parent_id, parent_var, suffix, name_suffix,
+                            property_key, min_value, max_value, step,
+                            kwargs, hidden):
+    """Instantiates an ApplianceSetNumber HA entity, wires the parent +
+    property_key, and registers it with min/max/step traits."""
+    cfg_raw = {
+        CONF_ID: _entity_id(parent_id, suffix, ApplianceSetNumber),
+        CONF_NAME: name_suffix,
+    }
+    cfg_raw.update(kwargs)
+    if hidden:
+        cfg_raw[CONF_INTERNAL] = True
+    cfg = number.number_schema(ApplianceSetNumber)(cfg_raw)
+    n = await number.new_number(
+        cfg, min_value=min_value, max_value=max_value, step=step,
+    )
+    cg.add(n.set_parent(parent_var))
+    cg.add(n.set_property_key(property_key))
+    return n
+
+
 # ----------------------------------------------------------------------
 # to_code
 # ----------------------------------------------------------------------
@@ -491,14 +599,20 @@ async def to_code(config):
         bs_list = FRIDGE_BINARY_SENSORS
         s_list = FRIDGE_SENSORS
         ts_list = []
+        sw_list = FRIDGE_WRITABLE_SWITCHES
+        n_list = FRIDGE_WRITABLE_NUMBERS
     elif type_ == "dishwasher":
         bs_list = DISHWASHER_BINARY_SENSORS
         s_list = DISHWASHER_SENSORS
         ts_list = DISHWASHER_TEXT_SENSORS
+        sw_list = DISHWASHER_WRITABLE_SWITCHES
+        n_list = DISHWASHER_WRITABLE_NUMBERS
     else:  # range
         bs_list = RANGE_BINARY_SENSORS
         s_list = RANGE_SENSORS
         ts_list = RANGE_TEXT_SENSORS
+        sw_list = RANGE_WRITABLE_SWITCHES
+        n_list = RANGE_WRITABLE_NUMBERS
 
     for suffix, name_suffix, setter, kwargs, hide_key in bs_list:
         cfg = _build_binary_sensor_config(
@@ -523,6 +637,23 @@ async def to_code(config):
         )
         ts = await text_sensor.new_text_sensor(cfg)
         cg.add(getattr(var, setter)(ts))
+
+    # Writable switches — HA-toggled booleans that send `set` on D5.
+    for suffix, name_suffix, setter, prop_key, kwargs, hide_key in sw_list:
+        sw = await _build_set_switch(
+            parent_id, var, suffix, f"{name} {name_suffix}", prop_key, kwargs,
+            _resolve_hidden(config, hide_key),
+        )
+        cg.add(getattr(var, setter)(sw))
+
+    # Writable numbers — HA-set numerics (set temps, etc.) that send `set`.
+    for (suffix, name_suffix, setter, prop_key, mn, mx, step,
+         kwargs, hide_key) in n_list:
+        n = await _build_set_number(
+            parent_id, var, suffix, f"{name} {name_suffix}", prop_key,
+            mn, mx, step, kwargs, _resolve_hidden(config, hide_key),
+        )
+        cg.add(getattr(var, setter)(n))
 
     # ---- PIN text input ----
     # esphome::text::Text is abstract (control() is pure virtual); use

--- a/components/subzero_appliance/appliance.h
+++ b/components/subzero_appliance/appliance.h
@@ -120,8 +120,11 @@ public:
   void set_softener_low_sensor(esphome::binary_sensor::BinarySensor *s) {
     bus_.softener_low = s;
   }
-  // Writable: Light is a Switch (HA toggles → set light_on=true/false on D5).
-  void set_light_on_switch(esphome::switch_::Switch *s) { bus_.light_on = s; }
+  // Read-only: dishwasher light_on can't actually be toggled via `set`
+  // (appliance acks but doesn't honor the write). Stays a binary_sensor.
+  void set_light_on_sensor(esphome::binary_sensor::BinarySensor *s) {
+    bus_.light_on = s;
+  }
   void set_remote_ready_sensor(esphome::binary_sensor::BinarySensor *s) {
     bus_.remote_ready = s;
   }

--- a/components/subzero_appliance/appliance.h
+++ b/components/subzero_appliance/appliance.h
@@ -57,22 +57,23 @@ public:
     bus_.air_filter_on = s;
   }
 
-  // Writable set-temps — Number entities. See ApplianceSetNumber.
-  void set_set_temp_number(esphome::number::Number *n) { bus_.set_temp = n; }
-  void set_frz_set_temp_number(esphome::number::Number *n) {
-    bus_.frz_set_temp = n;
+  // Set-temps are read-only Sensors. See FRIDGE_SENSORS comment in
+  // __init__.py for why they're not yet exposed as writable Numbers.
+  void set_set_temp_sensor(esphome::sensor::Sensor *s) { bus_.set_temp = s; }
+  void set_frz_set_temp_sensor(esphome::sensor::Sensor *s) {
+    bus_.frz_set_temp = s;
   }
-  void set_ref2_set_temp_number(esphome::number::Number *n) {
-    bus_.ref2_set_temp = n;
+  void set_ref2_set_temp_sensor(esphome::sensor::Sensor *s) {
+    bus_.ref2_set_temp = s;
   }
-  void set_wine_set_temp_number(esphome::number::Number *n) {
-    bus_.wine_set_temp = n;
+  void set_wine_set_temp_sensor(esphome::sensor::Sensor *s) {
+    bus_.wine_set_temp = s;
   }
-  void set_wine2_set_temp_number(esphome::number::Number *n) {
-    bus_.wine2_set_temp = n;
+  void set_wine2_set_temp_sensor(esphome::sensor::Sensor *s) {
+    bus_.wine2_set_temp = s;
   }
-  void set_crisp_set_temp_number(esphome::number::Number *n) {
-    bus_.crisp_set_temp = n;
+  void set_crisp_set_temp_sensor(esphome::sensor::Sensor *s) {
+    bus_.crisp_set_temp = s;
   }
   void set_air_filter_pct_sensor(esphome::sensor::Sensor *s) {
     bus_.air_filter_pct = s;

--- a/components/subzero_appliance/appliance.h
+++ b/components/subzero_appliance/appliance.h
@@ -57,21 +57,22 @@ public:
     bus_.air_filter_on = s;
   }
 
-  void set_set_temp_sensor(esphome::sensor::Sensor *s) { bus_.set_temp = s; }
-  void set_frz_set_temp_sensor(esphome::sensor::Sensor *s) {
-    bus_.frz_set_temp = s;
+  // Writable set-temps — Number entities. See ApplianceSetNumber.
+  void set_set_temp_number(esphome::number::Number *n) { bus_.set_temp = n; }
+  void set_frz_set_temp_number(esphome::number::Number *n) {
+    bus_.frz_set_temp = n;
   }
-  void set_ref2_set_temp_sensor(esphome::sensor::Sensor *s) {
-    bus_.ref2_set_temp = s;
+  void set_ref2_set_temp_number(esphome::number::Number *n) {
+    bus_.ref2_set_temp = n;
   }
-  void set_wine_set_temp_sensor(esphome::sensor::Sensor *s) {
-    bus_.wine_set_temp = s;
+  void set_wine_set_temp_number(esphome::number::Number *n) {
+    bus_.wine_set_temp = n;
   }
-  void set_wine2_set_temp_sensor(esphome::sensor::Sensor *s) {
-    bus_.wine2_set_temp = s;
+  void set_wine2_set_temp_number(esphome::number::Number *n) {
+    bus_.wine2_set_temp = n;
   }
-  void set_crisp_set_temp_sensor(esphome::sensor::Sensor *s) {
-    bus_.crisp_set_temp = s;
+  void set_crisp_set_temp_number(esphome::number::Number *n) {
+    bus_.crisp_set_temp = n;
   }
   void set_air_filter_pct_sensor(esphome::sensor::Sensor *s) {
     bus_.air_filter_pct = s;
@@ -118,9 +119,8 @@ public:
   void set_softener_low_sensor(esphome::binary_sensor::BinarySensor *s) {
     bus_.softener_low = s;
   }
-  void set_light_on_sensor(esphome::binary_sensor::BinarySensor *s) {
-    bus_.light_on = s;
-  }
+  // Writable: Light is a Switch (HA toggles → set light_on=true/false on D5).
+  void set_light_on_switch(esphome::switch_::Switch *s) { bus_.light_on = s; }
   void set_remote_ready_sensor(esphome::binary_sensor::BinarySensor *s) {
     bus_.remote_ready = s;
   }
@@ -165,7 +165,8 @@ public:
   void set_cav_at_set_temp_sensor(esphome::binary_sensor::BinarySensor *s) {
     bus_.cav_at_set_temp = s;
   }
-  void set_cav_light_on_sensor(esphome::binary_sensor::BinarySensor *s) {
+  // Writable: Oven Light is a Switch.
+  void set_cav_light_on_switch(esphome::switch_::Switch *s) {
     bus_.cav_light_on = s;
   }
   void set_cav_remote_ready_sensor(esphome::binary_sensor::BinarySensor *s) {
@@ -192,8 +193,9 @@ public:
 
   // Primary cavity numeric / mode
   void set_cav_temp_sensor(esphome::sensor::Sensor *s) { bus_.cav_temp = s; }
-  void set_cav_set_temp_sensor(esphome::sensor::Sensor *s) {
-    bus_.cav_set_temp = s;
+  // Writable: cav_set_temp is a Number (HA writes target temp).
+  void set_cav_set_temp_number(esphome::number::Number *n) {
+    bus_.cav_set_temp = n;
   }
   void set_cav_cook_mode_sensor(esphome::sensor::Sensor *s) {
     bus_.cav_cook_mode = s;
@@ -204,8 +206,9 @@ public:
   void set_probe_temp_sensor(esphome::sensor::Sensor *s) {
     bus_.probe_temp = s;
   }
-  void set_probe_set_temp_sensor(esphome::sensor::Sensor *s) {
-    bus_.probe_set_temp = s;
+  // Writable: probe_set_temp is a Number.
+  void set_probe_set_temp_number(esphome::number::Number *n) {
+    bus_.probe_set_temp = n;
   }
 
   // Kitchen timers
@@ -244,7 +247,8 @@ public:
   void set_cav2_at_set_temp_sensor(esphome::binary_sensor::BinarySensor *s) {
     bus_.cav2_at_set_temp = s;
   }
-  void set_cav2_light_on_sensor(esphome::binary_sensor::BinarySensor *s) {
+  // Writable: Oven 2 Light is a Switch.
+  void set_cav2_light_on_switch(esphome::switch_::Switch *s) {
     bus_.cav2_light_on = s;
   }
   void set_cav2_remote_ready_sensor(esphome::binary_sensor::BinarySensor *s) {
@@ -267,8 +271,9 @@ public:
     bus_.cav2_cook_timer_done = s;
   }
   void set_cav2_temp_sensor(esphome::sensor::Sensor *s) { bus_.cav2_temp = s; }
-  void set_cav2_set_temp_sensor(esphome::sensor::Sensor *s) {
-    bus_.cav2_set_temp = s;
+  // Writable: cav2_set_temp is a Number.
+  void set_cav2_set_temp_number(esphome::number::Number *n) {
+    bus_.cav2_set_temp = n;
   }
   void set_cav2_cook_mode_sensor(esphome::sensor::Sensor *s) {
     bus_.cav2_cook_mode = s;
@@ -276,8 +281,9 @@ public:
   void set_cav2_probe_temp_sensor(esphome::sensor::Sensor *s) {
     bus_.cav2_probe_temp = s;
   }
-  void set_cav2_probe_set_temp_sensor(esphome::sensor::Sensor *s) {
-    bus_.cav2_probe_set_temp = s;
+  // Writable: cav2_probe_set_temp is a Number.
+  void set_cav2_probe_set_temp_number(esphome::number::Number *n) {
+    bus_.cav2_probe_set_temp = n;
   }
 
 protected:

--- a/components/subzero_appliance/appliance_base.cpp
+++ b/components/subzero_appliance/appliance_base.cpp
@@ -98,7 +98,8 @@ void ApplianceBase::gattc_event_handler(esp_gattc_cb_event_t event,
     std::uint16_t nh = param->notify.handle;
     std::uint16_t d5 = h->d5_handle();
     std::uint16_t d6 = h->d6_handle();
-    if (nh == 0) break;
+    if (nh == 0)
+      break;
     if (d5 != 0 && nh == d5) {
       h->handle_d5_notify(param->notify.value, param->notify.value_len);
     } else if (d6 != 0 && nh == d6) {

--- a/components/subzero_appliance/appliance_base.h
+++ b/components/subzero_appliance/appliance_base.h
@@ -11,6 +11,7 @@
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/ble_client/ble_client.h"
 #include "esphome/components/button/button.h"
+#include "esphome/components/number/number.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/text/text.h"
@@ -117,6 +118,19 @@ public:
     hub()->set_stored_pin(pin);
   }
 
+  // Used by ApplianceSetSwitch / ApplianceSetNumber when HA writes a
+  // value. Forwards directly to the hub which handles JSON-formatting
+  // and the D5 write.
+  void write_set_bool(const std::string &key, bool value) {
+    hub()->write_set_bool(key, value);
+  }
+  void write_set_int(const std::string &key, int value) {
+    hub()->write_set_int(key, value);
+  }
+  void write_set_string(const std::string &key, const std::string &value) {
+    hub()->write_set_string(key, value);
+  }
+
   // ---- Button actions (called from ApplianceButton::press_action) ----
 
   // Connect: reset hub state and trigger ble_client connect.
@@ -131,6 +145,15 @@ public:
   // Reset: full pairing wipe — clear bond + handles + state, then
   // disconnect and let auto_connect re-pair on the next session.
   void press_reset_pairing();
+  // Clear cloud token: sends `set remote_svc_reg_token=""` to deregister
+  // the appliance from Azure IoT Hub, forcing the official app to fall
+  // back to BLE for everything (which then fights us for the single
+  // connection slot — diagnostic only). Verified mechanism via HCI snoop
+  // 2026-04-26: the app's `isBluetoothOnlyMode` flips false once any
+  // token is present.
+  void press_clear_cloud_token() {
+    write_set_string("remote_svc_reg_token", "");
+  }
 
 protected:
   // Subclass plug-in points
@@ -163,6 +186,7 @@ enum class ApplianceButtonKind {
   kPoll,
   kLogDebugInfo,
   kResetPairing,
+  kClearCloudToken,
 };
 
 class ApplianceButton : public esphome::button::Button {
@@ -196,6 +220,9 @@ protected:
     case ApplianceButtonKind::kResetPairing:
       parent_->press_reset_pairing();
       break;
+    case ApplianceButtonKind::kClearCloudToken:
+      parent_->press_clear_cloud_token();
+      break;
     }
   }
 
@@ -222,6 +249,54 @@ protected:
 
 private:
   ApplianceBase *parent_ = nullptr;
+};
+
+// Switch subclass for writable boolean properties (cav_light_on, sabbath_on,
+// dishwasher light_on, etc.). One class powers all of them — the property
+// key is wired in by Python codegen. write_state forwards to the hub via
+// `set` on D5; the appliance acks then pushes the new value back on D6,
+// which our normal read pipeline catches and publishes back via the
+// dispatch bus, keeping the switch in sync. publish_state happens here too
+// so the UI updates instantly without waiting for the round-trip echo.
+class ApplianceSetSwitch : public esphome::switch_::Switch {
+public:
+  void set_parent(ApplianceBase *p) { parent_ = p; }
+  void set_property_key(const std::string &k) { property_key_ = k; }
+
+protected:
+  void write_state(bool state) override {
+    if (parent_ != nullptr && !property_key_.empty()) {
+      parent_->write_set_bool(property_key_, state);
+    }
+    this->publish_state(state);
+  }
+
+private:
+  ApplianceBase *parent_ = nullptr;
+  std::string property_key_;
+};
+
+// Number subclass for writable numeric properties (set_temp, frz_set_temp,
+// kitchen_timer_duration, etc.). Sub-Zero's protocol uses integers for all
+// the writable numerics we've observed (temps in whole degrees F, timer
+// durations in whole seconds), so control() rounds the float to int before
+// formatting. publish_state echoes back so the UI updates instantly.
+class ApplianceSetNumber : public esphome::number::Number {
+public:
+  void set_parent(ApplianceBase *p) { parent_ = p; }
+  void set_property_key(const std::string &k) { property_key_ = k; }
+
+protected:
+  void control(float value) override {
+    if (parent_ != nullptr && !property_key_.empty()) {
+      parent_->write_set_int(property_key_, static_cast<int>(value));
+    }
+    this->publish_state(value);
+  }
+
+private:
+  ApplianceBase *parent_ = nullptr;
+  std::string property_key_;
 };
 
 // Text input subclass for the PIN field. esphome::text::Text is abstract

--- a/components/subzero_appliance/hub.cpp
+++ b/components/subzero_appliance/hub.cpp
@@ -650,5 +650,37 @@ void SubzeroHub::write_get_async_(std::uint16_t handle) {
                     cmd.size());
 }
 
+void SubzeroHub::write_set_property_(const std::string &key,
+                                     const std::string &json_value) {
+  if (transport_ == nullptr)
+    return;
+  // `set` requires the control channel to be unlocked. d5_handle_ is
+  // populated after subscribe completes; pin_confirmed_ flips true when
+  // the unlock_channel response lands. Drop the write if either guard
+  // fails — the alternative is queueing, which adds complexity for no
+  // visible UX win (HA will retry on the next user action).
+  if (d5_handle_ == 0 || !pin_confirmed_)
+    return;
+  std::string cmd = esphome::subzero_protocol::build_set(key, json_value);
+  transport_->write(d5_handle_,
+                    reinterpret_cast<const std::uint8_t *>(cmd.data()),
+                    cmd.size());
+}
+
+void SubzeroHub::write_set_bool(const std::string &key, bool value) {
+  write_set_property_(key, value ? "true" : "false");
+}
+
+void SubzeroHub::write_set_int(const std::string &key, int value) {
+  write_set_property_(key, std::to_string(value));
+}
+
+void SubzeroHub::write_set_string(const std::string &key,
+                                  const std::string &value) {
+  write_set_property_(
+      key, "\"" + esphome::subzero_protocol::detail::escape_json_string(value) +
+               "\"");
+}
+
 } // namespace subzero_appliance
 } // namespace esphome

--- a/components/subzero_appliance/hub.h
+++ b/components/subzero_appliance/hub.h
@@ -91,6 +91,16 @@ public:
   // YAML; this method handles all the in-process cleanup.
   void press_reset_pairing();
 
+  // ---- Property writes (HA -> appliance via `set` on D5) ----
+  //
+  // All three forward to write_set_property_(); the type-specific
+  // overloads exist so callers don't have to JSON-format the value
+  // themselves. No-ops when the channel isn't open (d5_handle_ == 0)
+  // or PIN isn't confirmed — same guard as write_unlock_channel_.
+  void write_set_bool(const std::string &key, bool value);
+  void write_set_int(const std::string &key, int value);
+  void write_set_string(const std::string &key, const std::string &value);
+
   // ---- Configuration setters (called once at boot) ----
 
   // The PIN in the HA text input. on_value writes through this.
@@ -182,6 +192,8 @@ private:
   void log_chunked_debug_(const std::string &msg);
   void write_unlock_channel_(std::uint16_t handle);
   void write_get_async_(std::uint16_t handle);
+  void write_set_property_(const std::string &key,
+                           const std::string &json_value);
   void update_handles_from_db_();
 
   // ---- collaborators (non-owning pointers, lifetime owned by caller) ----

--- a/components/subzero_protocol/commands.h
+++ b/components/subzero_protocol/commands.h
@@ -115,8 +115,8 @@ inline std::string build_display_pin(int duration_seconds = 30) {
 // below instead of build_set directly when possible).
 inline std::string build_set(const std::string &key,
                              const std::string &json_value) {
-  return "{\"cmd\":\"set\",\"params\":{\"" +
-         detail::escape_json_string(key) + "\":" + json_value + "}}\n";
+  return "{\"cmd\":\"set\",\"params\":{\"" + detail::escape_json_string(key) +
+         "\":" + json_value + "}}\n";
 }
 
 inline std::string build_set_bool(const std::string &key, bool value) {

--- a/components/subzero_protocol/commands.h
+++ b/components/subzero_protocol/commands.h
@@ -100,5 +100,37 @@ inline std::string build_display_pin(int duration_seconds = 30) {
          std::to_string(duration_seconds) + "}}\n";
 }
 
+// `set` writes a single property on the appliance. Sent on D5 (control
+// channel) — the appliance acks with `{"status":0,"resp":{}}` and within
+// ~1s pushes a `msg_types:2` notification on D6 echoing the new value,
+// which our normal read pipeline picks up.
+//
+// Verified verbs from official-app HCI snoop (2026-04-26): bool fields
+// like `cav_light_on`, integer fields like `kitchen_timer_duration`,
+// string fields like `remote_svc_reg_token` and the WiFi triplet
+// (`ap_ssid`/`ap_pass`/`ap_enc`).
+//
+// `json_value` is the already-formatted JSON literal (no quotes for
+// numbers/bools, quotes + escaping for strings — use the typed helpers
+// below instead of build_set directly when possible).
+inline std::string build_set(const std::string &key,
+                             const std::string &json_value) {
+  return "{\"cmd\":\"set\",\"params\":{\"" +
+         detail::escape_json_string(key) + "\":" + json_value + "}}\n";
+}
+
+inline std::string build_set_bool(const std::string &key, bool value) {
+  return build_set(key, value ? "true" : "false");
+}
+
+inline std::string build_set_int(const std::string &key, int value) {
+  return build_set(key, std::to_string(value));
+}
+
+inline std::string build_set_string(const std::string &key,
+                                    const std::string &value) {
+  return build_set(key, "\"" + detail::escape_json_string(value) + "\"");
+}
+
 } // namespace subzero_protocol
 } // namespace esphome

--- a/components/subzero_protocol/dispatch_esphome.h
+++ b/components/subzero_protocol/dispatch_esphome.h
@@ -35,7 +35,9 @@
 // instantiate dispatch.h's templates with their own recording bus.
 
 #include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/components/number/number.h"
 #include "esphome/components/sensor/sensor.h"
+#include "esphome/components/switch/switch.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 
 namespace esphome {
@@ -53,6 +55,10 @@ template <typename S, typename V> inline void publish_if(S *s, V v) {
 } // namespace detail
 
 // Common (appliance-agnostic) bus. Inherited by every appliance bus.
+//
+// Writable fields per type are exposed as Switch / Number rather than
+// BinarySensor / Sensor. publish_X(bool/float) signatures stay the same
+// since both flavors accept the same value type.
 struct CommonBus {
   esphome::binary_sensor::BinarySensor *sabbath_on = nullptr;
   esphome::binary_sensor::BinarySensor *svc_required = nullptr;
@@ -112,12 +118,16 @@ struct FridgeBus : CommonBus {
   esphome::binary_sensor::BinarySensor *wine_temp_alert = nullptr;
   esphome::binary_sensor::BinarySensor *air_filter_on = nullptr;
 
-  esphome::sensor::Sensor *set_temp = nullptr;
-  esphome::sensor::Sensor *frz_set_temp = nullptr;
-  esphome::sensor::Sensor *ref2_set_temp = nullptr;
-  esphome::sensor::Sensor *wine_set_temp = nullptr;
-  esphome::sensor::Sensor *wine2_set_temp = nullptr;
-  esphome::sensor::Sensor *crisp_set_temp = nullptr;
+  // Set temps are writable via HA — exposed as Numbers, not read-only
+  // Sensors. `set` writes to D5 and the appliance pushes the new value
+  // back, which lands here via publish_set_temp(float) and updates the
+  // Number's state.
+  esphome::number::Number *set_temp = nullptr;
+  esphome::number::Number *frz_set_temp = nullptr;
+  esphome::number::Number *ref2_set_temp = nullptr;
+  esphome::number::Number *wine_set_temp = nullptr;
+  esphome::number::Number *wine2_set_temp = nullptr;
+  esphome::number::Number *crisp_set_temp = nullptr;
   esphome::sensor::Sensor *air_filter_pct = nullptr;
   esphome::sensor::Sensor *water_filter_pct = nullptr;
 
@@ -158,7 +168,7 @@ struct DishwasherBus : CommonBus {
   esphome::binary_sensor::BinarySensor *sani_rinse = nullptr;
   esphome::binary_sensor::BinarySensor *rinse_aid_low = nullptr;
   esphome::binary_sensor::BinarySensor *softener_low = nullptr;
-  esphome::binary_sensor::BinarySensor *light_on = nullptr;
+  esphome::switch_::Switch *light_on = nullptr;
   esphome::binary_sensor::BinarySensor *remote_ready = nullptr;
   esphome::binary_sensor::BinarySensor *delay_start = nullptr;
 
@@ -209,7 +219,7 @@ struct RangeBus : CommonBus {
   esphome::binary_sensor::BinarySensor *door_ajar = nullptr;
   esphome::binary_sensor::BinarySensor *cav_unit_on = nullptr;
   esphome::binary_sensor::BinarySensor *cav_at_set_temp = nullptr;
-  esphome::binary_sensor::BinarySensor *cav_light_on = nullptr;
+  esphome::switch_::Switch *cav_light_on = nullptr;
   esphome::binary_sensor::BinarySensor *cav_remote_ready = nullptr;
   esphome::binary_sensor::BinarySensor *cav_probe_on = nullptr;
   esphome::binary_sensor::BinarySensor *cav_probe_at_temp = nullptr;
@@ -219,11 +229,11 @@ struct RangeBus : CommonBus {
   esphome::binary_sensor::BinarySensor *cook_timer_near = nullptr;
 
   esphome::sensor::Sensor *cav_temp = nullptr;
-  esphome::sensor::Sensor *cav_set_temp = nullptr;
+  esphome::number::Number *cav_set_temp = nullptr; // writable
   esphome::sensor::Sensor *cav_cook_mode = nullptr;
   esphome::sensor::Sensor *cav_gourmet_recipe = nullptr;
   esphome::sensor::Sensor *probe_temp = nullptr;
-  esphome::sensor::Sensor *probe_set_temp = nullptr;
+  esphome::number::Number *probe_set_temp = nullptr; // writable
 
   // Kitchen timers (1 + 2)
   esphome::binary_sensor::BinarySensor *ktimer_active = nullptr;
@@ -239,7 +249,7 @@ struct RangeBus : CommonBus {
   esphome::binary_sensor::BinarySensor *cav2_unit_on = nullptr;
   esphome::binary_sensor::BinarySensor *cav2_door_ajar = nullptr;
   esphome::binary_sensor::BinarySensor *cav2_at_set_temp = nullptr;
-  esphome::binary_sensor::BinarySensor *cav2_light_on = nullptr;
+  esphome::switch_::Switch *cav2_light_on = nullptr;
   esphome::binary_sensor::BinarySensor *cav2_remote_ready = nullptr;
   esphome::binary_sensor::BinarySensor *cav2_probe_on = nullptr;
   esphome::binary_sensor::BinarySensor *cav2_probe_at_temp = nullptr;
@@ -248,10 +258,10 @@ struct RangeBus : CommonBus {
   esphome::binary_sensor::BinarySensor *cav2_cook_timer_done = nullptr;
 
   esphome::sensor::Sensor *cav2_temp = nullptr;
-  esphome::sensor::Sensor *cav2_set_temp = nullptr;
+  esphome::number::Number *cav2_set_temp = nullptr; // writable
   esphome::sensor::Sensor *cav2_cook_mode = nullptr;
   esphome::sensor::Sensor *cav2_probe_temp = nullptr;
-  esphome::sensor::Sensor *cav2_probe_set_temp = nullptr;
+  esphome::number::Number *cav2_probe_set_temp = nullptr; // writable
 
   // Primary cavity publishes
   void publish_door_ajar(bool v) { detail::publish_if(door_ajar, v); }

--- a/components/subzero_protocol/dispatch_esphome.h
+++ b/components/subzero_protocol/dispatch_esphome.h
@@ -118,16 +118,19 @@ struct FridgeBus : CommonBus {
   esphome::binary_sensor::BinarySensor *wine_temp_alert = nullptr;
   esphome::binary_sensor::BinarySensor *air_filter_on = nullptr;
 
-  // Set temps are writable via HA — exposed as Numbers, not read-only
-  // Sensors. `set` writes to D5 and the appliance pushes the new value
-  // back, which lands here via publish_set_temp(float) and updates the
-  // Number's state.
-  esphome::number::Number *set_temp = nullptr;
-  esphome::number::Number *frz_set_temp = nullptr;
-  esphome::number::Number *ref2_set_temp = nullptr;
-  esphome::number::Number *wine_set_temp = nullptr;
-  esphome::number::Number *wine2_set_temp = nullptr;
-  esphome::number::Number *crisp_set_temp = nullptr;
+  // Set-temps are read-only Sensors for now. Writing them via `set`
+  // doesn't appear to work on the fridges we've tested — the appliance
+  // accepts the write (status:0) but the setpoint never actually
+  // changes. Suspect this needs an "edit mode" on the front panel
+  // first, similar to how oven cav_set_temp only accepts writes once
+  // the oven is in an active cook mode. Keep these read-only until
+  // that's understood.
+  esphome::sensor::Sensor *set_temp = nullptr;
+  esphome::sensor::Sensor *frz_set_temp = nullptr;
+  esphome::sensor::Sensor *ref2_set_temp = nullptr;
+  esphome::sensor::Sensor *wine_set_temp = nullptr;
+  esphome::sensor::Sensor *wine2_set_temp = nullptr;
+  esphome::sensor::Sensor *crisp_set_temp = nullptr;
   esphome::sensor::Sensor *air_filter_pct = nullptr;
   esphome::sensor::Sensor *water_filter_pct = nullptr;
 

--- a/components/subzero_protocol/dispatch_esphome.h
+++ b/components/subzero_protocol/dispatch_esphome.h
@@ -171,7 +171,8 @@ struct DishwasherBus : CommonBus {
   esphome::binary_sensor::BinarySensor *sani_rinse = nullptr;
   esphome::binary_sensor::BinarySensor *rinse_aid_low = nullptr;
   esphome::binary_sensor::BinarySensor *softener_low = nullptr;
-  esphome::switch_::Switch *light_on = nullptr;
+  // Read-only: writing `set light_on` doesn't actually toggle the light.
+  esphome::binary_sensor::BinarySensor *light_on = nullptr;
   esphome::binary_sensor::BinarySensor *remote_ready = nullptr;
   esphome::binary_sensor::BinarySensor *delay_start = nullptr;
 

--- a/docs/advanced.adoc
+++ b/docs/advanced.adoc
@@ -115,89 +115,39 @@ If you experience crashes (typically `__cxa_allocate_exception` -> `operator new
 
 . Reducing the number of Home Assistant API connections to the device
 . Setting `ble_client: WARN` in the logger config
-. Lengthening the poll interval (default `60s` in `subzero_base.yaml`) to `120s` or `300s`
+. Lengthening the poll interval (default `60s`, set in the hub) to `120s` or `300s`
 
 [[reconnect-logic]]
 == Reconnect Logic
 
-The integration runs a periodic poll every 60 seconds against each bonded appliance and uses two complementary mechanisms to keep things alive: zombie detection (catches a fully dead link) and a subscribe-retry safety net (catches a half-initialized session where the unlock_channel got dropped).
+The integration runs a periodic poll every 60 seconds against each bonded appliance and keeps things alive with two simple mechanisms: zombie detection (catches a dead link) and stale-bond cleanup (catches an overnight bond timeout).
 
 === Zombie Detection
 
-`poll_ok` is set to `true` by *any* D5 or D4 indication - poll response or push notification. At each poll interval, if `poll_ok` is still `false` from the previous interval, `poll_miss` increments. When `poll_miss` reaches 15 (= 15 minutes of total silence at the 60s interval), the integration calls `client->disconnect()` to force a fresh connection.
+`poll_ok` is set to `true` by any indication on D5 (heartbeat) or D6 (poll response or push notification). Each `periodic_poll` clears `poll_ok` and writes both `unlock_channel` and `get_async` to D6 - either response (~37-byte unlock ack or ~2 KB full state) sets `poll_ok` again. If `poll_ok` is still `false` at the next tick, `poll_miss` increments. When `poll_miss` reaches 3 (~3 minutes of total silence), the integration calls `client->disconnect()` to force a fresh connection - `auto_connect: true` brings it back through `post_bond` + `subscribe` with a fresh full-state poll.
 
-This catches cases where the BLE link has died entirely. It intentionally does *not* try to distinguish "poll silently unanswered" from "appliance is quiet" - past attempts at a tighter signal caused pointless reconnect loops on fw 8.5 appliances whose polls sometimes fail to reassemble (see link:ble-protocol.adoc#_key_protocol_details[ACL Fragment Drops]) while pushes keep flowing.
+This catches both:
 
-=== Subscribe Retry on Stale Unlock or Stuck Boot
+* **Cold-boot race.** When multiple appliances reconnect simultaneously at boot, the ESP-IDF Bluedroid stack occasionally drops one peer's `unlock_channel` write under the concurrent traffic. That appliance ends up subscribed and `get_async`-written at the BLE layer (status 0), but never responds. After 3 missed polls the zombie detector reconnects and the cleaner second-time bonding usually succeeds.
 
-Two distinct conditions land the same appliance in the same state - bonded and connected at the GATT layer, but the command channel goes silent:
-
-1. **Cold-boot race.** When multiple appliances reconnect simultaneously at boot, the ESP-IDF Bluedroid stack occasionally drops one peer's `unlock_channel` write under the concurrent traffic. That appliance ends up subscribed and `get_async`-written at the BLE layer (status 0), but never responds because its session was never unlocked.
-
-2. **fw 8.5 unlock-session expiry.** Sub-Zero fridges and wall ovens running fw 8.5 / API 5.4 silently invalidate the unlock session within ~1 minute (much shorter than the 20-25 minute window observed on other firmware). After that, `get_async` writes on D5 are accepted at the BLE layer but produce no indication response, even though push notifications keep flowing.
-
-`poll_in_flight` is a per-appliance bool, cleared on disconnect, set to `true` whenever a `get_async` is written (in `subscribe` or `periodic_poll`), and cleared only by a valid poll response (`{"status":0,"resp":...}`, parser sets `is_poll=true`). Push notifications do **not** clear it - they prove the connection is alive but don't prove the command channel is responding.
-
-When `periodic_poll` fires and finds `poll_in_flight` still `true` from the previous tick, the previous poll went unanswered. Instead of writing another bare `get_async` into the void, it runs `_subscribe.execute()` - which re-writes CCCDs (idempotent), re-issues `unlock_channel`, and writes `get_async` again. The `unlock_channel` response is small (40 bytes, single fragment, not vulnerable to ACL drops) so it parses cleanly and clears `poll_in_flight`. Next tick takes the bare-poll path again.
-
-`unanswered_polls` is a small int counter that increments each time the subscribe-retry branch fires. It resets to 0 on any valid `is_poll` parse and on disconnect. When it reaches 3 (= 3 minutes of subscribe-retries that produced no poll response - not even an `unlock_channel` reply), the session is wedged at a level even subscribe can't unstick (we never even saw the unlock response come back). At that point the script calls `client->disconnect()` and `auto_connect: true` brings the connection back from scratch. This is intentionally faster than zombie detection (15 min) because zombie won't fire as long as pushes keep flowing.
-
-For the false-positive scenario the prior unlock-expiry detector hit (a push interleaving with a poll on fw 8.5 makes the poll's brace-balance never reach zero, so we never get an `is_poll=true` parse): re-running subscribe is the right response anyway. The unlock response on retry parses cleanly and clears the counter. We only escalate to reconnect if even unlock_channel goes silent - which is the genuinely-stuck case where reconnecting is correct.
-
-The `Log Debug Info` button on each appliance also calls `_subscribe.execute()` for the same reason: a bare `get_async` from the button doesn't work on a stale-unlock fw 8.5 appliance. Going through subscribe refreshes the session first.
+* **fw 8.5 silent-poll behavior.** On Sub-Zero fridges and wall ovens running fw 8.5 / API 5.4, the second-and-later `get_async` writes within a held-open connection go silent - only a full BLE disconnect/reconnect produces a working session again. The official Sub-Zero Android app handles this the same way (verified via HCI snoop). Net effect on fw 8.5: roughly one full state refresh every ~3 min plus continuous push notifications between cycles.
 
 === Boot Stagger via `poll_offset`
 
-`poll_offset` (substitution, default `0s`) is applied at the top of `periodic_poll`, `post_bond`, and `fast_reconnect`. Setting per-appliance values like `0s / 5s / 10s` on a multi-appliance ESP32 spreads the bonding chains in time so the concurrent-bonding race doesn't trigger in the first place. The subscribe-retry path above remains as a safety net.
-
-=== Push-Only Mode for fw 8.5 Appliances
-
-`push_only_after_first_poll` (substitution) controls whether the integration stops polling after the first successful response on each connect, relying on push notifications for live state. Three values:
-
-* `"auto"` *(default)* - decide at runtime from the firmware version reported in the first poll response. If the appliance reports `version.fw == "8.5"` (API 5.4), enable push-only mode for that connection. Otherwise leave it off. Sub-Zero 313 fridges, Wolf SO3050PESP wall ovens, and similar fw 8.5 / API 5.4 appliances are auto-detected and run in push-only mode without any per-appliance config. fw 2.27 / API 5.5 appliances stay on the standard 60s polling cadence.
-* `"true"` - always enable push-only after the first successful poll, regardless of detected firmware. Useful if you want the behavior on a fw 2.27 appliance to minimize BLE airtime.
-* `"false"` - never enable push-only. Use this to override the auto detection on a fw 8.5 appliance where you really want fresh `uptime` and `diagnostic_status` at the cost of the ~4 minute reconnect cycle the recovery ladder produces.
-
-When push-only is active, `periodic_poll` fires exactly once after each (re)connect to land an initial full state (sets `first_poll_done`), then returns early on every subsequent tick - no `get_async` writes, no subscribe-retry ladder. Push notifications carry live state and keep `poll_ok` set in the notify handler so zombie detection stays at zero unless 15 min of total silence happens. Poll-only fields (`appliance_model`, `appliance_serial`, version tree, `uptime`, `diagnostic_status`) refresh only on the next reconnect.
-
-This matches the strategy of the official Sub-Zero Android app (poll briefly, stop polling once async indications flow, rely on pushes thereafter - see link:ble-protocol.adoc#_unlock_session_research_fw_8_5[Unlock Session Research]).
-
-==== Trade-offs
-
-* **fw 8.5 with default `"auto"`**: connection stays up indefinitely if pushes are flowing (door opens, setpoint changes, light toggles, etc.), or until 15 min of total silence triggers zombie reconnect. No 4-min reconnect cycle. `uptime` only updates on reconnects - could be hours if the appliance is busy.
-* **fw 8.5 with `"false"`**: the recovery ladder kicks in (subscribe-retry × 3 → forced reconnect after 3 unanswered polls), so reconnects fire roughly every 4 minutes regardless of activity. `uptime` and `diagnostic_status` refresh on every cycle.
-* **fw 2.27 with default `"auto"`**: stays on the bare-poll fast path forever, just like before. Polls land every 60s, all sensors refresh every cycle.
-
-For fridge configurations using `poll_via_d4: "true"`, push-only is mostly moot since D4 polls don't need an unlock at all and never fail with the unlock-expiry symptom.
-
-Per-appliance override in your entry-point YAML:
-
-[source,yaml]
-----
-packages:
-  main_fridge: !include
-    file: subzero_fridge.yaml
-    vars:
-      prefix: "szg"
-      appliance_name: "Main Fridge"
-      appliance_mac: !secret main_fridge_mac
-      appliance_pin: !secret main_fridge_pin
-      push_only_after_first_poll: "false"   # override auto, keep polling
-----
+`poll_offset` (config field per appliance, default `0s`) is applied at the top of `periodic_poll`, `post_bond`, and `fast_reconnect`. Setting per-appliance values like `0s / 5s / 10s` on a multi-appliance ESP32 spreads the bonding chains in time so the concurrent-bonding race doesn't trigger in the first place. Zombie detection remains as a safety net.
 
 === Log Format
 
 [source]
 ----
-[I][szg:XXX]: [Left Dishwasher] Periodic poll (miss=2, retries=0)
-[W][szg:XXX]: [Wall Oven] Previous poll unanswered (1/3) - re-running subscribe to refresh session
-[W][szg:XXX]: [Wall Oven] 3 subscribe retries unanswered - session wedged, forcing reconnect
+[I][szg:XXX]: [Left Dishwasher] Periodic poll D6 (miss=0, retries=0)
+[I][szg:XXX]: [Wall Oven]      Periodic poll D6 (miss=2, retries=0)
+[E][szg:XXX]: [Kitchen Range]  Pairing rejected (status 302). The PIN has likely changed - press 'Start Pairing' on the appliance and enter the new PIN in HA.
 ----
 
-* `miss` - zombie counter (0-15, reconnect at 15 = 15 min of total silence)
-* `retries` - fast-reconnect retry counter (0-3, bond clear at 3; see below)
-* `Previous poll unanswered (N/3)` - subscribe-retry path firing (poll_in_flight stayed `true` across a tick); on fw 8.5 appliances this is normal once per ~minute as the unlock session refreshes
-* `subscribe retries unanswered - session wedged` - escalation to reconnect after 3 subscribe-retries with no poll response
+* `miss` - zombie counter (0–3, reconnect at 3 = ~3 min of total silence)
+* `retries` - fast-reconnect retry counter (0–3, bond clear at 3; see below)
+* `Pairing rejected (status 302)` - the appliance refused `unlock_channel`, usually because its PIN rotated after a power cycle. Press *Start Pairing* and re-enter the PIN displayed on the appliance.
 
 === Fast Reconnect + Bond Clear
 
@@ -205,9 +155,9 @@ Separately, when the BLE connection drops and `auto_connect: true` reconnects, t
 
 === Tuning
 
-* `interval: 60s` in `subzero_base.yaml` - poll cadence. Shortening to 30s halves detection time and doubles radio utilization (still single-digit percent for typical configs).
-* `poll_miss >= 15` - zombie threshold. Scales with the interval: at 60s that's 15 min.
-* `poll_offset` substitution per-appliance - boot stagger. `0s` for first, `5s` or `10s` for subsequent appliances on the same ESP32.
+* `interval: 60s` in the hub - poll cadence. Shortening to 30s halves detection time and doubles radio utilization (still single-digit percent for typical configs).
+* `poll_miss >= 3` - zombie threshold. Scales with the interval: at 60s that's 3 min.
+* `poll_offset` per appliance - boot stagger. `0s` for first, `5s` or `10s` for subsequent appliances on the same ESP32.
 
 [[parser-component]]
 == Parser Component
@@ -260,69 +210,38 @@ Grep for `Response\[` and concatenate the payloads in order to reassemble the fu
 
 IMPORTANT: Debug-mode payload logging is intentionally gated behind the switch. Normal operation never logs raw BLE bytes, because any non-UTF-8 byte in a log message crashes Home Assistant's protobuf decoder (`LogEntryResponse` requires valid UTF-8) and HA caches the bad event into a restart loop. When debug mode IS on, bytes outside the printable-ASCII range are replaced with `?` as a safety net.
 
-The *Log Debug Info* button is a one-press shortcut: it turns on debug mode and lands a fresh poll. The path it takes depends on detected firmware:
+The *Log Debug Info* button is a one-press shortcut: it turns on debug mode and lands a fresh poll. It always forces a BLE disconnect - `auto_connect: true` brings the connection back via `post_bond` + `subscribe`, which lands a fresh full-state get_async response on D6 in ~10-15 seconds. We use disconnect uniformly because fw 8.5 sessions cannot be refreshed in-place (the official Sub-Zero app does the same), and the extra ~10s wait on fw 2.27 keeps the code path simple.
 
-* **fw 2.27 / API 5.5**: re-runs the subscribe chain (CCCDs + `unlock_channel` + `get_async`) on the existing connection. Debug logs land in ~1.5 seconds.
-* **fw 8.5 / API 5.4**: forces a BLE disconnect. `auto_connect: true` brings the connection back via `post_bond` which naturally runs subscribe with a fresh unlock window. Debug logs land in ~10-15 seconds. Required because the fw 8.5 unlock session expires within ~1 minute and re-issuing `unlock_channel` on the existing connection produces no response (see link:ble-protocol.adoc#_unlock_session_research_fw_8_5[Unlock Session Research]).
+=== Capturing a Full Poll
 
-Either way the user-visible workflow is the same: press the button, wait, grep `Response\[` in the logs.
-
-=== Dishwashers & Ranges
-
-Dishwashers and ranges respond to polls on the D5 (encrypted) channel with their full state - all sensor keys in a single response.
-
-. Press *Log Debug Info* (or turn on *Debug Mode* and press *Poll*).
-. Wait ~1.5s on fw 2.27 or ~10-15s on fw 8.5 for the poll to land.
-. Grep `Response\[` in the ESPHome logs, concatenate the chunks in order to get the full JSON.
-. Turn *Debug Mode* off when done.
-
-=== Refrigerators / Freezers
-
-Fridges have 5 BLE characteristics (D4-D8) instead of 2 (D4-D5):
-
-* *D4* (open channel) - responds to `get_async` with basic diagnostic data (model, doors, uptime), no unlock needed; mirrors D5 push notifications with `msg_types: 8`
-* *D5* (encrypted channel) - responds to `get_async` with the full appliance state after a fresh `unlock_channel`; push notifications continue regardless of session state
-* *D6-D8* - accept writes but do not respond
-
-The *Log Debug Info* button now uses the same path as ranges and dishwashers: subscribe-refresh on fw 2.27 (~1.5s), or force-reconnect on fw 8.5 (~10-15s). Either way you get a full D5 poll response logged as `Response[N/M]:` chunks. To capture the full set of keys including the live state changes:
+The procedure is the same for every appliance type:
 
 . Press *Log Debug Info*.
-. Wait for the `Response[N/M]:` chunks - that's the full poll snapshot.
-. Optionally *interact with the appliance* (open/close doors, change set temp, toggle ice maker) to capture push notifications too. Each change triggers a small push on D5 with just the changed field.
-
-Between the full D5 poll and D5 push notifications, you can map out every key your fridge exposes.
+. Wait ~10-15s for the reconnect cycle to complete and the next D6 poll to land.
+. Grep `Response\[` in the ESPHome logs, concatenate the chunks in order to reassemble the full JSON.
+. Optionally *interact with the appliance* (open/close doors, change set temp, toggle the light) to capture push notifications too. Each change triggers a small push on D6 with just the changed field - useful for confirming a sensor binding is correct.
+. Turn *Debug Mode* off when done.
 
 === Reading the Logs
 
 With debug mode on, the ESPHome log output includes every key in the response:
 
-.Range/Dishwasher (single poll, all keys)
+.Initial poll (full state, all keys)
 [source]
 ----
-[I][szg:087]: [Kitchen Range] Parsing JSON (1700 bytes)
-[I][szg-debug:140]: [Kitchen Range] key=cav_door_ajar
-[I][szg-debug:140]: [Kitchen Range] key=cav_unit_on
-[I][szg-debug:140]: [Kitchen Range] key=cav_temp
-[I][szg-debug:140]: [Kitchen Range] key=cav_set_temp
+[I][szg:###]: [Kitchen Range] Parsing JSON (1700 bytes)
+[I][szg-debug:###]: [Kitchen Range] key=cav_door_ajar
+[I][szg-debug:###]: [Kitchen Range] key=cav_unit_on
+[I][szg-debug:###]: [Kitchen Range] key=cav_temp
+[I][szg-debug:###]: [Kitchen Range] key=cav_set_temp
 ...
 ----
 
-.Fridge (D4 poll - basic info)
+.Push notification (single field, triggered by opening door)
 [source]
 ----
-[I][szg:087]: [Main Fridge] Parsing JSON (403 bytes)
-[I][szg-debug:140]: [Main Fridge] key=diagnostic_status
-[I][szg-debug:140]: [Main Fridge] key=appliance_model
-[I][szg-debug:140]: [Main Fridge] key=ref_door_ajar
-[I][szg-debug:140]: [Main Fridge] key=frz_door_ajar
-[I][szg-debug:140]: [Main Fridge] key=uptime
-----
-
-.Fridge (D5 push - triggered by opening door)
-[source]
-----
-[I][szg:087]: [Main Fridge] Parsing JSON (94 bytes)
-[I][szg-debug:140]: [Main Fridge] key=ref_door_ajar
+[I][szg:###]: [Main Fridge] Parsing JSON (94 bytes)
+[I][szg-debug:###]: [Main Fridge] key=ref_door_ajar
 ----
 
 If you have an appliance type that isn't fully supported, capture the full JSON and open an issue with the output. This helps expand support for new appliance variants.

--- a/docs/ble-protocol.adoc
+++ b/docs/ble-protocol.adoc
@@ -54,10 +54,13 @@ NOTE: We previously misdiagnosed "fw 8.5 unlock session expiry" as the cause of 
 
 === Firmware Versions
 
-| Firmware | API | Models | Indication Fragment Size | CCCD Property |
-|----------|-----|--------|--------------------------|---------------|
-| fw 8.5 | API 5.4 | Sub-Zero 313, Wolf SO3050PESP, DEU2450R | ~40 bytes (fragmented) | INDICATE only (0x2A) |
-| fw 2.27 | API 5.5 | Wolf DF36450GSP, Cove DW2450, Sub-Zero IW30R | ~244 bytes (mostly single-fragment) | NOTIFY + INDICATE (0x3E) |
+[cols="1,1,3,2,2", options="header"]
+|===
+| Firmware | API | Models | Indication Fragment Size | CCCD Property
+
+| fw 8.5 | API 5.4 | Sub-Zero 313, Wolf SO3050PESP, DEU2450R | ~40 bytes (fragmented) | INDICATE only (0x2A)
+| fw 2.27 | API 5.5 | Wolf DF36450GSP, Cove DW2450, Sub-Zero IW30R | ~244 bytes (mostly single-fragment) | NOTIFY + INDICATE (0x3E)
+|===
 
 The fragment size difference matters because fw 8.5 is more sensitive to the ESP-IDF Bluedroid HCI bug (see <<ACL Fragment Drops>> below). The CCCD property difference matters because the official app writes 0x0001 (notifications) on fw 2.27 vs 0x0002 (indications) on fw 8.5. Our integration writes 0x0002 universally - safe on both firmware versions, since fw 2.27 chars also support indications.
 

--- a/tests/cpp/commands_test.cpp
+++ b/tests/cpp/commands_test.cpp
@@ -133,17 +133,15 @@ TEST(Commands, SetIntNegative) {
 TEST(Commands, SetStringEscapesQuotes) {
   // Keep the wire format well-formed even with hostile/odd inputs - same
   // discipline as build_unlock_channel for PINs.
-  EXPECT_EQ(
-      build_set_string("ap_ssid", "my\"ssid"),
-      "{\"cmd\":\"set\",\"params\":{\"ap_ssid\":\"my\\\"ssid\"}}\n");
+  EXPECT_EQ(build_set_string("ap_ssid", "my\"ssid"),
+            "{\"cmd\":\"set\",\"params\":{\"ap_ssid\":\"my\\\"ssid\"}}\n");
 }
 
 TEST(Commands, SetStringEmptyClearsCloudToken) {
   // The "BT-only mode" diagnostic action — clearing remote_svc_reg_token
   // deregisters the appliance from Azure IoT Hub.
-  EXPECT_EQ(
-      build_set_string("remote_svc_reg_token", ""),
-      "{\"cmd\":\"set\",\"params\":{\"remote_svc_reg_token\":\"\"}}\n");
+  EXPECT_EQ(build_set_string("remote_svc_reg_token", ""),
+            "{\"cmd\":\"set\",\"params\":{\"remote_svc_reg_token\":\"\"}}\n");
 }
 
 TEST(Commands, SetGenericAcceptsRawJsonValue) {

--- a/tests/cpp/commands_test.cpp
+++ b/tests/cpp/commands_test.cpp
@@ -6,6 +6,10 @@
 
 using esphome::subzero_protocol::build_display_pin;
 using esphome::subzero_protocol::build_get_async;
+using esphome::subzero_protocol::build_set;
+using esphome::subzero_protocol::build_set_bool;
+using esphome::subzero_protocol::build_set_int;
+using esphome::subzero_protocol::build_set_string;
 using esphome::subzero_protocol::build_unlock_channel;
 
 TEST(Commands, GetAsyncIsExactWireFormat) {
@@ -100,4 +104,65 @@ TEST(Commands, DisplayPinCustomDuration) {
 TEST(Commands, DisplayPinTerminatesWithNewline) {
   EXPECT_EQ(build_display_pin().back(), '\n');
   EXPECT_EQ(build_display_pin(60).back(), '\n');
+}
+
+TEST(Commands, SetBoolTrueAndFalse) {
+  EXPECT_EQ(build_set_bool("cav_light_on", true),
+            "{\"cmd\":\"set\",\"params\":{\"cav_light_on\":true}}\n");
+  EXPECT_EQ(build_set_bool("cav_light_on", false),
+            "{\"cmd\":\"set\",\"params\":{\"cav_light_on\":false}}\n");
+}
+
+TEST(Commands, SetIntPositive) {
+  EXPECT_EQ(build_set_int("set_temp", 38),
+            "{\"cmd\":\"set\",\"params\":{\"set_temp\":38}}\n");
+}
+
+TEST(Commands, SetIntZeroCancelsTimer) {
+  // Setting kitchen_timer_duration:0 cancels a running timer per HCI snoop.
+  EXPECT_EQ(build_set_int("kitchen_timer_duration", 0),
+            "{\"cmd\":\"set\",\"params\":{\"kitchen_timer_duration\":0}}\n");
+}
+
+TEST(Commands, SetIntNegative) {
+  // Freezer set_temp can be negative on Fahrenheit appliances.
+  EXPECT_EQ(build_set_int("frz_set_temp", -5),
+            "{\"cmd\":\"set\",\"params\":{\"frz_set_temp\":-5}}\n");
+}
+
+TEST(Commands, SetStringEscapesQuotes) {
+  // Keep the wire format well-formed even with hostile/odd inputs - same
+  // discipline as build_unlock_channel for PINs.
+  EXPECT_EQ(
+      build_set_string("ap_ssid", "my\"ssid"),
+      "{\"cmd\":\"set\",\"params\":{\"ap_ssid\":\"my\\\"ssid\"}}\n");
+}
+
+TEST(Commands, SetStringEmptyClearsCloudToken) {
+  // The "BT-only mode" diagnostic action — clearing remote_svc_reg_token
+  // deregisters the appliance from Azure IoT Hub.
+  EXPECT_EQ(
+      build_set_string("remote_svc_reg_token", ""),
+      "{\"cmd\":\"set\",\"params\":{\"remote_svc_reg_token\":\"\"}}\n");
+}
+
+TEST(Commands, SetGenericAcceptsRawJsonValue) {
+  // For the rare composite payloads (e.g. WiFi config sends three keys
+  // in one call). Generic build_set passes the value through verbatim.
+  EXPECT_EQ(build_set("foo", "[1,2,3]"),
+            "{\"cmd\":\"set\",\"params\":{\"foo\":[1,2,3]}}\n");
+}
+
+TEST(Commands, SetTerminatesWithNewline) {
+  EXPECT_EQ(build_set_bool("cav_light_on", true).back(), '\n');
+  EXPECT_EQ(build_set_int("set_temp", 38).back(), '\n');
+  EXPECT_EQ(build_set_string("ap_ssid", "iot").back(), '\n');
+}
+
+TEST(Commands, SetEscapesKeyName) {
+  // Defensive: keys come from C++ string literals in our code, so this
+  // shouldn't fire in practice. But if a key name ever did contain a
+  // quote/backslash, JSON-escape it rather than emitting broken wire data.
+  EXPECT_EQ(build_set_int("a\"b", 1),
+            "{\"cmd\":\"set\",\"params\":{\"a\\\"b\":1}}\n");
 }

--- a/tests/cpp/hub_test.cpp
+++ b/tests/cpp/hub_test.cpp
@@ -515,6 +515,65 @@ TEST_F(HubFixture, PinConfirmedFromParse_UpdatesStoredPinAndCallback) {
 // Restart-style timeouts (mode: restart)
 // =============================================================================
 
+// =============================================================================
+// `set` writes (HA -> appliance via D5)
+// =============================================================================
+
+TEST_F(HubFixture, WriteSetBool_GoesToD5WithCorrectJson) {
+  hub_.set_stored_pin("12345");
+  run_to_ready_();
+  transport_.clear_writes();
+  hub_.write_set_bool("cav_light_on", true);
+  ASSERT_EQ(transport_.write_count(), 1u);
+  EXPECT_EQ(transport_.write_at(0).handle, 0x10u); // D5 in our test fixture
+  std::string body(transport_.write_at(0).bytes.begin(),
+                   transport_.write_at(0).bytes.end());
+  EXPECT_EQ(body, "{\"cmd\":\"set\",\"params\":{\"cav_light_on\":true}}\n");
+}
+
+TEST_F(HubFixture, WriteSetInt_FormatsAsBareNumber) {
+  hub_.set_stored_pin("12345");
+  run_to_ready_();
+  transport_.clear_writes();
+  hub_.write_set_int("set_temp", 38);
+  ASSERT_EQ(transport_.write_count(), 1u);
+  std::string body(transport_.write_at(0).bytes.begin(),
+                   transport_.write_at(0).bytes.end());
+  EXPECT_EQ(body, "{\"cmd\":\"set\",\"params\":{\"set_temp\":38}}\n");
+}
+
+TEST_F(HubFixture, WriteSetString_QuotesAndEscapes) {
+  hub_.set_stored_pin("12345");
+  run_to_ready_();
+  transport_.clear_writes();
+  hub_.write_set_string("ap_ssid", "my\"net");
+  ASSERT_EQ(transport_.write_count(), 1u);
+  std::string body(transport_.write_at(0).bytes.begin(),
+                   transport_.write_at(0).bytes.end());
+  EXPECT_EQ(body, "{\"cmd\":\"set\",\"params\":{\"ap_ssid\":\"my\\\"net\"}}\n");
+}
+
+TEST_F(HubFixture, WriteSet_NoOpWhenD5HandleMissing) {
+  // Pre-subscribe state — d5_handle_ stays 0. Writes must not land.
+  hub_.set_stored_pin("12345");
+  // No run_to_ready_() here.
+  transport_.clear_writes();
+  hub_.write_set_bool("cav_light_on", true);
+  hub_.write_set_int("set_temp", 38);
+  hub_.write_set_string("ap_ssid", "iot");
+  EXPECT_EQ(transport_.write_count(), 0u);
+}
+
+TEST_F(HubFixture, WriteSet_NoOpWhenPinNotConfirmed) {
+  // Force pin_confirmed_ false (e.g. after a stale-bond reset).
+  hub_.set_stored_pin("12345");
+  run_to_ready_();
+  hub_.set_pin_confirmed(false);
+  transport_.clear_writes();
+  hub_.write_set_bool("cav_light_on", true);
+  EXPECT_EQ(transport_.write_count(), 0u);
+}
+
 TEST_F(HubFixture, PostBondRestart_CancelsPriorPostBond) {
   // Re-entering handle_connected during an in-flight post_bond should
   // not double-fire stages. The YAML's `mode: restart` semantics are


### PR DESCRIPTION
## Summary

Adds the `set` write verb to the integration so HA users can:

* Toggle the **oven cavity light** (range, primary + dual-oven cav2)
* Adjust the **oven target temperature** (cav, cav2) — *only when the oven is already in a cook mode*
* Adjust the **probe target temperature** (cav, cav2) — *only when the appliance is running with the probe inserted*
* Press a diagnostic **Clear Cloud Token (BT-Only)** button per appliance to deregister the appliance from Azure IoT Hub (forces the official mobile app onto the BLE-only path — useful if you want to fully decouple from the manufacturer cloud)

Wire format and protocol details verified against an HCI snoop of the official Sub-Zero Android app on a Wolf DF36450GSP (fw 2.27), 2026-04-26 (capture in `unused/2.27-dual-fuel-main-kitchen-range-3.zip`).

## Scope

Confirmed-working writable entities (range only) + 1 button per appliance:

| Appliance | Writable Switches | Writable Numbers |
|---|---|---|
| Fridge | _none_ | _none — see "Why no fridge or dishwasher writes" below_ |
| Dishwasher | _none_ | _none_ |
| Range | cav_light_on, cav2_light_on | cav_set_temp, cav2_set_temp, probe_set_temp, cav2_probe_set_temp |

Each writable entity is gated by the same `hide_X` flag as its read counterpart.

## Important constraints (documented in README)

**Oven Set Temperature only adjusts an already-running cycle.** The appliance silently ignores writes to `cav_set_temp` / `cav2_set_temp` when the cavity is off. To use this entity, first start a cook mode (Bake, Roast, etc.) at the appliance's front panel — once the oven is actively heating, HA can adjust the target temperature. Writing from the off state does NOT turn the oven on. Probe Set Temperature behaves the same way (probe must be inserted with appliance running in a probe-aware mode).

**Why no fridge or dishwasher writes?** The appliance acks `set` writes on `set_temp` / `frz_set_temp` / `wine_set_temp` / `wine2_set_temp` / `ref2_set_temp` / `crisp_set_temp` (fridge zones) and `light_on` (dishwasher) with `status:0`, but the actual state never changes. Same kind of appliance-side guard mode as the oven's "must be in a cook mode" requirement, applied more broadly. Until that's understood (and we can warn the user when a write won't take), those entities stay as read-only sensors so a misclick can't risk altering a running zone.

## Architecture

* `commands.h`: `build_set_bool / _int / _string / build_set` with JSON-escape on key + value
* `hub.h/cpp`: `write_set_bool / _int / _string` write to D5 (control channel). Drops silently if `d5_handle_ == 0` or PIN isn't confirmed
* `appliance_base.h`: Two new ESPHome entity subclasses — `ApplianceSetSwitch` (bool) and `ApplianceSetNumber` (int) — that hold a parent + property_key wired in from Python codegen. New `kClearCloudToken` button kind
* `dispatch_esphome.h`: Range-only `Switch*` / `Number*` pointers for the writable bus paths. Same `publish_X(value)` signatures as before so dispatch.h templates and host tests didn't need to change
* `__init__.py`: New `WRITABLE_SWITCHES` / `WRITABLE_NUMBERS` descriptors per appliance type plus codegen helpers. Adds `kClearCloudToken` to BUTTON_DEFINITIONS. AUTO_LOAD picks up `number`

## Doc cleanup (bundled in this PR)

* `README.adoc` Getting Started section rewritten to use the current `subzero_appliance:` native-component schema instead of the v2 `subzero_*.yaml` packages (which no longer exist in the repo at HEAD). New "Writable Entities" + "Clear Cloud Token Diagnostic Button" sections, plus IMPORTANT blocks documenting the oven cook-mode requirement and why fridge/dishwasher writes are read-only. Outdated "20-25 min unlock expiry" troubleshooting row updated to reflect the current 3-min zombie threshold
* `docs/advanced.adoc` Reconnect Logic section rewritten — drops the obsolete subscribe-retry ladder, `push_only_after_first_poll` substitution mode, and "Trade-offs" subsection (all removed in PR #72 / #75). Debug Mode section updated to reflect uniform disconnect behavior on the Log Debug Info button
* `docs/ble-protocol.adoc` Firmware Versions table converted from broken markdown syntax to proper asciidoc

## Style

Whole-tree `clang-format -i` pass on every `.h` / `.cpp` under `components/` and `tests/cpp/`. No `.clang-format` config in the repo, so this picks up the LLVM default. Touches 5 source files with whitespace-only changes.

## Test plan

- [x] All 148 host gtest cases pass (14 new — 9 commands + 5 hub)
- [x] `esphome config` validates locally for fridge / range / dishwasher minimal configs
- [x] `esphome compile --only-generate` produces correct main.cpp:
  - Fridge → only read-only Sensors for set-temps (no Number entities), Clear Cloud Token button
  - Range → 2 ApplianceSetSwitch + 4 ApplianceSetNumber + Clear Cloud Token
  - Dishwasher → only read-only entities (no Switches/Numbers), Clear Cloud Token button
- [ ] Flash and verify HA can toggle the oven light end-to-end
- [ ] Verify oven set-temp adjustment works while oven is in Bake mode (and confirm it does NOT work from the off state)
- [ ] Verify Clear Cloud Token actually deregisters the appliance (official app falls back to error after pressing it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Range oven cavity lights and temperature set/probe targets are now writable from Home Assistant.
  * Added a diagnostic "Clear Cloud Token" button to deregister an appliance from the cloud.

* **Documentation**
  * Revised ESPHome examples and BLE setup (external component usage, per-appliance ble_client, poll_offset).
  * Updated multiple-appliance examples, inline hide_* options, troubleshooting, and writable-entity documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->