### PR TITLE
Minor improvements to documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,8 +16,8 @@ Sub-Zero Group (SZG) appliances include a BLE radio that the official _Sub-Zero 
 
 == Requirements
 
-* An *ESP32* board. The https://shop.everythingsmart.io/products/everything-presence-one-kit[Everything Presence One] and https://www.amazon.com/dp/B0DKJ5VXC9[Waveshare POE ESP32] are what I have experience with and seem to work well.
-* *ESPHome 2024.6+* (tested on 2026.3.0)
+* An *ESP32* board. I've had good results with the https://shop.everythingsmart.io/products/everything-presence-one-kit[Everything Presence One] and the https://www.amazon.com/dp/B0DKJ5VXC9[Waveshare POE ESP32]. In general, any ESP32-S3 module should work well and has been tested with up to 5 simultaneous BLE connections. Less capable variants, such as the ESP-C6, support fewer concurrent connections and are typically limited to about three appliances. 
+* *ESPHome 2025.7+* (tested on 2026.3.0)
 * *Python 3.10+* and a working ESPHome installation
 * The *6-digit PIN* from your appliance display (one-time)
 
@@ -245,7 +245,7 @@ You need the 6-digit PIN from your appliance. There are two ways to get it:
 . **From the official app:** Open the _Sub-Zero Group Owner_ app, connect to your appliance, and note the PIN shown during pairing. *You will have to delete the BT pairing from your phone after this to allow the ESP32 to connect.*
 . **From the appliance display:** After the ESP32 connects and bonds, press the "Start Pairing" button in Home Assistant. The PIN will appear on the appliance's physical display for 30 seconds.
 
-TIP: Sub-Zero appliance BLE MAC addresses typically start with `00:06:80`. You can confirm with a Bluetooth scanner app on your phone or use a spare ESP32 to scan for BLE advertisements.
+TIP: Sub-Zero appliance BLE MAC addresses typically begin with `00:06:80`. You can verify this using a Bluetooth scanner app on an Android device (iOS does not expose BLE MAC addresses) or by scanning for BLE advertisements with a spare ESP32. On MacOS. connect to the appliance using a bluetooth scanner, then run `system_profiler SPBluetoothDataType` in a Terminal window to retrieve the BLE MAC Address.
 
 == Troubleshooting
 

--- a/README.adoc
+++ b/README.adoc
@@ -245,7 +245,7 @@ You need the 6-digit PIN from your appliance. There are two ways to get it:
 . **From the official app:** Open the _Sub-Zero Group Owner_ app, connect to your appliance, and note the PIN shown during pairing. *You will have to delete the BT pairing from your phone after this to allow the ESP32 to connect.*
 . **From the appliance display:** After the ESP32 connects and bonds, press the "Start Pairing" button in Home Assistant. The PIN will appear on the appliance's physical display for 30 seconds.
 
-TIP: Sub-Zero appliance BLE MAC addresses typically begin with `00:06:80`. You can verify this using a Bluetooth scanner app on an Android device (iOS does not expose BLE MAC addresses) or by scanning for BLE advertisements with a spare ESP32. On MacOS. connect to the appliance using a bluetooth scanner, then run `system_profiler SPBluetoothDataType` in a Terminal window to retrieve the BLE MAC Address.
+TIP: Sub-Zero appliance BLE MAC addresses typically begin with `00:06:80`. You can verify this using a Bluetooth scanner app on Android (iOS does not expose BLE MAC addresses), or by scanning BLE advertisements with a spare ESP32. On macOS, connect to the appliance with a Bluetooth scanner, then run `system_profiler SPBluetoothDataType` in Terminal to retrieve the BLE MAC address.
 
 == Troubleshooting
 

--- a/secrets-example.yaml
+++ b/secrets-example.yaml
@@ -2,5 +2,5 @@
 wifi_ssid: ""
 wifi_password: ""
 ota_password: ""
-# Generate a random 32-byte encryption key for the API and or visit https://esphome.io/components/api/ to automatically generate one.
+# Generate a random 32-byte API encryption key, or visit https://esphome.io/components/api/ to generate one automatically.
 encryption_key: ""

--- a/secrets-example.yaml
+++ b/secrets-example.yaml
@@ -2,6 +2,5 @@
 wifi_ssid: ""
 wifi_password: ""
 ota_password: ""
-# Generate a random 32-byte encryption key for the API and paste it here or visit https://esphome.io/components/api/ to generate one.
-# This is required if you want to use integrate with Home Assistant.
+# Generate a random 32-byte encryption key for the API and or visit https://esphome.io/components/api/ to automatically generate one.
 encryption_key: ""


### PR DESCRIPTION
**README.adoc**

* Bumped the minimum ESPHome version to **2025.7** (sub-device support for logical entity grouping in Home Assistant was introduced in [[2025.7.0](https://esphome.io/changelog/2025.7.0/)](https://esphome.io/changelog/2025.7.0/))
* Improved ESP32 hardware guidance:
  * Low-cost **ESP32-S3-Mini** tested successfully with up to 5 appliances
  * **ESP32-C6-Zero** tested but only supports up to 3 appliances
* Clarified how to obtain BLE MAC addresses, including additional guidance for iOS and macOS

**secrets-example.yaml**

* Fixed comment grammar related to generating or obtaining a Home Assistant encryption key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ESPHome minimum version requirement
  * Enhanced ESP32 hardware recommendations and BLE connection specifications
  * Improved BLE MAC address pairing instructions with platform-specific guidance for Android, iOS, and macOS
  * Clarified API encryption key setup guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->