### PR TITLE
Home Assistant sub-device per appliance support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -37,6 +37,8 @@ pip install esphome
 
 Create a YAML file (e.g. `subzero.yaml`). The `external_components:` block pulls the native `subzero_appliance` component directly from this GitHub repo at compile time - no cloning required. Each appliance is then declared as a single `subzero_appliance:` entry that creates its full set of sensors, switches, numbers, buttons, and the diagnostic Status text sensor.
 
+Each `subzero_appliance:` entry also auto-creates an ESPHome sub-device using the appliance config `id` with `_device` appended, so entities are grouped per appliance in Home Assistant and the ESPHome web UI without needing a separate manual `esphome.devices:` block.
+
 Pick the appropriate `type:` for your appliance:
 
 [cols="1,1"]
@@ -80,11 +82,14 @@ logger:
     BT_GATTC: WARN
 
 api:
+  encryption:
+    key: !secret encryption_key
   reboot_timeout: 5min
 
 ota:
   - platform: esphome
-
+    password: !secret ota_password
+    
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
@@ -465,19 +470,22 @@ These diagnostic text sensors are exposed under HA's Diagnostic section for ever
 |===
 | Brand | Model | Type | Status
 
-| Sub-Zero | DEU2450R | Under-counter refrigerator | Fully working
-| Sub-Zero | 313 | French-door fridge/freezer with ice maker | Fully working
-| Sub-Zero | PRO3650G | Refrigerator/Freezer | Fully working
 | Cove | DW2450 | Dishwasher | Fully working
-| Cove | DW2450WS | Dishwasher (with water softener) | Fully working
+| Cove | DW2450WS | Dishwasher with water softener | Fully working
+| Sub-Zero | BI36UFDID | Built-in refrigerator/freezer with ice maker | Fully working
+| Sub-Zero | CL44750SID | Refrigerator/freezer with ice maker | Fully working
+| Sub-Zero | CL4850SID | Refrigerator/freezer with ice maker | Fully working
+| Sub-Zero | DEU2450BG | Under-counter beverage center refrigerator | Fully working
+| Sub-Zero | DEU2450R | Under-counter refrigerator | Fully working
+| Sub-Zero | DEU2450WDZ | Under-counter wine storage, dual-zone | Fully working
+| Sub-Zero | IW30R | Wine storage, dual-zone | Fully working
+| Sub-Zero | IT36CIID | Refrigerator/freezer with ice maker | Fully working
+| Sub-Zero | 313 | French-door fridge/freezer with ice maker | Fully working
+| Sub-Zero | 48SID | Refrigerator/freezer with ice maker | Fully working
 | Wolf | DF36450GSP | Dual-fuel range | Fully working
+| Wolf | DF48850SP | Dual-fuel range | Fully working
+| Wolf | IR36550ST | Induction range | Fully working
 | Wolf | SO3050PESP | Wall oven | Fully working
-| Wolf | DO30PM | Double wall oven | Fully working
-| Sub-Zero | IW30R | Wine storage (dual-zone) | Fully working
-| Sub-Zero | IT36CIID | Refrigerator/Freezer with Ice Maker | Fully working
-| Sub-Zero | 48SID | Refrigerator/Freezer with Ice Maker | Fully working
-| Sub-Zero | BI36UFDID | Built-in Refrigerator/Freezer with Ice Maker | Fully working
-| Wolf | IR36550ST | Induction Range | Fully working
 |===
 
 Other Sub-Zero, Wolf, and Cove appliances with BLE should work - they all use the same protocol. If you test with a different model, please open an issue or PR to update this table. See link:docs/advanced.adoc#_debug_mode[Debug Mode] for how to capture your appliance's data.

--- a/components/subzero_appliance/__init__.py
+++ b/components/subzero_appliance/__init__.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import esphome.codegen as cg
 import esphome.config_validation as cv
+import esphome.final_validate as fv
 from esphome import core
 from esphome.components import (
     binary_sensor,
@@ -46,8 +47,11 @@ from esphome.components import (
     text_sensor,
 )
 from esphome.const import (
+    CONF_DEVICE_ID,
     CONF_DEVICE_CLASS,
+    CONF_DEVICES,
     CONF_ENTITY_CATEGORY,
+    CONF_ESPHOME,
     CONF_ICON,
     CONF_ID,
     CONF_INTERNAL,
@@ -65,6 +69,7 @@ from esphome.const import (
     STATE_CLASS_MEASUREMENT,
     UNIT_PERCENT,
 )
+from esphome.core.config import Device
 
 CODEOWNERS = ["@JonGilmore"]
 DEPENDENCIES = ["ble_client"]
@@ -447,6 +452,31 @@ CONFIG_SCHEMA = cv.typed_schema(
 )
 
 
+def _subdevice_id(parent_id: core.ID) -> core.ID:
+    return core.ID(f"{parent_id.id}_device", type=Device)
+
+
+def _final_validate(config):
+    full_conf = fv.full_config.get()
+    esphome_conf = full_conf.setdefault(CONF_ESPHOME, {})
+    devices = esphome_conf.setdefault(CONF_DEVICES, [])
+
+    device_id = _subdevice_id(config[CONF_ID])
+    if not any(dev[CONF_ID].id == device_id.id for dev in devices):
+        devices.append(
+            {
+                CONF_ID: device_id,
+                CONF_NAME: config[CONF_NAME],
+            }
+        )
+        fv.full_config.set(full_conf)
+
+    return config
+
+
+FINAL_VALIDATE_SCHEMA = _final_validate
+
+
 # ----------------------------------------------------------------------
 # Codegen helpers
 # ----------------------------------------------------------------------
@@ -478,6 +508,7 @@ def _build_sensor_config(parent_id, suffix, name_suffix, kwargs, hidden):
     cfg = {
         CONF_ID: _entity_id(parent_id, suffix, sensor.Sensor),
         CONF_NAME: f"{name_suffix}",
+        CONF_DEVICE_ID: _subdevice_id(parent_id),
     }
     cfg.update(kwargs)
     if hidden:
@@ -489,6 +520,7 @@ def _build_binary_sensor_config(parent_id, suffix, name_suffix, kwargs, hidden):
     cfg = {
         CONF_ID: _entity_id(parent_id, suffix, binary_sensor.BinarySensor),
         CONF_NAME: f"{name_suffix}",
+        CONF_DEVICE_ID: _subdevice_id(parent_id),
     }
     cfg.update(kwargs)
     if hidden:
@@ -500,6 +532,7 @@ def _build_text_sensor_config(parent_id, suffix, name_suffix, kwargs, hidden):
     cfg = {
         CONF_ID: _entity_id(parent_id, suffix, text_sensor.TextSensor),
         CONF_NAME: f"{name_suffix}",
+        CONF_DEVICE_ID: _subdevice_id(parent_id),
     }
     cfg.update(kwargs)
     if hidden:
@@ -524,6 +557,7 @@ async def _build_set_switch(parent_id, parent_var, suffix, name_suffix,
     cfg_raw = {
         CONF_ID: _entity_id(parent_id, suffix, ApplianceSetSwitch),
         CONF_NAME: name_suffix,
+        CONF_DEVICE_ID: _subdevice_id(parent_id),
     }
     cfg_raw.update(kwargs)
     if hidden:
@@ -543,6 +577,7 @@ async def _build_set_number(parent_id, parent_var, suffix, name_suffix,
     cfg_raw = {
         CONF_ID: _entity_id(parent_id, suffix, ApplianceSetNumber),
         CONF_NAME: name_suffix,
+        CONF_DEVICE_ID: _subdevice_id(parent_id),
     }
     cfg_raw.update(kwargs)
     if hidden:
@@ -578,6 +613,7 @@ async def to_code(config):
     status_cfg = _validate_text_sensor({
         CONF_ID: _entity_id(parent_id, "status", text_sensor.TextSensor),
         CONF_NAME: f"{name} Status",
+        CONF_DEVICE_ID: _subdevice_id(parent_id),
     })
     status_var = await text_sensor.new_text_sensor(status_cfg)
     cg.add(var.set_status_text_sensor(status_var))
@@ -662,6 +698,7 @@ async def to_code(config):
     pin_cfg_raw = {
         CONF_ID: _entity_id(parent_id, "pin_input", AppliancePinText),
         CONF_NAME: f"{name} PIN",
+        CONF_DEVICE_ID: _subdevice_id(parent_id),
         CONF_ICON: "mdi:key-variant",
         CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_CONFIG,
         # PIN entries are masked in the UI (PASSWORD mode). Sub-Zero PINs
@@ -678,6 +715,7 @@ async def to_code(config):
     debug_sw_cfg_raw = {
         CONF_ID: _entity_id(parent_id, "debug_switch", ApplianceDebugSwitch),
         CONF_NAME: f"{name} Debug Mode",
+        CONF_DEVICE_ID: _subdevice_id(parent_id),
         CONF_ICON: "mdi:bug",
         CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC,
     }
@@ -694,6 +732,7 @@ async def to_code(config):
                 ApplianceButton,
             ),
             CONF_NAME: name_fmt.format(name=name),
+            CONF_DEVICE_ID: _subdevice_id(parent_id),
             CONF_ICON: icon,
         }
         if entity_category is not None:

--- a/secrets-example.yaml
+++ b/secrets-example.yaml
@@ -1,0 +1,7 @@
+# Update the following secrets with your own values.
+wifi_ssid: ""
+wifi_password: ""
+ota_password: ""
+# Generate a random 32-byte encryption key for the API and paste it here or visit https://esphome.io/components/api/ to generate one.
+# This is required if you want to use integrate with Home Assistant.
+encryption_key: ""


### PR DESCRIPTION
- Adding support for per-appliance sub-devices to improve usability in Home Assistant. 
- Updated README.adoc to provide a more secure YAML template with HA API encryption key and OTA password.
- Reformatted the list of tested devices and added additional appliance models I've been able to test.
- Added example secrets.yaml file to make it easier to deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Getting Started guide with security best practices: API encryption and OTA password configuration
  * Updated tested appliances list with additional supported models

* **New Features**
  * Automatic ESPHome sub-device generation from appliance IDs
  * Added example secrets configuration template

<!-- end of auto-generated comment: release notes by coderabbit.ai -->