### PR TITLE
feat: sync up debug once again, log keys

### DIFF
--- a/components/subzero_appliance/__init__.py
+++ b/components/subzero_appliance/__init__.py
@@ -23,11 +23,10 @@ User YAML shape:
         hide_freezer: true
         hide_ice_maker: true
 
-The component generates ~30 sensors per appliance type, the PIN text
-input, the debug-mode switch, the status text sensor, and seven
-control buttons (Connect / Start Pairing / Submit PIN & Unlock / Poll /
-Log Debug Info / Disconnect / Reset Pairing). Multiple appliances can
-coexist on one ESP — the component is MULTI_CONF.
+The component generates a number of sensors per appliance type, the PIN text
+input, the debug-mode switch, the status text sensor, and
+control buttons. Multiple appliances can coexist on one ESP — the component
+is MULTI_CONF.
 """
 
 from __future__ import annotations
@@ -121,35 +120,102 @@ UNIT_FAHRENHEIT = "°F"
 # Common (appliance-agnostic) — all three types get these.
 COMMON_BINARY_SENSORS = [
     # (suffix, friendly-name suffix, setter, kwargs)
-    ("svc_required", "Service Required", "set_svc_required_sensor",
-     {CONF_DEVICE_CLASS: DEVICE_CLASS_PROBLEM}),
+    (
+        "svc_required",
+        "Service Required",
+        "set_svc_required_sensor",
+        {CONF_DEVICE_CLASS: DEVICE_CLASS_PROBLEM},
+    ),
 ]
 
 COMMON_TEXT_SENSORS = [
-    ("model", "Model", "set_model_sensor",
-     {CONF_ICON: "mdi:devices", CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC}),
-    ("uptime", "Uptime", "set_uptime_sensor",
-     {CONF_ICON: "mdi:timer-outline", CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC}),
-    ("serial", "Appliance Serial", "set_serial_sensor",
-     {CONF_ICON: "mdi:identifier", CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC}),
-    ("appliance_type", "Appliance Type", "set_appliance_type_sensor",
-     {CONF_ICON: "mdi:shape", CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC}),
-    ("diag_status", "Diagnostic Status", "set_diag_status_sensor",
-     {CONF_ICON: "mdi:stethoscope", CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC}),
-    ("fw_version", "Firmware Version", "set_fw_version_sensor",
-     {CONF_ICON: "mdi:chip", CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC}),
-    ("api_version", "API Version", "set_api_version_sensor",
-     {CONF_ICON: "mdi:api", CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC}),
-    ("bleapp_version", "BLE App Version", "set_bleapp_version_sensor",
-     {CONF_ICON: "mdi:bluetooth", CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC}),
-    ("os_version", "OS Version", "set_os_version_sensor",
-     {CONF_ICON: "mdi:memory", CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC}),
-    ("rtapp_version", "RTApp Version", "set_rtapp_version_sensor",
-     {CONF_ICON: "mdi:application-cog", CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC}),
-    ("board_version", "Appliance Board Version", "set_board_version_sensor",
-     {CONF_ICON: "mdi:developer-board", CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC}),
-    ("build_date", "Build Date", "set_build_date_sensor",
-     {CONF_ICON: "mdi:calendar-clock", CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC}),
+    (
+        "model",
+        "Model",
+        "set_model_sensor",
+        {CONF_ICON: "mdi:devices", CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC},
+    ),
+    (
+        "uptime",
+        "Uptime",
+        "set_uptime_sensor",
+        {
+            CONF_ICON: "mdi:timer-outline",
+            CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC,
+        },
+    ),
+    (
+        "serial",
+        "Appliance Serial",
+        "set_serial_sensor",
+        {CONF_ICON: "mdi:identifier", CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC},
+    ),
+    (
+        "appliance_type",
+        "Appliance Type",
+        "set_appliance_type_sensor",
+        {CONF_ICON: "mdi:shape", CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC},
+    ),
+    (
+        "diag_status",
+        "Diagnostic Status",
+        "set_diag_status_sensor",
+        {
+            CONF_ICON: "mdi:stethoscope",
+            CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC,
+        },
+    ),
+    (
+        "fw_version",
+        "Firmware Version",
+        "set_fw_version_sensor",
+        {CONF_ICON: "mdi:chip", CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC},
+    ),
+    (
+        "api_version",
+        "API Version",
+        "set_api_version_sensor",
+        {CONF_ICON: "mdi:api", CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC},
+    ),
+    (
+        "bleapp_version",
+        "BLE App Version",
+        "set_bleapp_version_sensor",
+        {CONF_ICON: "mdi:bluetooth", CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC},
+    ),
+    (
+        "os_version",
+        "OS Version",
+        "set_os_version_sensor",
+        {CONF_ICON: "mdi:memory", CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC},
+    ),
+    (
+        "rtapp_version",
+        "RTApp Version",
+        "set_rtapp_version_sensor",
+        {
+            CONF_ICON: "mdi:application-cog",
+            CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC,
+        },
+    ),
+    (
+        "board_version",
+        "Appliance Board Version",
+        "set_board_version_sensor",
+        {
+            CONF_ICON: "mdi:developer-board",
+            CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC,
+        },
+    ),
+    (
+        "build_date",
+        "Build Date",
+        "set_build_date_sensor",
+        {
+            CONF_ICON: "mdi:calendar-clock",
+            CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC,
+        },
+    ),
 ]
 
 # Buttons — same across all appliance types.
@@ -159,16 +225,30 @@ BUTTON_DEFINITIONS = [
     ("kStartPairing", "{name} Start Pairing", "mdi:key-plus", None),
     ("kSubmitPin", "{name} Submit PIN & Unlock", "mdi:lock-open-variant", None),
     ("kPoll", "Poll {name}", "mdi:refresh", None),
-    ("kLogDebugInfo", "{name} Log Debug Info", "mdi:bug-play", ENTITY_CATEGORY_DIAGNOSTIC),
+    (
+        "kLogDebugInfo",
+        "{name} Log Debug Info",
+        "mdi:bug-play",
+        ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
     ("kDisconnect", "Disconnect {name}", "mdi:bluetooth-off", None),
-    ("kResetPairing", "Reset {name} Pairing", "mdi:bluetooth-settings", ENTITY_CATEGORY_CONFIG),
+    (
+        "kResetPairing",
+        "Reset {name} Pairing",
+        "mdi:bluetooth-settings",
+        ENTITY_CATEGORY_CONFIG,
+    ),
     # Diagnostic: deregister the appliance from Azure IoT Hub by sending
     # `set remote_svc_reg_token=""`. After that, the official app can no
     # longer reach the appliance over cloud — it will fall back to BLE
     # and fight us for the single connection slot. Useful only if you
     # specifically want to disable the cloud path.
-    ("kClearCloudToken", "{name} Clear Cloud Token (BT-Only)",
-     "mdi:cloud-off-outline", ENTITY_CATEGORY_DIAGNOSTIC),
+    (
+        "kClearCloudToken",
+        "{name} Clear Cloud Token (BT-Only)",
+        "mdi:cloud-off-outline",
+        ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
 ]
 
 # Per-type sensor descriptors. Each entry: (suffix, name_suffix, setter, kwargs, hide_key_or_None).
@@ -176,22 +256,62 @@ BUTTON_DEFINITIONS = [
 # user's `hide_X: true|false` config (default true → hidden).
 
 FRIDGE_BINARY_SENSORS = [
-    ("door_ajar", "Door", "set_door_ajar_sensor",
-     {CONF_DEVICE_CLASS: DEVICE_CLASS_DOOR}, None),
-    ("sabbath_on", "Sabbath Mode", "set_sabbath_on_sensor",
-     {CONF_ICON: "mdi:candelabra"}, "hide_sabbath"),
-    ("frz_door_ajar", "Freezer Door", "set_frz_door_ajar_sensor",
-     {CONF_DEVICE_CLASS: DEVICE_CLASS_DOOR}, "hide_freezer"),
-    ("ice_maker", "Ice Maker", "set_ice_maker_sensor",
-     {CONF_ICON: "mdi:ice-cream"}, "hide_ice_maker"),
-    ("ref2_door_ajar", "Refrigerator Drawer Door", "set_ref2_door_ajar_sensor",
-     {CONF_DEVICE_CLASS: DEVICE_CLASS_DOOR}, "hide_ref_drawer"),
-    ("wine_door_ajar", "Wine Door", "set_wine_door_ajar_sensor",
-     {CONF_DEVICE_CLASS: DEVICE_CLASS_DOOR}, "hide_wine"),
-    ("wine_temp_alert", "Wine Temperature Alert", "set_wine_temp_alert_sensor",
-     {CONF_DEVICE_CLASS: DEVICE_CLASS_PROBLEM}, "hide_wine"),
-    ("air_filter_on", "Air Filter", "set_air_filter_on_sensor",
-     {CONF_ICON: "mdi:air-filter"}, "hide_air_filter"),
+    (
+        "door_ajar",
+        "Door",
+        "set_door_ajar_sensor",
+        {CONF_DEVICE_CLASS: DEVICE_CLASS_DOOR},
+        None,
+    ),
+    (
+        "sabbath_on",
+        "Sabbath Mode",
+        "set_sabbath_on_sensor",
+        {CONF_ICON: "mdi:candelabra"},
+        "hide_sabbath",
+    ),
+    (
+        "frz_door_ajar",
+        "Freezer Door",
+        "set_frz_door_ajar_sensor",
+        {CONF_DEVICE_CLASS: DEVICE_CLASS_DOOR},
+        "hide_freezer",
+    ),
+    (
+        "ice_maker",
+        "Ice Maker",
+        "set_ice_maker_sensor",
+        {CONF_ICON: "mdi:ice-cream"},
+        "hide_ice_maker",
+    ),
+    (
+        "ref2_door_ajar",
+        "Refrigerator Drawer Door",
+        "set_ref2_door_ajar_sensor",
+        {CONF_DEVICE_CLASS: DEVICE_CLASS_DOOR},
+        "hide_ref_drawer",
+    ),
+    (
+        "wine_door_ajar",
+        "Wine Door",
+        "set_wine_door_ajar_sensor",
+        {CONF_DEVICE_CLASS: DEVICE_CLASS_DOOR},
+        "hide_wine",
+    ),
+    (
+        "wine_temp_alert",
+        "Wine Temperature Alert",
+        "set_wine_temp_alert_sensor",
+        {CONF_DEVICE_CLASS: DEVICE_CLASS_PROBLEM},
+        "hide_wine",
+    ),
+    (
+        "air_filter_on",
+        "Air Filter",
+        "set_air_filter_on_sensor",
+        {CONF_ICON: "mdi:air-filter"},
+        "hide_air_filter",
+    ),
 ]
 
 TEMP_KWARGS = {
@@ -209,28 +329,72 @@ FRIDGE_SENSORS = [
     # we understand the appliance's set-temp guard mode (suspect: needs
     # some "edit mode" enabled at the front panel first, similar to oven
     # cav_set_temp requiring an active cook mode), keep these read-only.
-    ("set_temp", "Set Temperature", "set_set_temp_sensor",
-     {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer"}, None),
-    ("frz_set_temp", "Freezer Set Temperature", "set_frz_set_temp_sensor",
-     {**TEMP_KWARGS, CONF_ICON: "mdi:snowflake-thermometer"}, "hide_freezer"),
-    ("wine_set_temp", "Wine Zone Upper Set Temperature",
-     "set_wine_set_temp_sensor",
-     {**TEMP_KWARGS, CONF_ICON: "mdi:glass-wine"}, "hide_wine"),
-    ("wine2_set_temp", "Wine Zone Lower Set Temperature",
-     "set_wine2_set_temp_sensor",
-     {**TEMP_KWARGS, CONF_ICON: "mdi:glass-wine"}, "hide_wine"),
-    ("ref2_set_temp", "Refrigerator Drawer Set Temperature",
-     "set_ref2_set_temp_sensor",
-     {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer"}, "hide_ref_drawer"),
-    ("crisp_set_temp", "Crisper Drawer Set Temperature",
-     "set_crisp_set_temp_sensor",
-     {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer"}, "hide_crisper"),
-    ("air_filter_pct", "Air Filter Remaining", "set_air_filter_pct_sensor",
-     {CONF_UNIT_OF_MEASUREMENT: UNIT_PERCENT, "state_class": STATE_CLASS_MEASUREMENT,
-      "accuracy_decimals": 0, CONF_ICON: "mdi:air-filter"}, "hide_air_filter"),
-    ("water_filter_pct", "Water Filter Remaining", "set_water_filter_pct_sensor",
-     {CONF_UNIT_OF_MEASUREMENT: UNIT_PERCENT, "state_class": STATE_CLASS_MEASUREMENT,
-      "accuracy_decimals": 0, CONF_ICON: "mdi:water-percent"}, "hide_water_filter"),
+    (
+        "set_temp",
+        "Set Temperature",
+        "set_set_temp_sensor",
+        {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer"},
+        None,
+    ),
+    (
+        "frz_set_temp",
+        "Freezer Set Temperature",
+        "set_frz_set_temp_sensor",
+        {**TEMP_KWARGS, CONF_ICON: "mdi:snowflake-thermometer"},
+        "hide_freezer",
+    ),
+    (
+        "wine_set_temp",
+        "Wine Zone Upper Set Temperature",
+        "set_wine_set_temp_sensor",
+        {**TEMP_KWARGS, CONF_ICON: "mdi:glass-wine"},
+        "hide_wine",
+    ),
+    (
+        "wine2_set_temp",
+        "Wine Zone Lower Set Temperature",
+        "set_wine2_set_temp_sensor",
+        {**TEMP_KWARGS, CONF_ICON: "mdi:glass-wine"},
+        "hide_wine",
+    ),
+    (
+        "ref2_set_temp",
+        "Refrigerator Drawer Set Temperature",
+        "set_ref2_set_temp_sensor",
+        {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer"},
+        "hide_ref_drawer",
+    ),
+    (
+        "crisp_set_temp",
+        "Crisper Drawer Set Temperature",
+        "set_crisp_set_temp_sensor",
+        {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer"},
+        "hide_crisper",
+    ),
+    (
+        "air_filter_pct",
+        "Air Filter Remaining",
+        "set_air_filter_pct_sensor",
+        {
+            CONF_UNIT_OF_MEASUREMENT: UNIT_PERCENT,
+            "state_class": STATE_CLASS_MEASUREMENT,
+            "accuracy_decimals": 0,
+            CONF_ICON: "mdi:air-filter",
+        },
+        "hide_air_filter",
+    ),
+    (
+        "water_filter_pct",
+        "Water Filter Remaining",
+        "set_water_filter_pct_sensor",
+        {
+            CONF_UNIT_OF_MEASUREMENT: UNIT_PERCENT,
+            "state_class": STATE_CLASS_MEASUREMENT,
+            "accuracy_decimals": 0,
+            CONF_ICON: "mdi:water-percent",
+        },
+        "hide_water_filter",
+    ),
 ]
 
 # Writable numbers — entry shape: (suffix, name_suffix, setter, property_key,
@@ -250,123 +414,378 @@ FRIDGE_WRITABLE_NUMBERS: list = []
 FRIDGE_WRITABLE_SWITCHES: list = []  # sabbath_on writability also unconfirmed
 
 DISHWASHER_BINARY_SENSORS = [
-    ("door_ajar", "Door", "set_door_ajar_sensor", {CONF_DEVICE_CLASS: DEVICE_CLASS_DOOR}, None),
-    ("wash_cycle_on", "Wash Cycle Active", "set_wash_cycle_on_sensor",
-     {CONF_ICON: "mdi:dishwasher"}, None),
-    ("heated_dry", "Heated Dry", "set_heated_dry_sensor", {CONF_ICON: "mdi:heat-wave"}, None),
-    ("extended_dry", "Extended Dry", "set_extended_dry_sensor", {CONF_ICON: "mdi:heat-wave"}, None),
-    ("high_temp_wash", "High Temp Wash", "set_high_temp_wash_sensor",
-     {CONF_ICON: "mdi:thermometer-high"}, None),
-    ("sani_rinse", "Sanitize Rinse", "set_sani_rinse_sensor", {CONF_ICON: "mdi:hand-wash"}, None),
-    ("rinse_aid_low", "Rinse Aid Low", "set_rinse_aid_low_sensor",
-     {CONF_DEVICE_CLASS: DEVICE_CLASS_PROBLEM}, None),
-    ("softener_low", "Softener Low", "set_softener_low_sensor",
-     {CONF_DEVICE_CLASS: DEVICE_CLASS_PROBLEM}, "hide_softener"),
+    (
+        "door_ajar",
+        "Door",
+        "set_door_ajar_sensor",
+        {CONF_DEVICE_CLASS: DEVICE_CLASS_DOOR},
+        None,
+    ),
+    (
+        "wash_cycle_on",
+        "Wash Cycle Active",
+        "set_wash_cycle_on_sensor",
+        {CONF_ICON: "mdi:dishwasher"},
+        None,
+    ),
+    (
+        "heated_dry",
+        "Heated Dry",
+        "set_heated_dry_sensor",
+        {CONF_ICON: "mdi:heat-wave"},
+        None,
+    ),
+    (
+        "extended_dry",
+        "Extended Dry",
+        "set_extended_dry_sensor",
+        {CONF_ICON: "mdi:heat-wave"},
+        None,
+    ),
+    (
+        "high_temp_wash",
+        "High Temp Wash",
+        "set_high_temp_wash_sensor",
+        {CONF_ICON: "mdi:thermometer-high"},
+        None,
+    ),
+    (
+        "sani_rinse",
+        "Sanitize Rinse",
+        "set_sani_rinse_sensor",
+        {CONF_ICON: "mdi:hand-wash"},
+        None,
+    ),
+    (
+        "rinse_aid_low",
+        "Rinse Aid Low",
+        "set_rinse_aid_low_sensor",
+        {CONF_DEVICE_CLASS: DEVICE_CLASS_PROBLEM},
+        None,
+    ),
+    (
+        "softener_low",
+        "Softener Low",
+        "set_softener_low_sensor",
+        {CONF_DEVICE_CLASS: DEVICE_CLASS_PROBLEM},
+        "hide_softener",
+    ),
     # Read-only: writing `set light_on` on dishwashers acks (status:0)
     # but the appliance does not actually toggle the light. Same guard
     # behavior as fridge set-temps — see FRIDGE_SENSORS comment above.
     ("light_on", "Light", "set_light_on_sensor", {CONF_ICON: "mdi:lightbulb"}, None),
-    ("remote_ready", "Remote Ready", "set_remote_ready_sensor", {CONF_ICON: "mdi:remote"}, None),
-    ("delay_start", "Delay Start", "set_delay_start_sensor", {CONF_ICON: "mdi:timer-sand"}, None),
+    (
+        "remote_ready",
+        "Remote Ready",
+        "set_remote_ready_sensor",
+        {CONF_ICON: "mdi:remote"},
+        None,
+    ),
+    (
+        "delay_start",
+        "Delay Start",
+        "set_delay_start_sensor",
+        {CONF_ICON: "mdi:timer-sand"},
+        None,
+    ),
 ]
 
 DISHWASHER_WRITABLE_SWITCHES: list = []
 DISHWASHER_WRITABLE_NUMBERS: list = []
 
 DISHWASHER_SENSORS = [
-    ("wash_status", "Wash Status", "set_wash_status_sensor",
-     {CONF_ICON: "mdi:dishwasher", "accuracy_decimals": 0}, None),
-    ("wash_cycle", "Wash Cycle", "set_wash_cycle_sensor",
-     {CONF_ICON: "mdi:counter", "accuracy_decimals": 0}, None),
-    ("wash_time_remaining", "Wash Time Remaining", "set_wash_time_remaining_sensor",
-     {CONF_ICON: "mdi:timer-sand", CONF_UNIT_OF_MEASUREMENT: "min",
-      "accuracy_decimals": 0, CONF_DEVICE_CLASS: DEVICE_CLASS_DURATION}, None),
+    (
+        "wash_status",
+        "Wash Status",
+        "set_wash_status_sensor",
+        {CONF_ICON: "mdi:dishwasher", "accuracy_decimals": 0},
+        None,
+    ),
+    (
+        "wash_cycle",
+        "Wash Cycle",
+        "set_wash_cycle_sensor",
+        {CONF_ICON: "mdi:counter", "accuracy_decimals": 0},
+        None,
+    ),
+    (
+        "wash_time_remaining",
+        "Wash Time Remaining",
+        "set_wash_time_remaining_sensor",
+        {
+            CONF_ICON: "mdi:timer-sand",
+            CONF_UNIT_OF_MEASUREMENT: "min",
+            "accuracy_decimals": 0,
+            CONF_DEVICE_CLASS: DEVICE_CLASS_DURATION,
+        },
+        None,
+    ),
 ]
 
 DISHWASHER_TEXT_SENSORS = [
-    ("wash_cycle_end_time", "Wash Cycle End Time", "set_wash_cycle_end_time_sensor",
-     {CONF_ICON: "mdi:clock-end"}, None),
+    (
+        "wash_cycle_end_time",
+        "Wash Cycle End Time",
+        "set_wash_cycle_end_time_sensor",
+        {CONF_ICON: "mdi:clock-end"},
+        None,
+    ),
 ]
 
 RANGE_BINARY_SENSORS = [
-    ("door_ajar", "Door", "set_door_ajar_sensor", {CONF_DEVICE_CLASS: DEVICE_CLASS_DOOR}, None),
-    ("sabbath_on", "Sabbath Mode", "set_sabbath_on_sensor", {CONF_ICON: "mdi:candelabra"}, None),
+    (
+        "door_ajar",
+        "Door",
+        "set_door_ajar_sensor",
+        {CONF_DEVICE_CLASS: DEVICE_CLASS_DOOR},
+        None,
+    ),
+    (
+        "sabbath_on",
+        "Sabbath Mode",
+        "set_sabbath_on_sensor",
+        {CONF_ICON: "mdi:candelabra"},
+        None,
+    ),
     ("cav_unit_on", "Oven", "set_cav_unit_on_sensor", {CONF_ICON: "mdi:stove"}, None),
-    ("cav_at_set_temp", "Oven At Temperature", "set_cav_at_set_temp_sensor",
-     {CONF_ICON: "mdi:thermometer-check"}, None),
+    (
+        "cav_at_set_temp",
+        "Oven At Temperature",
+        "set_cav_at_set_temp_sensor",
+        {CONF_ICON: "mdi:thermometer-check"},
+        None,
+    ),
     # cav_light_on moved to RANGE_WRITABLE_SWITCHES.
-    ("cav_remote_ready", "Oven Remote Ready", "set_cav_remote_ready_sensor",
-     {CONF_ICON: "mdi:remote"}, None),
-    ("cav_probe_on", "Probe Inserted", "set_cav_probe_on_sensor",
-     {CONF_ICON: "mdi:thermometer-probe"}, None),
-    ("cav_probe_at_temp", "Probe At Temperature", "set_cav_probe_at_temp_sensor",
-     {CONF_ICON: "mdi:thermometer-probe"}, None),
-    ("cav_probe_near", "Probe Within 10°", "set_cav_probe_near_sensor",
-     {CONF_ICON: "mdi:thermometer-probe"}, None),
-    ("cav_gourmet", "Gourmet Mode", "set_cav_gourmet_sensor", {CONF_ICON: "mdi:chef-hat"}, None),
-    ("cook_timer_done", "Cook Timer Complete", "set_cook_timer_done_sensor",
-     {CONF_ICON: "mdi:timer-alert"}, None),
-    ("cook_timer_near", "Cook Timer Within 1 Min", "set_cook_timer_near_sensor",
-     {CONF_ICON: "mdi:timer-alert-outline"}, None),
-    ("ktimer_active", "Kitchen Timer Active", "set_ktimer_active_sensor",
-     {CONF_ICON: "mdi:timer"}, None),
-    ("ktimer_done", "Kitchen Timer Complete", "set_ktimer_done_sensor",
-     {CONF_ICON: "mdi:timer-alert"}, None),
-    ("ktimer_near", "Kitchen Timer Within 1 Min", "set_ktimer_near_sensor",
-     {CONF_ICON: "mdi:timer-alert-outline"}, None),
-    ("ktimer2_active", "Kitchen Timer 2 Active", "set_ktimer2_active_sensor",
-     {CONF_ICON: "mdi:timer"}, None),
-    ("ktimer2_done", "Kitchen Timer 2 Complete", "set_ktimer2_done_sensor",
-     {CONF_ICON: "mdi:timer-alert"}, None),
-    ("ktimer2_near", "Kitchen Timer 2 Within 1 Min", "set_ktimer2_near_sensor",
-     {CONF_ICON: "mdi:timer-alert-outline"}, None),
+    (
+        "cav_remote_ready",
+        "Oven Remote Ready",
+        "set_cav_remote_ready_sensor",
+        {CONF_ICON: "mdi:remote"},
+        None,
+    ),
+    (
+        "cav_probe_on",
+        "Probe Inserted",
+        "set_cav_probe_on_sensor",
+        {CONF_ICON: "mdi:thermometer-probe"},
+        None,
+    ),
+    (
+        "cav_probe_at_temp",
+        "Probe At Temperature",
+        "set_cav_probe_at_temp_sensor",
+        {CONF_ICON: "mdi:thermometer-probe"},
+        None,
+    ),
+    (
+        "cav_probe_near",
+        "Probe Within 10°",
+        "set_cav_probe_near_sensor",
+        {CONF_ICON: "mdi:thermometer-probe"},
+        None,
+    ),
+    (
+        "cav_gourmet",
+        "Gourmet Mode",
+        "set_cav_gourmet_sensor",
+        {CONF_ICON: "mdi:chef-hat"},
+        None,
+    ),
+    (
+        "cook_timer_done",
+        "Cook Timer Complete",
+        "set_cook_timer_done_sensor",
+        {CONF_ICON: "mdi:timer-alert"},
+        None,
+    ),
+    (
+        "cook_timer_near",
+        "Cook Timer Within 1 Min",
+        "set_cook_timer_near_sensor",
+        {CONF_ICON: "mdi:timer-alert-outline"},
+        None,
+    ),
+    (
+        "ktimer_active",
+        "Kitchen Timer Active",
+        "set_ktimer_active_sensor",
+        {CONF_ICON: "mdi:timer"},
+        None,
+    ),
+    (
+        "ktimer_done",
+        "Kitchen Timer Complete",
+        "set_ktimer_done_sensor",
+        {CONF_ICON: "mdi:timer-alert"},
+        None,
+    ),
+    (
+        "ktimer_near",
+        "Kitchen Timer Within 1 Min",
+        "set_ktimer_near_sensor",
+        {CONF_ICON: "mdi:timer-alert-outline"},
+        None,
+    ),
+    (
+        "ktimer2_active",
+        "Kitchen Timer 2 Active",
+        "set_ktimer2_active_sensor",
+        {CONF_ICON: "mdi:timer"},
+        None,
+    ),
+    (
+        "ktimer2_done",
+        "Kitchen Timer 2 Complete",
+        "set_ktimer2_done_sensor",
+        {CONF_ICON: "mdi:timer-alert"},
+        None,
+    ),
+    (
+        "ktimer2_near",
+        "Kitchen Timer 2 Within 1 Min",
+        "set_ktimer2_near_sensor",
+        {CONF_ICON: "mdi:timer-alert-outline"},
+        None,
+    ),
     # Oven 2 (dual-oven)
-    ("cav2_unit_on", "Oven 2", "set_cav2_unit_on_sensor",
-     {CONF_ICON: "mdi:stove"}, "hide_oven2"),
-    ("cav2_door_ajar", "Oven 2 Door", "set_cav2_door_ajar_sensor",
-     {CONF_DEVICE_CLASS: DEVICE_CLASS_DOOR}, "hide_oven2"),
-    ("cav2_at_set_temp", "Oven 2 At Temperature", "set_cav2_at_set_temp_sensor",
-     {CONF_ICON: "mdi:thermometer-check"}, "hide_oven2"),
+    (
+        "cav2_unit_on",
+        "Oven 2",
+        "set_cav2_unit_on_sensor",
+        {CONF_ICON: "mdi:stove"},
+        "hide_oven2",
+    ),
+    (
+        "cav2_door_ajar",
+        "Oven 2 Door",
+        "set_cav2_door_ajar_sensor",
+        {CONF_DEVICE_CLASS: DEVICE_CLASS_DOOR},
+        "hide_oven2",
+    ),
+    (
+        "cav2_at_set_temp",
+        "Oven 2 At Temperature",
+        "set_cav2_at_set_temp_sensor",
+        {CONF_ICON: "mdi:thermometer-check"},
+        "hide_oven2",
+    ),
     # cav2_light_on moved to RANGE_WRITABLE_SWITCHES.
-    ("cav2_remote_ready", "Oven 2 Remote Ready", "set_cav2_remote_ready_sensor",
-     {CONF_ICON: "mdi:remote"}, "hide_oven2"),
-    ("cav2_probe_on", "Oven 2 Probe Inserted", "set_cav2_probe_on_sensor",
-     {CONF_ICON: "mdi:thermometer-probe"}, "hide_oven2"),
-    ("cav2_probe_at_temp", "Oven 2 Probe At Temperature", "set_cav2_probe_at_temp_sensor",
-     {CONF_ICON: "mdi:thermometer-probe"}, "hide_oven2"),
-    ("cav2_probe_near", "Oven 2 Probe Within 10°", "set_cav2_probe_near_sensor",
-     {CONF_ICON: "mdi:thermometer-probe"}, "hide_oven2"),
-    ("cav2_gourmet", "Oven 2 Gourmet Mode", "set_cav2_gourmet_sensor",
-     {CONF_ICON: "mdi:chef-hat"}, "hide_oven2"),
-    ("cav2_cook_timer_done", "Oven 2 Cook Timer Complete", "set_cav2_cook_timer_done_sensor",
-     {CONF_ICON: "mdi:timer-alert"}, "hide_oven2"),
+    (
+        "cav2_remote_ready",
+        "Oven 2 Remote Ready",
+        "set_cav2_remote_ready_sensor",
+        {CONF_ICON: "mdi:remote"},
+        "hide_oven2",
+    ),
+    (
+        "cav2_probe_on",
+        "Oven 2 Probe Inserted",
+        "set_cav2_probe_on_sensor",
+        {CONF_ICON: "mdi:thermometer-probe"},
+        "hide_oven2",
+    ),
+    (
+        "cav2_probe_at_temp",
+        "Oven 2 Probe At Temperature",
+        "set_cav2_probe_at_temp_sensor",
+        {CONF_ICON: "mdi:thermometer-probe"},
+        "hide_oven2",
+    ),
+    (
+        "cav2_probe_near",
+        "Oven 2 Probe Within 10°",
+        "set_cav2_probe_near_sensor",
+        {CONF_ICON: "mdi:thermometer-probe"},
+        "hide_oven2",
+    ),
+    (
+        "cav2_gourmet",
+        "Oven 2 Gourmet Mode",
+        "set_cav2_gourmet_sensor",
+        {CONF_ICON: "mdi:chef-hat"},
+        "hide_oven2",
+    ),
+    (
+        "cav2_cook_timer_done",
+        "Oven 2 Cook Timer Complete",
+        "set_cav2_cook_timer_done_sensor",
+        {CONF_ICON: "mdi:timer-alert"},
+        "hide_oven2",
+    ),
 ]
 
 RANGE_SENSORS = [
-    ("cav_temp", "Oven Temperature", "set_cav_temp_sensor",
-     {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer"}, None),
+    (
+        "cav_temp",
+        "Oven Temperature",
+        "set_cav_temp_sensor",
+        {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer"},
+        None,
+    ),
     # cav_set_temp / probe_set_temp / cav2_set_temp / cav2_probe_set_temp
     # moved to RANGE_WRITABLE_NUMBERS.
-    ("cav_cook_mode", "Cook Mode", "set_cav_cook_mode_sensor",
-     {CONF_ICON: "mdi:stove", "accuracy_decimals": 0}, None),
-    ("cav_gourmet_recipe", "Gourmet Recipe", "set_cav_gourmet_recipe_sensor",
-     {CONF_ICON: "mdi:chef-hat", "accuracy_decimals": 0}, None),
-    ("probe_temp", "Probe Temperature", "set_probe_temp_sensor",
-     {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer-probe"}, None),
-    ("cav2_temp", "Oven 2 Temperature", "set_cav2_temp_sensor",
-     {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer"}, "hide_oven2"),
-    ("cav2_cook_mode", "Oven 2 Cook Mode", "set_cav2_cook_mode_sensor",
-     {CONF_ICON: "mdi:stove", "accuracy_decimals": 0}, "hide_oven2"),
-    ("cav2_probe_temp", "Oven 2 Probe Temperature", "set_cav2_probe_temp_sensor",
-     {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer-probe"}, "hide_oven2"),
+    (
+        "cav_cook_mode",
+        "Cook Mode",
+        "set_cav_cook_mode_sensor",
+        {CONF_ICON: "mdi:stove", "accuracy_decimals": 0},
+        None,
+    ),
+    (
+        "cav_gourmet_recipe",
+        "Gourmet Recipe",
+        "set_cav_gourmet_recipe_sensor",
+        {CONF_ICON: "mdi:chef-hat", "accuracy_decimals": 0},
+        None,
+    ),
+    (
+        "probe_temp",
+        "Probe Temperature",
+        "set_probe_temp_sensor",
+        {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer-probe"},
+        None,
+    ),
+    (
+        "cav2_temp",
+        "Oven 2 Temperature",
+        "set_cav2_temp_sensor",
+        {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer"},
+        "hide_oven2",
+    ),
+    (
+        "cav2_cook_mode",
+        "Oven 2 Cook Mode",
+        "set_cav2_cook_mode_sensor",
+        {CONF_ICON: "mdi:stove", "accuracy_decimals": 0},
+        "hide_oven2",
+    ),
+    (
+        "cav2_probe_temp",
+        "Oven 2 Probe Temperature",
+        "set_cav2_probe_temp_sensor",
+        {**TEMP_KWARGS, CONF_ICON: "mdi:thermometer-probe"},
+        "hide_oven2",
+    ),
 ]
 
 RANGE_WRITABLE_SWITCHES = [
     # (suffix, name_suffix, setter, property_key, kwargs, hide_key)
-    ("cav_light_on", "Oven Light", "set_cav_light_on_switch", "cav_light_on",
-     {CONF_ICON: "mdi:lightbulb"}, None),
-    ("cav2_light_on", "Oven 2 Light", "set_cav2_light_on_switch", "cav2_light_on",
-     {CONF_ICON: "mdi:lightbulb"}, "hide_oven2"),
+    (
+        "cav_light_on",
+        "Oven Light",
+        "set_cav_light_on_switch",
+        "cav_light_on",
+        {CONF_ICON: "mdi:lightbulb"},
+        None,
+    ),
+    (
+        "cav2_light_on",
+        "Oven 2 Light",
+        "set_cav2_light_on_switch",
+        "cav2_light_on",
+        {CONF_ICON: "mdi:lightbulb"},
+        "hide_oven2",
+    ),
 ]
 
 # Wolf ovens (both wall and range cavities) won't accept a target below
@@ -377,25 +796,67 @@ RANGE_WRITABLE_SWITCHES = [
 # value the appliance accepts; the front panel typically rounds to 5°.
 RANGE_WRITABLE_NUMBERS = [
     # (suffix, name_suffix, setter, property_key, min, max, step, kwargs, hide_key)
-    ("cav_set_temp", "Oven Set Temperature", "set_cav_set_temp_number",
-     "cav_set_temp", 200, 550, 1,
-     {**NUMBER_KWARGS, CONF_ICON: "mdi:thermometer-check"}, None),
-    ("probe_set_temp", "Probe Set Temperature", "set_probe_set_temp_number",
-     "cav_probe_set_temp", 100, 200, 1,
-     {**NUMBER_KWARGS, CONF_ICON: "mdi:thermometer-probe"}, None),
-    ("cav2_set_temp", "Oven 2 Set Temperature", "set_cav2_set_temp_number",
-     "cav2_set_temp", 200, 550, 1,
-     {**NUMBER_KWARGS, CONF_ICON: "mdi:thermometer-check"}, "hide_oven2"),
-    ("cav2_probe_set_temp", "Oven 2 Probe Set Temperature",
-     "set_cav2_probe_set_temp_number", "cav2_probe_set_temp", 100, 200, 1,
-     {**NUMBER_KWARGS, CONF_ICON: "mdi:thermometer-probe"}, "hide_oven2"),
+    (
+        "cav_set_temp",
+        "Oven Set Temperature",
+        "set_cav_set_temp_number",
+        "cav_set_temp",
+        200,
+        550,
+        1,
+        {**NUMBER_KWARGS, CONF_ICON: "mdi:thermometer-check"},
+        None,
+    ),
+    (
+        "probe_set_temp",
+        "Probe Set Temperature",
+        "set_probe_set_temp_number",
+        "cav_probe_set_temp",
+        100,
+        200,
+        1,
+        {**NUMBER_KWARGS, CONF_ICON: "mdi:thermometer-probe"},
+        None,
+    ),
+    (
+        "cav2_set_temp",
+        "Oven 2 Set Temperature",
+        "set_cav2_set_temp_number",
+        "cav2_set_temp",
+        200,
+        550,
+        1,
+        {**NUMBER_KWARGS, CONF_ICON: "mdi:thermometer-check"},
+        "hide_oven2",
+    ),
+    (
+        "cav2_probe_set_temp",
+        "Oven 2 Probe Set Temperature",
+        "set_cav2_probe_set_temp_number",
+        "cav2_probe_set_temp",
+        100,
+        200,
+        1,
+        {**NUMBER_KWARGS, CONF_ICON: "mdi:thermometer-probe"},
+        "hide_oven2",
+    ),
 ]
 
 RANGE_TEXT_SENSORS = [
-    ("ktimer_end_time", "Kitchen Timer End Time", "set_ktimer_end_time_sensor",
-     {CONF_ICON: "mdi:clock-end"}, None),
-    ("ktimer2_end_time", "Kitchen Timer 2 End Time", "set_ktimer2_end_time_sensor",
-     {CONF_ICON: "mdi:clock-end"}, None),
+    (
+        "ktimer_end_time",
+        "Kitchen Timer End Time",
+        "set_ktimer_end_time_sensor",
+        {CONF_ICON: "mdi:clock-end"},
+        None,
+    ),
+    (
+        "ktimer2_end_time",
+        "Kitchen Timer 2 End Time",
+        "set_ktimer2_end_time_sensor",
+        {CONF_ICON: "mdi:clock-end"},
+        None,
+    ),
 ]
 
 # ----------------------------------------------------------------------
@@ -434,20 +895,18 @@ def _schema_for_type(type_: str) -> cv.Schema:
         cv.GenerateID(): cv.declare_id(TYPE_TO_CLASS[type_]),
         cv.Required(CONF_NAME): cv.string,
         cv.Required(CONF_PIN): cv.string,
-        cv.Optional(CONF_POLL_OFFSET, default="0s"): cv.positive_time_period_milliseconds,
+        cv.Optional(
+            CONF_POLL_OFFSET, default="0s"
+        ): cv.positive_time_period_milliseconds,
     }
     base.update(TYPE_SCHEMAS[type_])
     return (
-        cv.Schema(base)
-        .extend(ble_client.BLE_CLIENT_SCHEMA)
-        .extend(cv.COMPONENT_SCHEMA)
+        cv.Schema(base).extend(ble_client.BLE_CLIENT_SCHEMA).extend(cv.COMPONENT_SCHEMA)
     )
 
 
 CONFIG_SCHEMA = cv.typed_schema(
-    {
-        type_: _schema_for_type(type_) for type_ in TYPE_TO_CLASS
-    },
+    {type_: _schema_for_type(type_) for type_ in TYPE_TO_CLASS},
     key=CONF_TYPE,
 )
 
@@ -491,6 +950,7 @@ def _entity_id(parent_id: core.ID, suffix: str, type_: type) -> core.ID:
 # `disabled_by_default`, `internal`, `id` are present). Hand-built dicts
 # crash. We construct minimal dicts and run them through the schema to
 # get a complete, validated config.
+
 
 def _validate_sensor(cfg):
     return sensor.sensor_schema()(cfg)
@@ -548,8 +1008,9 @@ def _resolve_hidden(config, hide_key):
     return bool(config.get(hide_key, False))
 
 
-async def _build_set_switch(parent_id, parent_var, suffix, name_suffix,
-                            property_key, kwargs, hidden):
+async def _build_set_switch(
+    parent_id, parent_var, suffix, name_suffix, property_key, kwargs, hidden
+):
     """Instantiates an ApplianceSetSwitch HA entity, wires the parent +
     property_key, and registers it. Caller binds the bus pointer via the
     setter on `parent_var` (e.g. `parent_var.set_cav_light_on_switch(s)`).
@@ -569,9 +1030,18 @@ async def _build_set_switch(parent_id, parent_var, suffix, name_suffix,
     return sw
 
 
-async def _build_set_number(parent_id, parent_var, suffix, name_suffix,
-                            property_key, min_value, max_value, step,
-                            kwargs, hidden):
+async def _build_set_number(
+    parent_id,
+    parent_var,
+    suffix,
+    name_suffix,
+    property_key,
+    min_value,
+    max_value,
+    step,
+    kwargs,
+    hidden,
+):
     """Instantiates an ApplianceSetNumber HA entity, wires the parent +
     property_key, and registers it with min/max/step traits."""
     cfg_raw = {
@@ -584,7 +1054,10 @@ async def _build_set_number(parent_id, parent_var, suffix, name_suffix,
         cfg_raw[CONF_INTERNAL] = True
     cfg = number.number_schema(ApplianceSetNumber)(cfg_raw)
     n = await number.new_number(
-        cfg, min_value=min_value, max_value=max_value, step=step,
+        cfg,
+        min_value=min_value,
+        max_value=max_value,
+        step=step,
     )
     cg.add(n.set_parent(parent_var))
     cg.add(n.set_property_key(property_key))
@@ -610,23 +1083,29 @@ async def to_code(config):
     cg.add(var.set_poll_offset_ms(config[CONF_POLL_OFFSET]))
 
     # ---- Status text sensor ----
-    status_cfg = _validate_text_sensor({
-        CONF_ID: _entity_id(parent_id, "status", text_sensor.TextSensor),
-        CONF_NAME: f"{name} Status",
-        CONF_DEVICE_ID: _subdevice_id(parent_id),
-    })
+    status_cfg = _validate_text_sensor(
+        {
+            CONF_ID: _entity_id(parent_id, "status", text_sensor.TextSensor),
+            CONF_NAME: f"{name} Status",
+            CONF_DEVICE_ID: _subdevice_id(parent_id),
+        }
+    )
     status_var = await text_sensor.new_text_sensor(status_cfg)
     cg.add(var.set_status_text_sensor(status_var))
 
     # ---- Common binary sensors ----
     for suffix, name_suffix, setter, kwargs in COMMON_BINARY_SENSORS:
-        cfg = _build_binary_sensor_config(parent_id, suffix, f"{name} {name_suffix}", kwargs, False)
+        cfg = _build_binary_sensor_config(
+            parent_id, suffix, f"{name} {name_suffix}", kwargs, False
+        )
         bs = await binary_sensor.new_binary_sensor(cfg)
         cg.add(getattr(var, setter)(bs))
 
     # ---- Common text sensors ----
     for suffix, name_suffix, setter, kwargs in COMMON_TEXT_SENSORS:
-        cfg = _build_text_sensor_config(parent_id, suffix, f"{name} {name_suffix}", kwargs, False)
+        cfg = _build_text_sensor_config(
+            parent_id, suffix, f"{name} {name_suffix}", kwargs, False
+        )
         ts = await text_sensor.new_text_sensor(cfg)
         cg.add(getattr(var, setter)(ts))
 
@@ -652,7 +1131,10 @@ async def to_code(config):
 
     for suffix, name_suffix, setter, kwargs, hide_key in bs_list:
         cfg = _build_binary_sensor_config(
-            parent_id, suffix, f"{name} {name_suffix}", kwargs,
+            parent_id,
+            suffix,
+            f"{name} {name_suffix}",
+            kwargs,
             _resolve_hidden(config, hide_key),
         )
         bs = await binary_sensor.new_binary_sensor(cfg)
@@ -660,7 +1142,10 @@ async def to_code(config):
 
     for suffix, name_suffix, setter, kwargs, hide_key in s_list:
         cfg = _build_sensor_config(
-            parent_id, suffix, f"{name} {name_suffix}", kwargs,
+            parent_id,
+            suffix,
+            f"{name} {name_suffix}",
+            kwargs,
             _resolve_hidden(config, hide_key),
         )
         s = await sensor.new_sensor(cfg)
@@ -668,7 +1153,10 @@ async def to_code(config):
 
     for suffix, name_suffix, setter, kwargs, hide_key in ts_list:
         cfg = _build_text_sensor_config(
-            parent_id, suffix, f"{name} {name_suffix}", kwargs,
+            parent_id,
+            suffix,
+            f"{name} {name_suffix}",
+            kwargs,
             _resolve_hidden(config, hide_key),
         )
         ts = await text_sensor.new_text_sensor(cfg)
@@ -677,17 +1165,29 @@ async def to_code(config):
     # Writable switches — HA-toggled booleans that send `set` on D5.
     for suffix, name_suffix, setter, prop_key, kwargs, hide_key in sw_list:
         sw = await _build_set_switch(
-            parent_id, var, suffix, f"{name} {name_suffix}", prop_key, kwargs,
+            parent_id,
+            var,
+            suffix,
+            f"{name} {name_suffix}",
+            prop_key,
+            kwargs,
             _resolve_hidden(config, hide_key),
         )
         cg.add(getattr(var, setter)(sw))
 
     # Writable numbers — HA-set numerics (set temps, etc.) that send `set`.
-    for (suffix, name_suffix, setter, prop_key, mn, mx, step,
-         kwargs, hide_key) in n_list:
+    for suffix, name_suffix, setter, prop_key, mn, mx, step, kwargs, hide_key in n_list:
         n = await _build_set_number(
-            parent_id, var, suffix, f"{name} {name_suffix}", prop_key,
-            mn, mx, step, kwargs, _resolve_hidden(config, hide_key),
+            parent_id,
+            var,
+            suffix,
+            f"{name} {name_suffix}",
+            prop_key,
+            mn,
+            mx,
+            step,
+            kwargs,
+            _resolve_hidden(config, hide_key),
         )
         cg.add(getattr(var, setter)(n))
 
@@ -722,6 +1222,7 @@ async def to_code(config):
     debug_sw_cfg = switch.switch_schema(ApplianceDebugSwitch)(debug_sw_cfg_raw)
     debug_sw = await switch.new_switch(debug_sw_cfg)
     cg.add(debug_sw.set_parent(var))
+    cg.add(var.set_debug_switch(debug_sw))
 
     # ---- Buttons ----
     for kind_name, name_fmt, icon, entity_category in BUTTON_DEFINITIONS:

--- a/components/subzero_appliance/appliance_base.cpp
+++ b/components/subzero_appliance/appliance_base.cpp
@@ -11,15 +11,11 @@ namespace subzero_appliance {
 static const char *const TAG = "subzero_appliance";
 
 void ApplianceBase::setup() {
-  // Wire the transport + scheduler to ESPHome's runtime.
   transport_.set_client(this->parent());
   scheduler_.set_component(this);
 
-  // Wire up the (typed) bus on the hub. Subclass overrides this to call
-  // `hub_.set_bus(&typed_bus_)`.
   wire_bus_();
 
-  // Configure the hub
   auto *h = hub();
   h->set_transport(&transport_);
   h->set_scheduler(&scheduler_);
@@ -30,29 +26,18 @@ void ApplianceBase::setup() {
     h->set_pin_confirmed(true);
   }
 
-  // Status callback → publish to the status text sensor (if wired).
   if (status_ts_ != nullptr) {
     auto *ts = status_ts_;
     h->set_status_callback(
         [ts](const std::string &text) { ts->publish_state(text); });
   }
 
-  // PIN-confirmation callback → update the HA text input + persist
-  // through the hub's stored_pin.
   if (pin_input_ != nullptr) {
     auto *pi = pin_input_;
     h->set_pin_input_callback(
         [pi](const std::string &pin) { pi->publish_state(pin); });
   }
 
-  // Subscribe-stage hook is intentionally NOT wired here. Phase 3's
-  // subscribe_callback existed to inject discovered handles into the
-  // ESPHome `ble_client::sensor` notify objects. In Phase 4 we don't
-  // create those sensors at all — gattc_event_handler routes raw
-  // ESP_GATTC_NOTIFY_EVT events directly to hub_.handle_d{5,6}_notify
-  // by handle, so the ESPHome sensor's stale handle is irrelevant.
-
-  // Periodic poll every 60s. set_interval is provided by Component.
   this->set_interval("subzero_periodic_poll", 60000,
                      [this]() { hub()->do_periodic_poll(); });
 
@@ -61,8 +46,6 @@ void ApplianceBase::setup() {
 }
 
 float ApplianceBase::get_setup_priority() const {
-  // After ble_client (which is AFTER_BLUETOOTH = 700) — we depend on
-  // the parent BLE client being ready for transport_.set_client().
   return esphome::setup_priority::AFTER_BLUETOOTH - 1.0f;
 }
 
@@ -72,13 +55,6 @@ void ApplianceBase::gattc_event_handler(esp_gattc_cb_event_t event,
   auto *h = hub();
   switch (event) {
   case ESP_GATTC_OPEN_EVT:
-    // Route OPEN-with-error to the hub's disconnect handler (cancels any
-    // pending discovery timeouts; idempotent for a not-yet-connected
-    // state). On OPEN-success we do NOT call handle_connected yet — the
-    // GATT cache isn't populated until SEARCH_CMPL fires, and our
-    // subscribe ladder needs handles+descriptors visible to bluedroid
-    // (otherwise register_for_notify and CCCD writes silently no-op,
-    // leaving the appliance unsubscribed and no data ever flows)
     if (param->open.status != ESP_GATT_OK) {
       ESP_LOGW(TAG, "[%s] GATT open failed (status=%d)", name_str_.c_str(),
                static_cast<int>(param->open.status));
@@ -86,11 +62,6 @@ void ApplianceBase::gattc_event_handler(esp_gattc_cb_event_t event,
     }
     break;
   case ESP_GATTC_SEARCH_CMPL_EVT:
-    // bluedroid GATT db is populated, safe to discover handles, register
-    // for notify & write CCCDs — but only if the search itself succeeded.
-    // A failed search means the GATT db is empty/stale; routing to
-    // handle_connected() would publish "Connected, discovering..." and
-    // start the post-bond ladder against handles that don't exist.
     if (param->search_cmpl.status != ESP_GATT_OK) {
       ESP_LOGW(TAG, "[%s] GATT search failed (status=%d)", name_str_.c_str(),
                static_cast<int>(param->search_cmpl.status));
@@ -103,12 +74,6 @@ void ApplianceBase::gattc_event_handler(esp_gattc_cb_event_t event,
     h->handle_disconnected();
     break;
   case ESP_GATTC_NOTIFY_EVT: {
-    // Route notification to D5 or D6 handler based on which handle
-    // it arrived on. The hub keeps these handles internally. Defensive
-    // guard: a stray notify with handle 0 (or any case where the hub
-    // hasn't discovered D5/D6 yet, so its handles are still 0) must
-    // NOT match — without this, `param->notify.handle == h->d5_handle()`
-    // succeeds at 0 == 0 and we'd dispatch garbage as a D5 heartbeat.
     std::uint16_t nh = param->notify.handle;
     std::uint16_t d5 = h->d5_handle();
     std::uint16_t d6 = h->d6_handle();
@@ -129,8 +94,6 @@ void ApplianceBase::gattc_event_handler(esp_gattc_cb_event_t event,
 void ApplianceBase::gap_event_handler(esp_gap_ble_cb_event_t event,
                                       esp_ble_gap_cb_param_t *param) {
   if (event == ESP_GAP_BLE_PASSKEY_REQ_EVT) {
-    // Match the address; the same callback fires for every BLE client
-    // on the bus, so confirm this one is for our parent before responding.
     if (this->parent() == nullptr)
       return;
     if (std::memcmp(param->ble_security.ble_req.bd_addr,
@@ -143,13 +106,6 @@ void ApplianceBase::gap_event_handler(esp_gap_ble_cb_event_t event,
 }
 
 void ApplianceBase::press_connect() {
-  // Reset hub state FIRST (clears phase_ to 0, zeros handles, drops
-  // pending timeouts), then ask the transport to (re)dial. The order
-  // matters: if we called transport_.connect() first and the BLEClient
-  // happened to be already-connected (e.g. user double-pressed Connect),
-  // BLEClient::connect() short-circuits via internal duplicate-detection
-  // and we'd end up with stale handles in the hub. Reset-then-connect
-  // ensures the next on_connect callback enters the cold-discovery path.
   hub()->press_connect();
   transport_.connect();
 }
@@ -157,9 +113,6 @@ void ApplianceBase::press_connect() {
 void ApplianceBase::press_disconnect() { transport_.disconnect(); }
 
 void ApplianceBase::press_log_debug_info() {
-  // Sync the HA Debug Mode switch state BEFORE forwarding to the hub —
-  // the hub's press_log_debug_info() immediately disconnects, so any
-  // post-disconnect publish would race with the BLE teardown.
   if (debug_switch_ != nullptr) {
     debug_switch_->publish_state(true);
   }
@@ -169,9 +122,6 @@ void ApplianceBase::press_log_debug_info() {
 void ApplianceBase::press_reset_pairing() {
   hub()->press_reset_pairing();
   transport_.disconnect();
-  // remove_bond was already called by hub.press_reset_pairing via
-  // transport_.remove_bond(); the YAML's old `ble_client.remove_bond:`
-  // action did the same thing. No additional 1s-delayed action needed.
 }
 
 } // namespace subzero_appliance

--- a/components/subzero_appliance/appliance_base.cpp
+++ b/components/subzero_appliance/appliance_base.cpp
@@ -72,18 +72,23 @@ void ApplianceBase::gattc_event_handler(esp_gattc_cb_event_t event,
   auto *h = hub();
   switch (event) {
   case ESP_GATTC_OPEN_EVT:
-    if (param->open.status == ESP_GATT_OK) {
-      h->handle_connected();
-    } else {
-      // Failed open — log it and route to the hub's disconnect handler
-      // so any pending discovery timeouts get cancelled. handle_disconnected
-      // is idempotent for a not-yet-connected state (clears handles + flags
-      // we never set), so calling it here is safe even when the previous
-      // state was already disconnected.
+    // Route OPEN-with-error to the hub's disconnect handler (cancels any
+    // pending discovery timeouts; idempotent for a not-yet-connected
+    // state). On OPEN-success we do NOT call handle_connected yet — the
+    // GATT cache isn't populated until SEARCH_CMPL fires, and our
+    // subscribe ladder needs handles+descriptors visible to bluedroid
+    // (otherwise register_for_notify and CCCD writes silently no-op,
+    // leaving the appliance unsubscribed and no data ever flows)
+    if (param->open.status != ESP_GATT_OK) {
       ESP_LOGW(TAG, "[%s] GATT open failed (status=%d)", name_str_.c_str(),
                static_cast<int>(param->open.status));
       h->handle_disconnected();
     }
+    break;
+  case ESP_GATTC_SEARCH_CMPL_EVT:
+    // bluedroid GATT db is populated, safe to discover handles, register for
+    // notify & write CCCDs
+    h->handle_connected();
     break;
   case ESP_GATTC_DISCONNECT_EVT:
     h->handle_disconnected();
@@ -141,6 +146,16 @@ void ApplianceBase::press_connect() {
 }
 
 void ApplianceBase::press_disconnect() { transport_.disconnect(); }
+
+void ApplianceBase::press_log_debug_info() {
+  // Sync the HA Debug Mode switch state BEFORE forwarding to the hub —
+  // the hub's press_log_debug_info() immediately disconnects, so any
+  // post-disconnect publish would race with the BLE teardown.
+  if (debug_switch_ != nullptr) {
+    debug_switch_->publish_state(true);
+  }
+  hub()->press_log_debug_info();
+}
 
 void ApplianceBase::press_reset_pairing() {
   hub()->press_reset_pairing();

--- a/components/subzero_appliance/appliance_base.cpp
+++ b/components/subzero_appliance/appliance_base.cpp
@@ -86,8 +86,17 @@ void ApplianceBase::gattc_event_handler(esp_gattc_cb_event_t event,
     }
     break;
   case ESP_GATTC_SEARCH_CMPL_EVT:
-    // bluedroid GATT db is populated, safe to discover handles, register for
-    // notify & write CCCDs
+    // bluedroid GATT db is populated, safe to discover handles, register
+    // for notify & write CCCDs — but only if the search itself succeeded.
+    // A failed search means the GATT db is empty/stale; routing to
+    // handle_connected() would publish "Connected, discovering..." and
+    // start the post-bond ladder against handles that don't exist.
+    if (param->search_cmpl.status != ESP_GATT_OK) {
+      ESP_LOGW(TAG, "[%s] GATT search failed (status=%d)", name_str_.c_str(),
+               static_cast<int>(param->search_cmpl.status));
+      h->handle_disconnected();
+      break;
+    }
     h->handle_connected();
     break;
   case ESP_GATTC_DISCONNECT_EVT:

--- a/components/subzero_appliance/appliance_base.h
+++ b/components/subzero_appliance/appliance_base.h
@@ -48,6 +48,9 @@ public:
     status_ts_ = s;
   }
   void set_pin_input(esphome::text::Text *t) { pin_input_ = t; }
+  // Debug Mode switch — held so press_log_debug_info() can flip the HA
+  // UI state when the user clicks the "Log Debug Info" button
+  void set_debug_switch(esphome::switch_::Switch *s) { debug_switch_ = s; }
 
   // CommonBus setters — match the fields on subzero_protocol::CommonBus.
   // Subclass's bus inherits CommonBus, so writing through common_bus()
@@ -135,22 +138,12 @@ public:
 
   // Connect: reset hub state and trigger ble_client connect.
   void press_connect();
-  // Disconnect: drop the BLE link (auto_connect will bring it back).
   void press_disconnect();
-  // Pairing flow
   void press_start_pairing() { hub()->press_start_pairing(); }
   void press_submit_pin() { hub()->press_submit_pin(); }
   void press_poll() { hub()->press_poll(); }
-  void press_log_debug_info() { hub()->press_log_debug_info(); }
-  // Reset: full pairing wipe — clear bond + handles + state, then
-  // disconnect and let auto_connect re-pair on the next session.
+  void press_log_debug_info();
   void press_reset_pairing();
-  // Clear cloud token: sends `set remote_svc_reg_token=""` to deregister
-  // the appliance from Azure IoT Hub, forcing the official app to fall
-  // back to BLE for everything (which then fights us for the single
-  // connection slot — diagnostic only). Verified mechanism via HCI snoop
-  // 2026-04-26: the app's `isBluetoothOnlyMode` flips false once any
-  // token is present.
   void press_clear_cloud_token() {
     write_set_string("remote_svc_reg_token", "");
   }
@@ -173,6 +166,7 @@ protected:
   // Entity refs (set from Python codegen)
   esphome::text_sensor::TextSensor *status_ts_ = nullptr;
   esphome::text::Text *pin_input_ = nullptr;
+  esphome::switch_::Switch *debug_switch_ = nullptr;
 };
 
 // One Button subclass for all 7 button actions. Python codegen

--- a/components/subzero_appliance/dishwasher_hub.h
+++ b/components/subzero_appliance/dishwasher_hub.h
@@ -23,6 +23,7 @@ protected:
     auto s = esphome::subzero_protocol::parse_dishwasher(msg);
     if (!s.valid)
       return false;
+    log_data_keys_(s.data_keys);
     if (s.common.pin_confirmed) {
       on_pin_confirmed_(*s.common.pin_confirmed);
     }

--- a/components/subzero_appliance/fridge_hub.h
+++ b/components/subzero_appliance/fridge_hub.h
@@ -25,6 +25,7 @@ protected:
     auto s = esphome::subzero_protocol::parse_fridge(msg);
     if (!s.valid)
       return false;
+    log_data_keys_(s.data_keys);
     if (s.common.pin_confirmed) {
       on_pin_confirmed_(*s.common.pin_confirmed);
     }

--- a/components/subzero_appliance/hub.cpp
+++ b/components/subzero_appliance/hub.cpp
@@ -577,9 +577,13 @@ void SubzeroHub::press_connect() {
     scheduler_->cancel_timeout(kTimeoutPostBondGiveup);
     scheduler_->cancel_timeout(kTimeoutSubscribeUnlock);
     scheduler_->cancel_timeout(kTimeoutSubscribeGet);
+    scheduler_->cancel_timeout(kTimeoutFastReconnect);
+    scheduler_->cancel_timeout(kTimeoutSubmitPinPoll);
+    scheduler_->cancel_timeout(kTimeoutVerbFallbackRetry);
   }
   post_bond_running_ = false;
   subscribe_running_ = false;
+  fast_reconnect_running_ = false;
 }
 
 void SubzeroHub::press_start_pairing() {
@@ -656,6 +660,20 @@ void SubzeroHub::press_log_debug_info() {
 void SubzeroHub::press_reset_pairing() {
   if (transport_ == nullptr)
     return;
+  if (scheduler_ != nullptr) {
+    scheduler_->cancel_timeout(kTimeoutPostBondInitial);
+    scheduler_->cancel_timeout(kTimeoutPostBondPostEnc);
+    scheduler_->cancel_timeout(kTimeoutPostBondSearch);
+    scheduler_->cancel_timeout(kTimeoutPostBondPoll1);
+    scheduler_->cancel_timeout(kTimeoutPostBondPoll2);
+    scheduler_->cancel_timeout(kTimeoutPostBondPoll3);
+    scheduler_->cancel_timeout(kTimeoutPostBondGiveup);
+    scheduler_->cancel_timeout(kTimeoutSubscribeUnlock);
+    scheduler_->cancel_timeout(kTimeoutSubscribeGet);
+    scheduler_->cancel_timeout(kTimeoutFastReconnect);
+    scheduler_->cancel_timeout(kTimeoutSubmitPinPoll);
+    scheduler_->cancel_timeout(kTimeoutVerbFallbackRetry);
+  }
   pin_confirmed_ = false;
   clear_handles_();
   phase_ = 0;
@@ -663,6 +681,9 @@ void SubzeroHub::press_reset_pairing() {
   poll_miss_ = 0;
   json_buf_.clear();
   poll_verb_ = esphome::subzero_protocol::PollVerb::kGetAsync;
+  post_bond_running_ = false;
+  subscribe_running_ = false;
+  fast_reconnect_running_ = false;
   transport_->cache_clean();
   transport_->remove_bond();
   HUB_LOGW("ble", "[%s] Bond removed, GATT cache cleared, all state reset",

--- a/components/subzero_appliance/hub.cpp
+++ b/components/subzero_appliance/hub.cpp
@@ -50,6 +50,7 @@ constexpr const char *kTimeoutSubscribeUnlock = "subscribe_unlock";
 constexpr const char *kTimeoutSubscribeGet = "subscribe_get";
 constexpr const char *kTimeoutFastReconnect = "fast_reconnect";
 constexpr const char *kTimeoutSubmitPinPoll = "submit_pin_poll";
+constexpr const char *kTimeoutVerbFallbackRetry = "verb_fallback_retry";
 } // namespace
 
 // =============================================================================
@@ -109,6 +110,7 @@ void SubzeroHub::handle_disconnected() {
   scheduler_->cancel_timeout(kTimeoutSubscribeGet);
   scheduler_->cancel_timeout(kTimeoutFastReconnect);
   scheduler_->cancel_timeout(kTimeoutSubmitPinPoll);
+  scheduler_->cancel_timeout(kTimeoutVerbFallbackRetry);
   post_bond_running_ = false;
   subscribe_running_ = false;
   fast_reconnect_running_ = false;
@@ -187,6 +189,8 @@ void SubzeroHub::process_message_complete_() {
           "Pairing required - press Start Pairing and re-enter PIN");
       return;
     }
+    if (handle_lacking_properties_(*msg))
+      return;
     HUB_LOGW("szg", "[%s] Parse failed or status!=0, skipping (%s...)",
              name_.c_str(),
              esphome::subzero_protocol::sanitize_for_log(
@@ -196,6 +200,37 @@ void SubzeroHub::process_message_complete_() {
   }
   fast_retries_ = 0;
   poll_ok_ = true;
+}
+
+bool SubzeroHub::handle_lacking_properties_(const std::string &msg) {
+  if (!esphome::subzero_protocol::is_lacking_properties_response(msg))
+    return false;
+  if (poll_verb_ == esphome::subzero_protocol::PollVerb::kGetAsync) {
+    HUB_LOGW("szg",
+             "[%s] Appliance returned 'lacking properties' to get_async; "
+             "switching to get_all fallback (mirrors official app behavior)",
+             name_.c_str());
+    poll_verb_ = esphome::subzero_protocol::PollVerb::kGetAll;
+    publish_status_("Switching to get_all fallback...");
+    if (scheduler_ != nullptr) {
+      scheduler_->set_timeout(kTimeoutVerbFallbackRetry,
+                              kVerbFallbackRetryDelayMs, [this]() {
+                                if (transport_ == nullptr || d6_handle_ == 0)
+                                  return;
+                                write_poll_command_(d6_handle_);
+                                publish_status_("Retrying with get_all...");
+                              });
+    }
+    return true;
+  }
+
+  HUB_LOGE("szg",
+           "[%s] Appliance returned 'lacking properties' to BOTH get_async "
+           "AND get_all; firmware does not support state polling. Push "
+           "notifications via CCCD may still work.",
+           name_.c_str());
+  publish_status_("Appliance does not support state polling");
+  return true;
 }
 
 void SubzeroHub::on_pin_confirmed_(const std::string &pin) {
@@ -263,7 +298,7 @@ void SubzeroHub::do_periodic_poll() {
   if (!stored_pin_.empty()) {
     write_unlock_channel_(d6_handle_);
   }
-  std::string cmd = esphome::subzero_protocol::build_get_async();
+  std::string cmd = esphome::subzero_protocol::build_poll_command(poll_verb_);
   BleResult err = transport_->write(
       d6_handle_, reinterpret_cast<const std::uint8_t *>(cmd.data()),
       cmd.size());
@@ -274,7 +309,11 @@ void SubzeroHub::do_periodic_poll() {
     transport_->disconnect();
     return;
   }
-  HUB_LOGI("szg", "[%s] Periodic poll D6 (miss=%d, retries=%d)", name_.c_str(),
+  HUB_LOGI("szg", "[%s] Periodic poll D6 (verb=%s, miss=%d, retries=%d)",
+           name_.c_str(),
+           poll_verb_ == esphome::subzero_protocol::PollVerb::kGetAll
+               ? "get_all"
+               : "get_async",
            poll_miss_, fast_retries_);
 }
 
@@ -478,7 +517,7 @@ void SubzeroHub::subscribe_initial_get_() {
   if (d6_handle_ == 0)
     return;
   poll_ok_ = false;
-  write_get_async_(d6_handle_);
+  write_poll_command_(d6_handle_);
   publish_status_("Connected and polling.");
 }
 
@@ -559,7 +598,7 @@ void SubzeroHub::press_submit_pin() {
                           [this]() {
                             if (d5_handle_ == 0)
                               return;
-                            write_get_async_(d5_handle_);
+                            write_poll_command_(d5_handle_);
                           });
 }
 
@@ -573,8 +612,11 @@ void SubzeroHub::press_poll() {
   if (!stored_pin_.empty()) {
     write_unlock_channel_(d6_handle_);
   }
-  write_get_async_(d6_handle_);
-  HUB_LOGI("ble", "[%s] POLL D6: re-unlock + get_async", name_.c_str());
+  write_poll_command_(d6_handle_);
+  HUB_LOGI("ble", "[%s] POLL D6: re-unlock + %s", name_.c_str(),
+           poll_verb_ == esphome::subzero_protocol::PollVerb::kGetAll
+               ? "get_all"
+               : "get_async");
   publish_status_("Polling...");
 }
 
@@ -601,6 +643,7 @@ void SubzeroHub::press_reset_pairing() {
   fast_retries_ = 0;
   poll_miss_ = 0;
   json_buf_.clear();
+  poll_verb_ = esphome::subzero_protocol::PollVerb::kGetAsync;
   transport_->cache_clean();
   transport_->remove_bond();
   HUB_LOGW("ble", "[%s] Bond removed, GATT cache cleared, all state reset",
@@ -648,12 +691,12 @@ void SubzeroHub::write_unlock_channel_(std::uint16_t handle) {
                     cmd.size());
 }
 
-void SubzeroHub::write_get_async_(std::uint16_t handle) {
+void SubzeroHub::write_poll_command_(std::uint16_t handle) {
   if (transport_ == nullptr)
     return;
   if (handle == 0)
     return;
-  std::string cmd = esphome::subzero_protocol::build_get_async();
+  std::string cmd = esphome::subzero_protocol::build_poll_command(poll_verb_);
   transport_->write(handle, reinterpret_cast<const std::uint8_t *>(cmd.data()),
                     cmd.size());
 }

--- a/components/subzero_appliance/hub.cpp
+++ b/components/subzero_appliance/hub.cpp
@@ -208,17 +208,19 @@ bool SubzeroHub::handle_lacking_properties_(const std::string &msg) {
   if (poll_verb_ == esphome::subzero_protocol::PollVerb::kGetAsync) {
     HUB_LOGW("szg",
              "[%s] Appliance returned 'lacking properties' to get_async; "
-             "switching to get_all fallback (mirrors official app behavior)",
+             "switching to {\"cmd\":\"get\"} fallback (verified working on "
+             "IR36550ST per issue #91; not a verb the official app sends "
+             "over BLE — see commands.h)",
              name_.c_str());
-    poll_verb_ = esphome::subzero_protocol::PollVerb::kGetAll;
-    publish_status_("Switching to get_all fallback...");
+    poll_verb_ = esphome::subzero_protocol::PollVerb::kGet;
+    publish_status_("Switching to get fallback...");
     if (scheduler_ != nullptr) {
       scheduler_->set_timeout(kTimeoutVerbFallbackRetry,
                               kVerbFallbackRetryDelayMs, [this]() {
                                 if (transport_ == nullptr || d6_handle_ == 0)
                                   return;
                                 write_poll_command_(d6_handle_);
-                                publish_status_("Retrying with get_all...");
+                                publish_status_("Retrying with get...");
                               });
     }
     return true;
@@ -226,7 +228,7 @@ bool SubzeroHub::handle_lacking_properties_(const std::string &msg) {
 
   HUB_LOGE("szg",
            "[%s] Appliance returned 'lacking properties' to BOTH get_async "
-           "AND get_all; firmware does not support state polling. Push "
+           "AND get; firmware does not support state polling. Push "
            "notifications via CCCD may still work.",
            name_.c_str());
   publish_status_("Appliance does not support state polling");
@@ -311,8 +313,8 @@ void SubzeroHub::do_periodic_poll() {
   }
   HUB_LOGI("szg", "[%s] Periodic poll D6 (verb=%s, miss=%d, retries=%d)",
            name_.c_str(),
-           poll_verb_ == esphome::subzero_protocol::PollVerb::kGetAll
-               ? "get_all"
+           poll_verb_ == esphome::subzero_protocol::PollVerb::kGet
+               ? "get"
                : "get_async",
            poll_miss_, fast_retries_);
 }
@@ -614,8 +616,8 @@ void SubzeroHub::press_poll() {
   }
   write_poll_command_(d6_handle_);
   HUB_LOGI("ble", "[%s] POLL D6: re-unlock + %s", name_.c_str(),
-           poll_verb_ == esphome::subzero_protocol::PollVerb::kGetAll
-               ? "get_all"
+           poll_verb_ == esphome::subzero_protocol::PollVerb::kGet
+               ? "get"
                : "get_async");
   publish_status_("Polling...");
 }

--- a/components/subzero_appliance/hub.cpp
+++ b/components/subzero_appliance/hub.cpp
@@ -7,7 +7,7 @@
 #include <cstring>
 #include <utility>
 
-#ifdef ESPHOME_LOG_HAS_INFO
+#ifdef USE_ESP32
 #include "esphome/core/log.h"
 #define HUB_LOGI(tag, ...) ESP_LOGI(tag, __VA_ARGS__)
 #define HUB_LOGW(tag, ...) ESP_LOGW(tag, __VA_ARGS__)
@@ -205,6 +205,14 @@ void SubzeroHub::on_pin_confirmed_(const std::string &pin) {
     pin_input_cb_(pin);
   HUB_LOGI("szg", "[%s] PIN confirmed: %s", name_.c_str(), pin.c_str());
   publish_status_("PIN confirmed! Channel unlocked.");
+}
+
+void SubzeroHub::log_data_keys_(const std::vector<std::string> &keys) {
+  if (!debug_mode_)
+    return;
+  for (const auto &k : keys) {
+    HUB_LOGI("szg-debug", "[%s] key=%s", name_.c_str(), k.c_str());
+  }
 }
 
 void SubzeroHub::log_chunked_debug_(const std::string &msg) {

--- a/components/subzero_appliance/hub.cpp
+++ b/components/subzero_appliance/hub.cpp
@@ -160,7 +160,15 @@ void SubzeroHub::handle_d5_notify(const std::uint8_t * /*data*/,
 }
 
 void SubzeroHub::handle_d6_notify(const std::uint8_t *data, std::size_t len) {
-  poll_ok_ = true;
+  // Don't set poll_ok_ here — push notifications on D6 (msg_types:1
+  // diagnostic_status, msg_types:2 props) would mask the fw 8.5
+  // silent-poll case where the appliance keeps pushing but never
+  // answers get_async. poll_ok_ is set in process_message_complete_
+  // only when a parsed message is a real POLL RESPONSE (status:0).
+  // The zombie detector then correctly forces a reconnect every ~3 min
+  // on fw 8.5, which is the only way to refresh full state on those
+  // devices (D6 unlock session expires server-side after ~60-80s of
+  // idle).
   if (json_buf_.feed(data, len)) {
     process_message_complete_();
   }
@@ -199,7 +207,16 @@ void SubzeroHub::process_message_complete_() {
     return;
   }
   fast_retries_ = 0;
-  poll_ok_ = true;
+  // poll_ok_ tracks specifically successful POLL RESPONSES (full state),
+  // not pushes. Setting it on incidental pushes (msg_types:1
+  // diagnostic_status, msg_types:2 props) would mask the fw 8.5
+  // silent-poll case — appliance keeps pushing but never answers
+  // get_async, so the zombie detector must still trigger a reconnect.
+  // String-search on `"status":0` is the cheap discriminator: poll
+  // responses always have it, push notifications never do.
+  if (msg->find("\"status\":0") != std::string::npos) {
+    poll_ok_ = true;
+  }
 }
 
 bool SubzeroHub::handle_lacking_properties_(const std::string &msg) {

--- a/components/subzero_appliance/hub.cpp
+++ b/components/subzero_appliance/hub.cpp
@@ -156,7 +156,15 @@ std::uint32_t SubzeroHub::handle_passkey_request() {
 
 void SubzeroHub::handle_d5_notify(const std::uint8_t * /*data*/,
                                   std::size_t /*len*/) {
-  poll_ok_ = true;
+  // D5 indications are control-channel responses (display_pin /
+  // unlock_channel / set / scan acks) and duplicate copies of D6 push
+  // notifications — never poll responses. Setting poll_ok_=true here
+  // would mask the fw 8.5 silent-D6-poll case the same way D6 push
+  // traffic used to (the appliance keeps acking D5 commands AND
+  // mirroring D6 pushes onto D5 even when get_async on D6 has gone
+  // silent). poll_ok_ flips only in process_message_complete_ on a
+  // successful POLL RESPONSE — see CodeRabbit review on PR f795296.
+  // Body intentionally empty.
 }
 
 void SubzeroHub::handle_d6_notify(const std::uint8_t *data, std::size_t len) {
@@ -212,9 +220,9 @@ void SubzeroHub::process_message_complete_() {
   // diagnostic_status, msg_types:2 props) would mask the fw 8.5
   // silent-poll case — appliance keeps pushing but never answers
   // get_async, so the zombie detector must still trigger a reconnect.
-  // String-search on `"status":0` is the cheap discriminator: poll
-  // responses always have it, push notifications never do.
-  if (msg->find("\"status\":0") != std::string::npos) {
+  // has_status_value is whitespace-tolerant and digit-suffix-safe (won't
+  // false-match `"status":01` or `"status": 0` or `"status":09`).
+  if (esphome::subzero_protocol::has_status_value(*msg, '0')) {
     poll_ok_ = true;
   }
 }

--- a/components/subzero_appliance/hub.h
+++ b/components/subzero_appliance/hub.h
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <vector>
 
 namespace esphome {
 namespace subzero_appliance {
@@ -164,6 +165,8 @@ protected:
   // CommonFields contains pin_confirmed. The hub updates stored_pin_
   // and pin_confirmed_, then notifies via pin_input_cb_.
   void on_pin_confirmed_(const std::string &pin);
+  // Virtual so host tests can spy on the subclass call contract
+  virtual void log_data_keys_(const std::vector<std::string> &keys);
 
 private:
   // ---- post_bond stages (translated from the 5-stage YAML script) ----

--- a/components/subzero_appliance/hub.h
+++ b/components/subzero_appliance/hub.h
@@ -22,6 +22,7 @@
 // `dispatch_X(state, bus)` from subzero_protocol.
 
 #include "../subzero_protocol/buffer.h"
+#include "../subzero_protocol/commands.h"
 #include "ble_transport.h"
 #include "scheduler.h"
 
@@ -148,6 +149,8 @@ public:
   bool subscribe_running() const { return subscribe_running_; }
   bool fast_reconnect_running() const { return fast_reconnect_running_; }
   const std::string &stored_pin() const { return stored_pin_; }
+  esphome::subzero_protocol::PollVerb poll_verb() const { return poll_verb_; }
+  void set_poll_verb(esphome::subzero_protocol::PollVerb v) { poll_verb_ = v; }
 
 protected:
   // Subclass hook — called when a complete JSON message has been
@@ -194,7 +197,8 @@ private:
   void process_message_complete_();
   void log_chunked_debug_(const std::string &msg);
   void write_unlock_channel_(std::uint16_t handle);
-  void write_get_async_(std::uint16_t handle);
+  void write_poll_command_(std::uint16_t handle);
+  bool handle_lacking_properties_(const std::string &msg);
   void write_set_property_(const std::string &key,
                            const std::string &json_value);
   void update_handles_from_db_();
@@ -219,6 +223,8 @@ private:
   int poll_miss_ = 0;
   bool debug_mode_ = false;
   std::uint32_t poll_offset_ms_ = 0;
+  esphome::subzero_protocol::PollVerb poll_verb_ =
+      esphome::subzero_protocol::PollVerb::kGetAsync;
 
   // Pending-flow flags — match the YAML scripts' `is_running()` checks.
   // periodic_poll consults these to avoid clobbering an in-progress
@@ -248,6 +254,7 @@ private:
   static constexpr std::uint32_t kResetPairingDisconnectDelayMs = 1000;
   static constexpr int kStaleBondsThreshold = 3;
   static constexpr int kZombiePollMissThreshold = 3;
+  static constexpr std::uint32_t kVerbFallbackRetryDelayMs = 1000;
 };
 
 } // namespace subzero_appliance

--- a/components/subzero_appliance/range_hub.h
+++ b/components/subzero_appliance/range_hub.h
@@ -23,6 +23,7 @@ protected:
     auto s = esphome::subzero_protocol::parse_range(msg);
     if (!s.valid)
       return false;
+    log_data_keys_(s.data_keys);
     if (s.common.pin_confirmed) {
       on_pin_confirmed_(*s.common.pin_confirmed);
     }

--- a/components/subzero_protocol/commands.h
+++ b/components/subzero_protocol/commands.h
@@ -89,18 +89,53 @@ inline std::string build_unlock_channel(const std::string &pin) {
 }
 
 // `get_async` requests a full state dump on the channel it's written to.
-// Used on D6 only post-PR-#72 — D5 returns nothing for get_async.
+// Used on D6 only post-PR-#72 — D5 returns nothing for get_async. Verified
+// in libapp.so blutter dump as the only BLE poll verb in
+// `BluetoothCommands::getAsyncCmd`.
 inline std::string build_get_async() { return "{\"cmd\":\"get_async\"}\n"; }
-inline std::string build_get_all() { return "{\"cmd\":\"get_all\"}\n"; }
+
+// `get` is our BLE-side fallback when an appliance returns
+// `{"status":1,"resp":{},"status_msg":"An error occurred"}` to `get_async`
+// — what the app's log strings call "appliance lacking properties".
+//
+// NOT a verb the official Android app sends over BLE. blutter
+// decompilation of libapp.so v4.5.1 (Dart 3.11.0) shows
+// `BluetoothCommands` has exactly 6 baked JSON verbs: `set`,
+// `unlock_channel`, `scan`, `get_async`, `display_pin`,
+// `reset_air_filter`. The official app's "Sending fallback GetAll
+// command" log lives in the *cloud* path (`AzureApplianceCommands.
+// sendGetCommand` Direct Method via `azure_appliance_commands.dart`),
+// not BLE — and the `getAllWithParameters`/`GetAllParameters` symbols
+// belong to the `shared_preferences_android` Flutter plugin, unrelated
+// to the Sub-Zero protocol entirely.
+//
+// `{"cmd":"get"}` is original protocol work, justified by issue #91:
+// mwbourgeois empirically confirmed it returns a 2394-byte full-state
+// response from a Sub-Zero IR36550ST induction range fw 2.27 across
+// multiple consecutive poll cycles. Plausibly accepted via firmware-side
+// prefix matching (`get` → `get_async`) or a Sub-Zero service verb.
+// Same response shape as `get_async` on success.
+inline std::string build_get() { return "{\"cmd\":\"get\"}\n"; }
+
+// Polling verb selector — the hub latches to whichever one a given
+// appliance accepts. Default is kGetAsync (the only BLE poll verb in the
+// official app); kGet is our empirical fallback for appliances that
+// return the "lacking properties" sentinel to get_async.
 enum class PollVerb {
   kGetAsync,
-  kGetAll,
+  kGet,
 };
 
 inline std::string build_poll_command(PollVerb v) {
-  return v == PollVerb::kGetAll ? build_get_all() : build_get_async();
+  return v == PollVerb::kGet ? build_get() : build_get_async();
 }
 
+// True if `msg` matches the "appliance lacking properties" sentinel:
+// status:1 plus an empty resp object. The exact wire bytes vary across
+// firmwares (some include "status_msg":"An error occurred", some don't,
+// whitespace differs), so we substring-match on the two stable tokens
+// rather than parsing JSON. Compatible with both `"resp":{}` (no space)
+// and `"resp": {}` (with space) — covers every observed variant.
 inline bool is_lacking_properties_response(const std::string &msg) {
   if (msg.find("\"status\":1") == std::string::npos)
     return false;

--- a/components/subzero_protocol/commands.h
+++ b/components/subzero_protocol/commands.h
@@ -91,6 +91,25 @@ inline std::string build_unlock_channel(const std::string &pin) {
 // `get_async` requests a full state dump on the channel it's written to.
 // Used on D6 only post-PR-#72 — D5 returns nothing for get_async.
 inline std::string build_get_async() { return "{\"cmd\":\"get_async\"}\n"; }
+inline std::string build_get_all() { return "{\"cmd\":\"get_all\"}\n"; }
+enum class PollVerb {
+  kGetAsync,
+  kGetAll,
+};
+
+inline std::string build_poll_command(PollVerb v) {
+  return v == PollVerb::kGetAll ? build_get_all() : build_get_async();
+}
+
+inline bool is_lacking_properties_response(const std::string &msg) {
+  if (msg.find("\"status\":1") == std::string::npos)
+    return false;
+  if (msg.find("\"resp\":{}") != std::string::npos)
+    return true;
+  if (msg.find("\"resp\": {}") != std::string::npos)
+    return true;
+  return false;
+}
 
 // `display_pin` makes the appliance show its random pairing PIN on its
 // front-panel display for the requested duration (seconds). Sent on D5

--- a/components/subzero_protocol/commands.h
+++ b/components/subzero_protocol/commands.h
@@ -1,36 +1,12 @@
 #pragma once
 
-// JSON command builders for the Sub-Zero BLE protocol.
-//
-// All commands are written to the appliance's D5 (control) or D6 (data)
-// characteristic and MUST be terminated with '\n' — the appliance's serial
-// parser only emits a response once the newline arrives.
-//
-// Pure string functions, host-testable. Existing call sites in the YAML
-// scripts inline these literals; centralizing them makes the protocol
-// vocabulary explicit and gives Phase 3's eventual BleTransport a single
-// source of truth for what bytes go on the wire.
-
 #include <cstdio>
 #include <string>
 
 namespace esphome {
 namespace subzero_protocol {
-
 namespace detail {
 
-// JSON-escape a string for safe embedding inside a `"..."` literal.
-// Real Sub-Zero PINs are 4-5 digit numeric, but the HA text input that
-// stores the PIN is `mode: text` and accepts arbitrary chars — a user
-// could paste a string containing a quote or backslash, which would
-// silently corrupt the unlock_channel payload and either drop the
-// command on the floor or, worse, confuse the appliance's serial parser.
-//
-// Handles the spec-required escapes (RFC 8259 §7): backslash, quote,
-// and the named C0 controls (\b \f \n \r \t). Other control bytes
-// (0x00..0x1F) become `\u00XX`. Higher-bit bytes are passed through
-// unmodified — the protocol is ASCII in practice and we don't want to
-// re-encode arbitrary UTF-8.
 inline std::string escape_json_string(const std::string &s) {
   std::string out;
   out.reserve(s.size() + 2);
@@ -74,53 +50,14 @@ inline std::string escape_json_string(const std::string &s) {
 
 } // namespace detail
 
-// `unlock_channel` opens the encrypted command/data channel after bonding
-// using the appliance's currently-displayed PIN. Sent on D5 (control)
-// during initial subscribe and on D6 (data) before every periodic poll
-// — D6's session expires independently of the BLE link.
-//
-// PIN is JSON-escaped before embedding (CodeRabbit on PR #73). Sub-Zero
-// PINs are numeric in practice, but the HA text input stores arbitrary
-// strings and we want a malformed PIN to produce well-formed JSON rather
-// than a corrupted wire payload.
 inline std::string build_unlock_channel(const std::string &pin) {
   return "{\"cmd\":\"unlock_channel\",\"params\":{\"pin\":\"" +
          detail::escape_json_string(pin) + "\"}}\n";
 }
 
-// `get_async` requests a full state dump on the channel it's written to.
-// Used on D6 only post-PR-#72 — D5 returns nothing for get_async. Verified
-// in libapp.so blutter dump as the only BLE poll verb in
-// `BluetoothCommands::getAsyncCmd`.
 inline std::string build_get_async() { return "{\"cmd\":\"get_async\"}\n"; }
-
-// `get` is our BLE-side fallback when an appliance returns
-// `{"status":1,"resp":{},"status_msg":"An error occurred"}` to `get_async`
-// — what the app's log strings call "appliance lacking properties".
-//
-// NOT a verb the official Android app sends over BLE. blutter
-// decompilation of libapp.so v4.5.1 (Dart 3.11.0) shows
-// `BluetoothCommands` has exactly 6 baked JSON verbs: `set`,
-// `unlock_channel`, `scan`, `get_async`, `display_pin`,
-// `reset_air_filter`. The official app's "Sending fallback GetAll
-// command" log lives in the *cloud* path (`AzureApplianceCommands.
-// sendGetCommand` Direct Method via `azure_appliance_commands.dart`),
-// not BLE — and the `getAllWithParameters`/`GetAllParameters` symbols
-// belong to the `shared_preferences_android` Flutter plugin, unrelated
-// to the Sub-Zero protocol entirely.
-//
-// `{"cmd":"get"}` is original protocol work, justified by issue #91:
-// mwbourgeois empirically confirmed it returns a 2394-byte full-state
-// response from a Sub-Zero IR36550ST induction range fw 2.27 across
-// multiple consecutive poll cycles. Plausibly accepted via firmware-side
-// prefix matching (`get` → `get_async`) or a Sub-Zero service verb.
-// Same response shape as `get_async` on success.
 inline std::string build_get() { return "{\"cmd\":\"get\"}\n"; }
 
-// Polling verb selector — the hub latches to whichever one a given
-// appliance accepts. Default is kGetAsync (the only BLE poll verb in the
-// official app); kGet is our empirical fallback for appliances that
-// return the "lacking properties" sentinel to get_async.
 enum class PollVerb {
   kGetAsync,
   kGet,
@@ -130,57 +67,39 @@ inline std::string build_poll_command(PollVerb v) {
   return v == PollVerb::kGet ? build_get() : build_get_async();
 }
 
-inline bool is_lacking_properties_response(const std::string &msg) {
+inline bool has_status_value(const std::string &msg, char digit) {
   static constexpr const char *kStatusKey = "\"status\":";
   static constexpr std::size_t kKeyLen = 9; // strlen(kStatusKey)
   std::size_t pos = 0;
-  bool found_status_1 = false;
   while ((pos = msg.find(kStatusKey, pos)) != std::string::npos) {
     std::size_t v = pos + kKeyLen;
     // Skip optional whitespace after colon.
     while (v < msg.size() && (msg[v] == ' ' || msg[v] == '\t'))
       v++;
-    if (v < msg.size() && msg[v] == '1') {
-      // The value must NOT be followed by another digit — that would be
-      // `10`, `11`, `12`, `100`, etc. (`1.0` doesn't appear in this
-      // protocol; `.` is allowed because Sub-Zero responses use integer
-      // status codes only).
+    if (v < msg.size() && msg[v] == digit) {
       char next = (v + 1 < msg.size()) ? msg[v + 1] : '\0';
       if (next < '0' || next > '9') {
-        found_status_1 = true;
-        break;
+        return true;
       }
     }
     pos++;
   }
-  if (!found_status_1)
+  return false;
+}
+
+inline bool is_lacking_properties_response(const std::string &msg) {
+  if (!has_status_value(msg, '1'))
     return false;
   // Empty resp object — accept both spacing variants observed on the wire.
   return msg.find("\"resp\":{}") != std::string::npos ||
          msg.find("\"resp\": {}") != std::string::npos;
 }
 
-// `display_pin` makes the appliance show its random pairing PIN on its
-// front-panel display for the requested duration (seconds). Sent on D5
-// before the user enters that PIN into HA.
 inline std::string build_display_pin(int duration_seconds = 30) {
   return "{\"cmd\":\"display_pin\",\"params\":{\"duration\": " +
          std::to_string(duration_seconds) + "}}\n";
 }
 
-// `set` writes a single property on the appliance. Sent on D5 (control
-// channel) — the appliance acks with `{"status":0,"resp":{}}` and within
-// ~1s pushes a `msg_types:2` notification on D6 echoing the new value,
-// which our normal read pipeline picks up.
-//
-// Verified verbs from official-app HCI snoop (2026-04-26): bool fields
-// like `cav_light_on`, integer fields like `kitchen_timer_duration`,
-// string fields like `remote_svc_reg_token` and the WiFi triplet
-// (`ap_ssid`/`ap_pass`/`ap_enc`).
-//
-// `json_value` is the already-formatted JSON literal (no quotes for
-// numbers/bools, quotes + escaping for strings — use the typed helpers
-// below instead of build_set directly when possible).
 inline std::string build_set(const std::string &key,
                              const std::string &json_value) {
   return "{\"cmd\":\"set\",\"params\":{\"" + detail::escape_json_string(key) +

--- a/components/subzero_protocol/commands.h
+++ b/components/subzero_protocol/commands.h
@@ -130,20 +130,34 @@ inline std::string build_poll_command(PollVerb v) {
   return v == PollVerb::kGet ? build_get() : build_get_async();
 }
 
-// True if `msg` matches the "appliance lacking properties" sentinel:
-// status:1 plus an empty resp object. The exact wire bytes vary across
-// firmwares (some include "status_msg":"An error occurred", some don't,
-// whitespace differs), so we substring-match on the two stable tokens
-// rather than parsing JSON. Compatible with both `"resp":{}` (no space)
-// and `"resp": {}` (with space) — covers every observed variant.
 inline bool is_lacking_properties_response(const std::string &msg) {
-  if (msg.find("\"status\":1") == std::string::npos)
+  static constexpr const char *kStatusKey = "\"status\":";
+  static constexpr std::size_t kKeyLen = 9; // strlen(kStatusKey)
+  std::size_t pos = 0;
+  bool found_status_1 = false;
+  while ((pos = msg.find(kStatusKey, pos)) != std::string::npos) {
+    std::size_t v = pos + kKeyLen;
+    // Skip optional whitespace after colon.
+    while (v < msg.size() && (msg[v] == ' ' || msg[v] == '\t'))
+      v++;
+    if (v < msg.size() && msg[v] == '1') {
+      // The value must NOT be followed by another digit — that would be
+      // `10`, `11`, `12`, `100`, etc. (`1.0` doesn't appear in this
+      // protocol; `.` is allowed because Sub-Zero responses use integer
+      // status codes only).
+      char next = (v + 1 < msg.size()) ? msg[v + 1] : '\0';
+      if (next < '0' || next > '9') {
+        found_status_1 = true;
+        break;
+      }
+    }
+    pos++;
+  }
+  if (!found_status_1)
     return false;
-  if (msg.find("\"resp\":{}") != std::string::npos)
-    return true;
-  if (msg.find("\"resp\": {}") != std::string::npos)
-    return true;
-  return false;
+  // Empty resp object — accept both spacing variants observed on the wire.
+  return msg.find("\"resp\":{}") != std::string::npos ||
+         msg.find("\"resp\": {}") != std::string::npos;
 }
 
 // `display_pin` makes the appliance show its random pairing PIN on its

--- a/components/subzero_protocol/protocol.cpp
+++ b/components/subzero_protocol/protocol.cpp
@@ -59,14 +59,6 @@ JsonObjectConst extract_data(JsonObjectConst root, bool &is_poll) {
     is_poll = false;
     return root["props"].as<JsonObjectConst>();
   }
-  // msg_types:1 push: a "diagnostic_status changed" notification that
-  // arrives with diagnostic_status at the ROOT level (no resp/props
-  // wrapper). Shape observed on Wolf SO3050PESP fw 8.5:
-  //   {"diagnostic_status": "0x00000301111", "msg_types": 1,
-  //    "seq": 475, "timestamp": "..."}
-  // Treat the root as the data object — fill_common picks up
-  // diagnostic_status by key, and seq/timestamp/msg_types are silently
-  // ignored by the type-checked field reads.
   if (root["msg_types"].is<int>() && root["msg_types"].as<int>() == 1) {
     is_poll = false;
     return root;

--- a/components/subzero_protocol/protocol.cpp
+++ b/components/subzero_protocol/protocol.cpp
@@ -59,6 +59,18 @@ JsonObjectConst extract_data(JsonObjectConst root, bool &is_poll) {
     is_poll = false;
     return root["props"].as<JsonObjectConst>();
   }
+  // msg_types:1 push: a "diagnostic_status changed" notification that
+  // arrives with diagnostic_status at the ROOT level (no resp/props
+  // wrapper). Shape observed on Wolf SO3050PESP fw 8.5:
+  //   {"diagnostic_status": "0x00000301111", "msg_types": 1,
+  //    "seq": 475, "timestamp": "..."}
+  // Treat the root as the data object — fill_common picks up
+  // diagnostic_status by key, and seq/timestamp/msg_types are silently
+  // ignored by the type-checked field reads.
+  if (root["msg_types"].is<int>() && root["msg_types"].as<int>() == 1) {
+    is_poll = false;
+    return root;
+  }
   return JsonObjectConst();
 }
 

--- a/docs/ble-protocol.adoc
+++ b/docs/ble-protocol.adoc
@@ -149,21 +149,59 @@ Any raw-buffer content that reaches ESPHome's logger (the debug-mode `Response[N
 
 == Command Reference
 
-Commands are JSON objects terminated with `\n`. The full command set per the official app's binary is six verbs: `unlock_channel`, `get_async`, `display_pin`, `set` (write properties), `scan` (Wi-Fi scan), `reset_air_filter`. There is no keepalive/ping verb.
+Commands are JSON objects terminated with `\n`. The full command set per the official app's binary is eight verbs: six baked as JSON literals (`unlock_channel`, `get_async`, `display_pin`, `set`, `scan`, `reset_air_filter`) plus two verbs constructed dynamically by the app (`get_all`, `exit_delay`). There is no keepalive/ping verb. There is no `subscribe` / `unsubscribe` / `set_async` - push subscriptions are pure CCCD writes (`0x02 0x00` to handle+2 of D5/D6).
 
 [cols="1,1,2,2"]
 |===
 | Command | Channel | Payload | Response
 
 | `unlock_channel` | *D5 + D6* | `{"cmd":"unlock_channel","params":{"pin":"XXXXXX"}}\n` | `{"status":0,"resp":{"pin":"XXXXXX"}}` on whichever channel was written. Each channel needs its own unlock.
-| `get_async` | *D6* | `{"cmd":"get_async"}\n` | Full appliance state as JSON (see <<Example Responses>>)
+| `get_async` | *D6* | `{"cmd":"get_async"}\n` | Full appliance state as JSON (see <<Example Responses>>). On firmwares "lacking properties" (e.g. Sub-Zero IR36550ST fw 2.27), returns `{"status":1,"resp":{},"status_msg":"An error occurred"}` - see <<get-fallback,Polling fallback chain>>.
+| `get_all` | *D6* | `{"cmd":"get_all"}\n` | Same shape as `get_async` success response. Used by the official app as a fallback when `get_async` returns `status:1` with empty `resp`. Constructed dynamically (no JSON literal in the binary), driven by `GetAllParameters` Dart class.
 | `display_pin` | *D5* | `{"cmd":"display_pin","params":{"duration": 30}}\n` | `{"status":0,"resp":{}}`. Displays PIN on appliance for 30 seconds.
 | `set` | *D5* | `{"cmd":"set","params":{"<field>":"<value>"}}\n` | `{"status":0,"resp":{}}`. Writes a single property (time, ap_ssid + ap_pass + ap_enc, remote_svc_reg_token, etc.)
 | `scan` | *D5* | `{"cmd":"scan"}\n` | `{"status":0,"resp":{"aps":[{"ap_ssid":"...","ap_enc":3,"ap_rssi":N},...]}}`
 | `reset_air_filter` | *D5* | `{"cmd":"reset_air_filter"}\n` | (untested by this integration)
+| `exit_delay` | *D5* | `{"cmd":"exit_delay"}\n` (likely shape) | (untested) Verb appears as a bare token in the official app, no JSON literal. Suspected to cancel a pending delayed-start state on dishwashers/ranges.
 |===
 
 The *open* channel `get_async` (no unlock required) the official app uses for its initial probe is on *D7*, not D4. It returns a much smaller response (model, doors, uptime, wlan_id) than D6's full state. The integration discovers D7 but doesn't currently use it.
+
+[[get-fallback]]
+=== Polling fallback chain (`get_async` -> `get_all`)
+
+Some appliance firmwares respond to D6 `get_async` with `{"status":1,"resp":{},"status_msg":"An error occurred"}` instead of full state - a 56-byte sentinel. The official Android app describes these as "appliances lacking properties" (see strings in `lib/arm64-v8a/libapp.so`):
+
+----
+"Async channel is open, stopping property polling"
+"Starting property polling for appliance"
+"Initial GetAll command failed (attempt"
+"Initial GetAll failed with maximum failures, not starting property polling"
+"Sending fallback GetAll command for appliance lacking properties"
+"Property polling failed (attempt"
+"Stopping property polling after 3 consecutive failures"
+"Failed to send GetAll command with error"
+----
+
+This integration mirrors the official app's behavior in `SubzeroHub`:
+
+. Default poll verb is `get_async`. Sent on `subscribe_initial_get_`, `do_periodic_poll`, and the "Poll Now" button.
+. If a poll response matches the sentinel (`"status":1` AND `"resp":{}`), the hub flips its `poll_verb_` to `kGetAll` for the rest of this session and schedules an immediate retry with `{"cmd":"get_all"}`.
+. The verb selection latches per-hub. Once an appliance is known to need `get_all`, every subsequent poll uses it directly (no `get_async` retry on every cycle).
+. The latch resets on `press_reset_pairing()` (full state wipe) but persists across normal disconnect/reconnect - the verb is a firmware capability, not a transient state.
+. If `get_all` also returns the lacking-properties sentinel, the hub logs an error and stops trying to switch - push notifications continue to work via CCCD even when neither poll verb does.
+
+Verified appliance behaviors:
+
+[cols="1,1,1,1"]
+|===
+| Appliance | FW | `get_async` D6 | `get_all` D6
+
+| Wolf SO3050PESP wall oven | 8.5 | works (~2178 byte poll) | (untested)
+| Wolf DF36450GSP range | 2.27 | works | (untested)
+| Sub-Zero DEU2450R fridge | 8.5 | works (HCI-confirmed) | (untested)
+| Sub-Zero IR36550ST induction range | 2.27 | *fails* (56-byte error) | works (~2394 byte poll, user-confirmed)
+|===
 
 [[example-responses]]
 == Example Responses

--- a/docs/ble-protocol.adoc
+++ b/docs/ble-protocol.adoc
@@ -149,53 +149,61 @@ Any raw-buffer content that reaches ESPHome's logger (the debug-mode `Response[N
 
 == Command Reference
 
-Commands are JSON objects terminated with `\n`. The full command set per the official app's binary is eight verbs: six baked as JSON literals (`unlock_channel`, `get_async`, `display_pin`, `set`, `scan`, `reset_air_filter`) plus two verbs constructed dynamically by the app (`get_all`, `exit_delay`). There is no keepalive/ping verb. There is no `subscribe` / `unsubscribe` / `set_async` - push subscriptions are pure CCCD writes (`0x02 0x00` to handle+2 of D5/D6).
+Commands are JSON objects terminated with `\n`. The official Android app's BLE protocol vocabulary is *exactly six verbs*, all baked as JSON literals in the `BluetoothCommands` Dart class (verified by blutter decompilation of `libapp.so` v4.5.1, Dart SDK 3.11.0):
 
 [cols="1,1,2,2"]
 |===
 | Command | Channel | Payload | Response
 
 | `unlock_channel` | *D5 + D6* | `{"cmd":"unlock_channel","params":{"pin":"XXXXXX"}}\n` | `{"status":0,"resp":{"pin":"XXXXXX"}}` on whichever channel was written. Each channel needs its own unlock.
-| `get_async` | *D6* | `{"cmd":"get_async"}\n` | Full appliance state as JSON (see <<Example Responses>>). On firmwares "lacking properties" (e.g. Sub-Zero IR36550ST fw 2.27), returns `{"status":1,"resp":{},"status_msg":"An error occurred"}` - see <<get-fallback,Polling fallback chain>>.
-| `get_all` | *D6* | `{"cmd":"get_all"}\n` | Same shape as `get_async` success response. Used by the official app as a fallback when `get_async` returns `status:1` with empty `resp`. Constructed dynamically (no JSON literal in the binary), driven by `GetAllParameters` Dart class.
+| `get_async` | *D6* | `{"cmd":"get_async"}\n` | Full appliance state as JSON (see <<Example Responses>>). On firmwares "lacking properties" (e.g. Sub-Zero IR36550ST fw 2.27), returns `{"status":1,"resp":{},"status_msg":"An error occurred"}` - see <<get-fallback,Polling fallback>>.
 | `display_pin` | *D5* | `{"cmd":"display_pin","params":{"duration": 30}}\n` | `{"status":0,"resp":{}}`. Displays PIN on appliance for 30 seconds.
-| `set` | *D5* | `{"cmd":"set","params":{"<field>":"<value>"}}\n` | `{"status":0,"resp":{}}`. Writes a single property (time, ap_ssid + ap_pass + ap_enc, remote_svc_reg_token, etc.)
+| `set` | *D5* | `{"cmd":"set","params":{"<field>":"<value>"}}\n` | `{"status":0,"resp":{}}`. Writes a single property (time, ap_ssid + ap_pass + ap_enc, remote_svc_reg_token, etc.). Specialized variant `connectWiFiCmd` writes the WiFi triplet.
 | `scan` | *D5* | `{"cmd":"scan"}\n` | `{"status":0,"resp":{"aps":[{"ap_ssid":"...","ap_enc":3,"ap_rssi":N},...]}}`
 | `reset_air_filter` | *D5* | `{"cmd":"reset_air_filter"}\n` | (untested by this integration)
-| `exit_delay` | *D5* | `{"cmd":"exit_delay"}\n` (likely shape) | (untested) Verb appears as a bare token in the official app, no JSON literal. Suspected to cancel a pending delayed-start state on dishwashers/ranges.
 |===
+
+The official app has *no other BLE verbs*. There is no keepalive/ping. There is no `subscribe`/`unsubscribe`/`set_async` - push subscriptions are pure CCCD writes (`0x02 0x00` to handle+2 of D5/D6).
 
 The *open* channel `get_async` (no unlock required) the official app uses for its initial probe is on *D7*, not D4. It returns a much smaller response (model, doors, uptime, wlan_id) than D6's full state. The integration discovers D7 but doesn't currently use it.
 
+==== Misleading symbols in libapp.so
+
+Several plausible-looking symbols in the binary are NOT BLE verbs:
+
+* *`getAllWithParameters` / `GetAllParameters`* - methods/class belonging to the `shared_preferences_android` Flutter plugin (Android local-storage API). Unrelated to the Sub-Zero protocol.
+* *`get_all` (bare token)* - a telemetry tag passed to `_stopPropertyLoadTrace`, AND the Azure IoT Hub Direct Method name. Never written to a BLE characteristic.
+* *`exit_delay` (bare token)* - present in the const string pool but no JSON literal exists, no `BluetoothCommands` method emits it. Suspected unused or used only via the cloud Direct Method path.
+* *`Sending "get" command`* - log line from a non-BLE code path.
+* *`Sending fallback GetAll command for appliance lacking properties`* - emitted in `appliance_list_card_controller.dart` and immediately followed by a call to `AzureApplianceCommands.sendGetCommand()`. *Cloud-side* fallback, not BLE.
+
+The official app's actual fallback for a "lacking properties" BLE response is to abandon BLE polling and fall back to *Azure IoT Hub Direct Method*. ESPHome can't do that - we have no Azure credentials and the appliance may not even be cloud-registered.
+
 [[get-fallback]]
-=== Polling fallback chain (`get_async` -> `get_all`)
+=== Polling fallback (`get_async` -> `get`)
 
-Some appliance firmwares respond to D6 `get_async` with `{"status":1,"resp":{},"status_msg":"An error occurred"}` instead of full state - a 56-byte sentinel. The official Android app describes these as "appliances lacking properties" (see strings in `lib/arm64-v8a/libapp.so`):
+Some appliance firmwares respond to D6 `get_async` with `{"status":1,"resp":{},"status_msg":"An error occurred"}` instead of full state - a 56-byte sentinel.
 
-----
-"Async channel is open, stopping property polling"
-"Starting property polling for appliance"
-"Initial GetAll command failed (attempt"
-"Initial GetAll failed with maximum failures, not starting property polling"
-"Sending fallback GetAll command for appliance lacking properties"
-"Property polling failed (attempt"
-"Stopping property polling after 3 consecutive failures"
-"Failed to send GetAll command with error"
-----
+[NOTE]
+====
+*This integration's BLE-side fallback is original protocol work, not a mirror of the official app.* The official app falls back to the Azure cloud (above); this integration falls back to a different BLE verb instead, since the cloud path isn't available to ESPHome.
+====
 
-This integration mirrors the official app's behavior in `SubzeroHub`:
+`SubzeroHub` behavior:
 
-. Default poll verb is `get_async`. Sent on `subscribe_initial_get_`, `do_periodic_poll`, and the "Poll Now" button.
-. If a poll response matches the sentinel (`"status":1` AND `"resp":{}`), the hub flips its `poll_verb_` to `kGetAll` for the rest of this session and schedules an immediate retry with `{"cmd":"get_all"}`.
-. The verb selection latches per-hub. Once an appliance is known to need `get_all`, every subsequent poll uses it directly (no `get_async` retry on every cycle).
+. Default poll verb is `get_async` (the only BLE poll verb in the official app). Sent on `subscribe_initial_get_`, `do_periodic_poll`, and the "Poll Now" button.
+. If a poll response matches the sentinel (`"status":1` AND `"resp":{}`), the hub flips its `poll_verb_` to `kGet` for the rest of this session and schedules an immediate retry with `{"cmd":"get"}`.
+. The verb selection latches per-hub. Once an appliance is known to need `get`, every subsequent poll uses it directly (no `get_async` retry on every cycle).
 . The latch resets on `press_reset_pairing()` (full state wipe) but persists across normal disconnect/reconnect - the verb is a firmware capability, not a transient state.
-. If `get_all` also returns the lacking-properties sentinel, the hub logs an error and stops trying to switch - push notifications continue to work via CCCD even when neither poll verb does.
+. If `get` also returns the lacking-properties sentinel, the hub logs an error and stops trying to switch - push notifications continue to work via CCCD even when neither poll verb does.
+
+`{"cmd":"get"}` was empirically verified by issue #91 reporter (mwbourgeois) on a Sub-Zero IR36550ST induction range fw 2.27: returns ~2394-byte full-state response across multiple consecutive poll cycles. The verb is *not* in the official app's `BluetoothCommands`; the most likely explanations are firmware-side prefix matching (`get` matches `get_async`) or a Sub-Zero service/diagnostic verb left in the firmware.
 
 Verified appliance behaviors:
 
 [cols="1,1,1,1"]
 |===
-| Appliance | FW | `get_async` D6 | `get_all` D6
+| Appliance | FW | `get_async` D6 | `get` D6
 
 | Wolf SO3050PESP wall oven | 8.5 | works (~2178 byte poll) | (untested)
 | Wolf DF36450GSP range | 2.27 | works | (untested)

--- a/docs/ble-protocol.adoc
+++ b/docs/ble-protocol.adoc
@@ -119,9 +119,14 @@ Response Fragmentation:: The appliance sends responses as BLE indications, fragm
 fw 8.5 appliances fragment at ~40 bytes per indication (50+ fragments for a ~2 KB poll response). fw 2.27 appliances use ~244 byte fragments (most pushes fit in a single indication).
 The receiver buffers and reassembles by tracking JSON brace depth (`{` / `}`) to detect message completion.
 
-Push Notifications:: Appliances send real-time push notifications for state changes (door open/close, temperature change, light toggle, etc.) on D6. Format: `{"seq":N,"props":{...},"msg_types":M}` (or `{"diagnostic_status":"...","msg_types":1}` for diagnostic_status updates).
+Push Notifications:: Appliances send real-time push notifications for state changes (door open/close, temperature change, light toggle, etc.) on D6. Two shapes:
++
+* `msg_types:2` - props update: `{"seq":N,"props":{<changed-fields>},"msg_types":2}`. Carries one or more state field changes.
+* `msg_types:1` - diagnostic_status update: `{"diagnostic_status":"0x...","msg_types":1,"seq":N,"timestamp":"..."}`. Carries the appliance's diagnostic_status field at the *root* of the JSON object (no `resp` or `props` wrapper). Sub-Zero/Wolf appliances emit these every minute or so when the appliance is otherwise idle. Initial implementations of `extract_data` only handled `resp` (poll) and `props` (msg_types:2 push); msg_types:1 pushes were dropped as parse failures until they were explicitly handled (see `extract_data` in `subzero_protocol/protocol.cpp`).
 +
 The appliance also broadcasts a duplicate copy of every D6 push on D5. We deliberately ignore those copies in the D5 notification handler (it doesn't feed the JSON buffer) to prevent the same push from being parsed twice and corrupting the buffer with duplicated bytes.
+
+Zombie-poll detection (poll vs push):: `poll_ok_` only flips on a successful POLL RESPONSE (the substring `"status":0`), never on incoming push notifications. The fw 8.5 silent-poll case keeps emitting `msg_types:1` pushes while `get_async` writes go silent server-side; treating those pushes as "evidence of life" would block the zombie detector from firing and the appliance state would freeze on its initial poll values forever. With this gating, pushes still update incremental state via the dispatch bus, but `poll_miss_` keeps incrementing each silent 60s window and forces a reconnect after 3 misses (~3 min) - matching the Sub-Zero Android app's disconnect-between-polls cadence on fw 8.5.
 
 D5 + D6 Discovery Timing:: The encrypted D5 and D6 characteristics are not visible in the initial GATT database - they only appear after BLE bonding completes.
 The implementation requests encryption, refreshes the GATT cache (`esp_ble_gattc_cache_refresh`), and re-runs service discovery to make them visible. The code polls up to three times with delays to handle timing variations across different appliance models.

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -66,6 +66,7 @@ add_executable(protocol_tests
   gatt_handles_test.cpp
   dispatch_test.cpp
   hub_test.cpp
+  lifecycle_guards_test.cpp
 )
 target_link_libraries(protocol_tests PRIVATE
   subzero_protocol
@@ -75,6 +76,8 @@ target_link_libraries(protocol_tests PRIVATE
 )
 target_compile_definitions(protocol_tests PRIVATE
   FIXTURES_DIR="${FIXTURES_DIR}"
+  PROTOCOL_DIR="${PROTOCOL_DIR}"
+  APPLIANCE_DIR="${APPLIANCE_DIR}"
 )
 
 include(GoogleTest)

--- a/tests/cpp/commands_test.cpp
+++ b/tests/cpp/commands_test.cpp
@@ -213,3 +213,18 @@ TEST(Commands, IsLackingProperties_RejectsHealthyPushNotification) {
   EXPECT_FALSE(is_lacking_properties_response(
       "{\"msg_types\":2,\"seq\":92,\"props\":{\"ref_door_ajar\":true}}"));
 }
+
+TEST(Commands, IsLackingProperties_RejectsStatusWithDigitSuffix) {
+  EXPECT_FALSE(is_lacking_properties_response("{\"status\":10,\"resp\":{}}"));
+  EXPECT_FALSE(is_lacking_properties_response("{\"status\":11,\"resp\":{}}"));
+  EXPECT_FALSE(is_lacking_properties_response("{\"status\":100,\"resp\":{}}"));
+  EXPECT_FALSE(
+      is_lacking_properties_response("{\"status\":1234,\"resp\":{}}"));
+}
+
+TEST(Commands, IsLackingProperties_AcceptsWhitespaceAfterColon) {
+  // some firmwares may emit `"status": 1` with a space after the colon
+  EXPECT_TRUE(is_lacking_properties_response("{\"status\": 1,\"resp\":{}}"));
+  EXPECT_TRUE(
+      is_lacking_properties_response("{\"status\": 1, \"resp\": {}}"));
+}

--- a/tests/cpp/commands_test.cpp
+++ b/tests/cpp/commands_test.cpp
@@ -5,12 +5,16 @@
 #include <string>
 
 using esphome::subzero_protocol::build_display_pin;
+using esphome::subzero_protocol::build_get_all;
 using esphome::subzero_protocol::build_get_async;
+using esphome::subzero_protocol::build_poll_command;
 using esphome::subzero_protocol::build_set;
 using esphome::subzero_protocol::build_set_bool;
 using esphome::subzero_protocol::build_set_int;
 using esphome::subzero_protocol::build_set_string;
 using esphome::subzero_protocol::build_unlock_channel;
+using esphome::subzero_protocol::is_lacking_properties_response;
+using esphome::subzero_protocol::PollVerb;
 
 TEST(Commands, GetAsyncIsExactWireFormat) {
   EXPECT_EQ(build_get_async(), "{\"cmd\":\"get_async\"}\n");
@@ -163,4 +167,44 @@ TEST(Commands, SetEscapesKeyName) {
   // quote/backslash, JSON-escape it rather than emitting broken wire data.
   EXPECT_EQ(build_set_int("a\"b", 1),
             "{\"cmd\":\"set\",\"params\":{\"a\\\"b\":1}}\n");
+}
+
+TEST(Commands, BuildGetAllProducesCanonicalLiteral) {
+  EXPECT_EQ(build_get_all(), "{\"cmd\":\"get_all\"}\n");
+  EXPECT_EQ(build_get_all().back(), '\n');
+}
+
+TEST(Commands, BuildPollCommandSelectsByVerb) {
+  EXPECT_EQ(build_poll_command(PollVerb::kGetAsync), build_get_async());
+  EXPECT_EQ(build_poll_command(PollVerb::kGetAll), build_get_all());
+}
+
+TEST(Commands, IsLackingProperties_ExactSentinel) {
+  EXPECT_TRUE(is_lacking_properties_response(
+      "{\"status\":1,\"resp\":{},\"status_msg\":\"An error occurred\"}\n"));
+}
+
+TEST(Commands, IsLackingProperties_AcceptsWhitespaceVariant) {
+  // Some firmwares may emit a space after the colon — both must trip.
+  EXPECT_TRUE(is_lacking_properties_response("{\"status\":1,\"resp\": {}}"));
+}
+
+TEST(Commands, IsLackingProperties_RejectsStatusZero) {
+  // Successful response — has data in resp, status:0. Must NOT trip.
+  EXPECT_FALSE(is_lacking_properties_response(
+      "{\"status\":0,\"resp\":{\"ref_set_temp\":38}}"));
+}
+
+TEST(Commands, IsLackingProperties_RejectsStatusNonzeroWithData) {
+  EXPECT_FALSE(is_lacking_properties_response(
+      "{\"status\":1,\"resp\":{\"ref_set_temp\":38}}"));
+}
+
+TEST(Commands, IsLackingProperties_RejectsStatus302) {
+  EXPECT_FALSE(is_lacking_properties_response("{\"status\":302,\"resp\":{}}"));
+}
+
+TEST(Commands, IsLackingProperties_RejectsHealthyPushNotification) {
+  EXPECT_FALSE(is_lacking_properties_response(
+      "{\"msg_types\":2,\"seq\":92,\"props\":{\"ref_door_ajar\":true}}"));
 }

--- a/tests/cpp/commands_test.cpp
+++ b/tests/cpp/commands_test.cpp
@@ -5,7 +5,7 @@
 #include <string>
 
 using esphome::subzero_protocol::build_display_pin;
-using esphome::subzero_protocol::build_get_all;
+using esphome::subzero_protocol::build_get;
 using esphome::subzero_protocol::build_get_async;
 using esphome::subzero_protocol::build_poll_command;
 using esphome::subzero_protocol::build_set;
@@ -169,14 +169,19 @@ TEST(Commands, SetEscapesKeyName) {
             "{\"cmd\":\"set\",\"params\":{\"a\\\"b\":1}}\n");
 }
 
-TEST(Commands, BuildGetAllProducesCanonicalLiteral) {
-  EXPECT_EQ(build_get_all(), "{\"cmd\":\"get_all\"}\n");
-  EXPECT_EQ(build_get_all().back(), '\n');
+TEST(Commands, BuildGetProducesCanonicalLiteral) {
+  // {"cmd":"get"}\n — what mwbourgeois empirically tested working on
+  // their IR36550ST per issue #91. NOT one of the 6 verbs the official
+  // app sends over BLE (those are: set, unlock_channel, scan, get_async,
+  // display_pin, reset_air_filter — verified via blutter dump of
+  // libapp.so v4.5.1's BluetoothCommands class).
+  EXPECT_EQ(build_get(), "{\"cmd\":\"get\"}\n");
+  EXPECT_EQ(build_get().back(), '\n');
 }
 
 TEST(Commands, BuildPollCommandSelectsByVerb) {
   EXPECT_EQ(build_poll_command(PollVerb::kGetAsync), build_get_async());
-  EXPECT_EQ(build_poll_command(PollVerb::kGetAll), build_get_all());
+  EXPECT_EQ(build_poll_command(PollVerb::kGet), build_get());
 }
 
 TEST(Commands, IsLackingProperties_ExactSentinel) {

--- a/tests/cpp/commands_test.cpp
+++ b/tests/cpp/commands_test.cpp
@@ -13,6 +13,7 @@ using esphome::subzero_protocol::build_set_bool;
 using esphome::subzero_protocol::build_set_int;
 using esphome::subzero_protocol::build_set_string;
 using esphome::subzero_protocol::build_unlock_channel;
+using esphome::subzero_protocol::has_status_value;
 using esphome::subzero_protocol::is_lacking_properties_response;
 using esphome::subzero_protocol::PollVerb;
 
@@ -162,19 +163,11 @@ TEST(Commands, SetTerminatesWithNewline) {
 }
 
 TEST(Commands, SetEscapesKeyName) {
-  // Defensive: keys come from C++ string literals in our code, so this
-  // shouldn't fire in practice. But if a key name ever did contain a
-  // quote/backslash, JSON-escape it rather than emitting broken wire data.
   EXPECT_EQ(build_set_int("a\"b", 1),
             "{\"cmd\":\"set\",\"params\":{\"a\\\"b\":1}}\n");
 }
 
 TEST(Commands, BuildGetProducesCanonicalLiteral) {
-  // {"cmd":"get"}\n — what mwbourgeois empirically tested working on
-  // their IR36550ST per issue #91. NOT one of the 6 verbs the official
-  // app sends over BLE (those are: set, unlock_channel, scan, get_async,
-  // display_pin, reset_air_filter — verified via blutter dump of
-  // libapp.so v4.5.1's BluetoothCommands class).
   EXPECT_EQ(build_get(), "{\"cmd\":\"get\"}\n");
   EXPECT_EQ(build_get().back(), '\n');
 }
@@ -225,4 +218,40 @@ TEST(Commands, IsLackingProperties_AcceptsWhitespaceAfterColon) {
   // some firmwares may emit `"status": 1` with a space after the colon
   EXPECT_TRUE(is_lacking_properties_response("{\"status\": 1,\"resp\":{}}"));
   EXPECT_TRUE(is_lacking_properties_response("{\"status\": 1, \"resp\": {}}"));
+}
+
+TEST(Commands, HasStatusValue_ZeroExactMatch) {
+  EXPECT_TRUE(has_status_value("{\"status\":0,\"resp\":{}}", '0'));
+  EXPECT_TRUE(has_status_value("{\"status\":0}", '0'));
+}
+
+TEST(Commands, HasStatusValue_ZeroAcceptsWhitespace) {
+  // Tab and space variants between the colon and the value.
+  EXPECT_TRUE(has_status_value("{\"status\": 0,\"resp\":{}}", '0'));
+  EXPECT_TRUE(has_status_value("{\"status\":\t0,\"resp\":{}}", '0'));
+}
+
+TEST(Commands, HasStatusValue_ZeroRejectsLargerNumber) {
+  // The killer case: 0 followed by another digit must NOT match.
+  EXPECT_FALSE(has_status_value("{\"status\":01,\"resp\":{}}", '0'));
+  EXPECT_FALSE(has_status_value("{\"status\":09,\"resp\":{}}", '0'));
+  EXPECT_FALSE(has_status_value("{\"status\":01234}", '0'));
+}
+
+TEST(Commands, HasStatusValue_ZeroRejectsPushNotification) {
+  // Push notifications never have a top-level "status" field.
+  EXPECT_FALSE(has_status_value(
+      "{\"msg_types\":2,\"seq\":1,\"props\":{\"door_ajar\":true}}", '0'));
+  EXPECT_FALSE(has_status_value(
+      "{\"diagnostic_status\":\"0x123\",\"msg_types\":1,\"seq\":1}", '0'));
+}
+
+TEST(Commands, HasStatusValue_DigitParameterDistinguishesValues) {
+  // Same message: status:1 matches digit '1' but not '0', and vice versa.
+  const std::string m1 = "{\"status\":1,\"resp\":{}}";
+  EXPECT_TRUE(has_status_value(m1, '1'));
+  EXPECT_FALSE(has_status_value(m1, '0'));
+  const std::string m0 = "{\"status\":0,\"resp\":{\"foo\":1}}";
+  EXPECT_TRUE(has_status_value(m0, '0'));
+  EXPECT_FALSE(has_status_value(m0, '1'));
 }

--- a/tests/cpp/commands_test.cpp
+++ b/tests/cpp/commands_test.cpp
@@ -218,13 +218,11 @@ TEST(Commands, IsLackingProperties_RejectsStatusWithDigitSuffix) {
   EXPECT_FALSE(is_lacking_properties_response("{\"status\":10,\"resp\":{}}"));
   EXPECT_FALSE(is_lacking_properties_response("{\"status\":11,\"resp\":{}}"));
   EXPECT_FALSE(is_lacking_properties_response("{\"status\":100,\"resp\":{}}"));
-  EXPECT_FALSE(
-      is_lacking_properties_response("{\"status\":1234,\"resp\":{}}"));
+  EXPECT_FALSE(is_lacking_properties_response("{\"status\":1234,\"resp\":{}}"));
 }
 
 TEST(Commands, IsLackingProperties_AcceptsWhitespaceAfterColon) {
   // some firmwares may emit `"status": 1` with a space after the colon
   EXPECT_TRUE(is_lacking_properties_response("{\"status\": 1,\"resp\":{}}"));
-  EXPECT_TRUE(
-      is_lacking_properties_response("{\"status\": 1, \"resp\": {}}"));
+  EXPECT_TRUE(is_lacking_properties_response("{\"status\": 1, \"resp\": {}}"));
 }

--- a/tests/cpp/hub_test.cpp
+++ b/tests/cpp/hub_test.cpp
@@ -375,10 +375,12 @@ TEST_F(HubFixture, PeriodicPoll_ZombieDetection_ReconnectsAfterThreeMisses) {
 // Notify + parse path
 // =============================================================================
 
-TEST_F(HubFixture, D5Notify_OnlyResetsZombieFlag) {
+TEST_F(HubFixture, D5Notify_DoesNotTouchPollOkOrBuffer) {
   std::uint8_t bytes[] = {'p', 'u', 's', 'h'};
   hub_.handle_d5_notify(bytes, sizeof(bytes));
-  EXPECT_TRUE(hub_.poll_ok());
+  EXPECT_FALSE(hub_.poll_ok())
+      << "D5 indications must not flip poll_ok_ — only successful POLL "
+         "RESPONSES on D6 (status:0) reset the zombie counter.";
   // D5 must NOT trigger parse_and_dispatch_ — buffer is for D6 only.
   EXPECT_FALSE(hub_.parse_called_);
 }
@@ -767,14 +769,6 @@ TEST_F(HubFixture, PeriodicPoll_UsesCurrentVerb) {
   hub_.do_periodic_poll();
   EXPECT_TRUE(transport_.wrote_command_to(hub_.d6_handle(), "\"get\"}"));
 }
-
-// =============================================================================
-// poll_ok_ semantics — must distinguish poll responses (full state) from
-// push notifications. The fw 8.5 silent-poll case keeps pushing
-// diagnostic_status (msg_types:1) every minute or so; if those reset
-// poll_miss_ the zombie detector never triggers, and we never reconnect
-// to refresh full state. See live log analysis 2026-05-01 (issue #91 thread).
-// =============================================================================
 
 namespace {
 

--- a/tests/cpp/hub_test.cpp
+++ b/tests/cpp/hub_test.cpp
@@ -702,34 +702,35 @@ TEST_F(HubFixture, LackingProperties_FlipsVerbAndSchedulesRetry) {
 
   feed_message(hub_, kLackingPropertiesSentinel);
 
-  EXPECT_EQ(hub_.poll_verb(), esphome::subzero_protocol::PollVerb::kGetAll);
-  EXPECT_TRUE(any_status_contains("get_all"));
+  EXPECT_EQ(hub_.poll_verb(), esphome::subzero_protocol::PollVerb::kGet);
+  EXPECT_TRUE(any_status_contains("get"));
   EXPECT_EQ(transport_.write_count(), writes_before)
       << "Retry must be deferred via scheduler — not written inline.";
   scheduler_.advance_by(1100); // > kVerbFallbackRetryDelayMs (1000)
-  EXPECT_TRUE(transport_.wrote_command_to(hub_.d6_handle(), "get_all"))
+  EXPECT_TRUE(transport_.wrote_command_to(hub_.d6_handle(), "\"get\"}"))
       << "After the verb-fallback retry timer fires, hub must write "
-         "{\"cmd\":\"get_all\"} to D6.";
+         "{\"cmd\":\"get\"} to D6 (the verb empirically confirmed working "
+         "on IR36550ST per issue #91).";
 }
 
-TEST_F(HubFixture, LackingProperties_LatchesOnGetAll) {
+TEST_F(HubFixture, LackingProperties_LatchesOnGet) {
   hub_.set_stored_pin("12345");
   run_to_ready_();
 
   hub_.parse_should_succeed_ = false;
   feed_message(hub_, kLackingPropertiesSentinel);
-  ASSERT_EQ(hub_.poll_verb(), esphome::subzero_protocol::PollVerb::kGetAll);
+  ASSERT_EQ(hub_.poll_verb(), esphome::subzero_protocol::PollVerb::kGet);
   scheduler_.advance_by(1100);
   transport_.clear_writes();
   hub_.parse_should_succeed_ = true;
   feed_message(hub_, "{\"status\":0,\"resp\":{\"ref_set_temp\":38}}\n");
-  EXPECT_EQ(hub_.poll_verb(), esphome::subzero_protocol::PollVerb::kGetAll);
+  EXPECT_EQ(hub_.poll_verb(), esphome::subzero_protocol::PollVerb::kGet);
 
-  // And the next periodic_poll must use get_all.
+  // Subsequent periodic_poll must use get, not get_async.
   hub_.do_periodic_poll();
-  EXPECT_TRUE(transport_.wrote_command_to(hub_.d6_handle(), "get_all"));
+  EXPECT_TRUE(transport_.wrote_command_to(hub_.d6_handle(), "\"get\"}"));
   EXPECT_FALSE(transport_.wrote_command_to(hub_.d6_handle(), "get_async"))
-      << "After latching, periodic poll must use get_all exclusively.";
+      << "After latching, periodic poll must use get exclusively.";
 }
 
 TEST_F(HubFixture, LackingProperties_SecondHitDoesNotPingPongVerb) {
@@ -738,20 +739,20 @@ TEST_F(HubFixture, LackingProperties_SecondHitDoesNotPingPongVerb) {
   hub_.parse_should_succeed_ = false;
 
   feed_message(hub_, kLackingPropertiesSentinel);
-  EXPECT_EQ(hub_.poll_verb(), esphome::subzero_protocol::PollVerb::kGetAll);
+  EXPECT_EQ(hub_.poll_verb(), esphome::subzero_protocol::PollVerb::kGet);
   scheduler_.advance_by(1100);
 
-  // Second hit — get_all also failed.
+  // Second hit — `get` also failed.
   feed_message(hub_, kLackingPropertiesSentinel);
-  EXPECT_EQ(hub_.poll_verb(), esphome::subzero_protocol::PollVerb::kGetAll)
-      << "Verb must stay at kGetAll on repeated sentinel responses — no "
+  EXPECT_EQ(hub_.poll_verb(), esphome::subzero_protocol::PollVerb::kGet)
+      << "Verb must stay at kGet on repeated sentinel responses — no "
          "ping-pong back to kGetAsync.";
 }
 
 TEST_F(HubFixture, ResetPairing_RestoresDefaultVerb) {
   hub_.set_stored_pin("12345");
   run_to_ready_();
-  hub_.set_poll_verb(esphome::subzero_protocol::PollVerb::kGetAll);
+  hub_.set_poll_verb(esphome::subzero_protocol::PollVerb::kGet);
 
   hub_.press_reset_pairing();
   EXPECT_EQ(hub_.poll_verb(), esphome::subzero_protocol::PollVerb::kGetAsync);
@@ -765,8 +766,8 @@ TEST_F(HubFixture, PeriodicPoll_UsesCurrentVerb) {
   hub_.do_periodic_poll();
   EXPECT_TRUE(transport_.wrote_command_to(hub_.d6_handle(), "get_async"));
 
-  hub_.set_poll_verb(esphome::subzero_protocol::PollVerb::kGetAll);
+  hub_.set_poll_verb(esphome::subzero_protocol::PollVerb::kGet);
   transport_.clear_writes();
   hub_.do_periodic_poll();
-  EXPECT_TRUE(transport_.wrote_command_to(hub_.d6_handle(), "get_all"));
+  EXPECT_TRUE(transport_.wrote_command_to(hub_.d6_handle(), "\"get\"}"));
 }

--- a/tests/cpp/hub_test.cpp
+++ b/tests/cpp/hub_test.cpp
@@ -674,3 +674,99 @@ TEST(SubzeroHubLogDataKeys, DebugModeOn_BaseCompletesWithoutError) {
   h.log_data_keys_({"a", "b"});
   EXPECT_EQ(h.invocations_, 1);
 }
+
+namespace {
+
+// 56-byte sentinel from the user's IR36550ST in issue #91.
+constexpr const char *kLackingPropertiesSentinel =
+    "{\"status\":1,\"resp\":{},\"status_msg\":\"An error occurred\"}\n";
+
+void feed_message(SubzeroHub &hub, const std::string &payload) {
+  hub.handle_d6_notify(reinterpret_cast<const std::uint8_t *>(payload.data()),
+                       payload.size());
+}
+
+} // namespace
+
+TEST_F(HubFixture, PollVerb_DefaultsToGetAsync) {
+  EXPECT_EQ(hub_.poll_verb(), esphome::subzero_protocol::PollVerb::kGetAsync);
+}
+
+TEST_F(HubFixture, LackingProperties_FlipsVerbAndSchedulesRetry) {
+  hub_.set_stored_pin("12345");
+  run_to_ready_();
+  ASSERT_GT(hub_.d6_handle(), 0);
+
+  hub_.parse_should_succeed_ = false;
+  std::size_t writes_before = transport_.write_count();
+
+  feed_message(hub_, kLackingPropertiesSentinel);
+
+  EXPECT_EQ(hub_.poll_verb(), esphome::subzero_protocol::PollVerb::kGetAll);
+  EXPECT_TRUE(any_status_contains("get_all"));
+  EXPECT_EQ(transport_.write_count(), writes_before)
+      << "Retry must be deferred via scheduler — not written inline.";
+  scheduler_.advance_by(1100); // > kVerbFallbackRetryDelayMs (1000)
+  EXPECT_TRUE(transport_.wrote_command_to(hub_.d6_handle(), "get_all"))
+      << "After the verb-fallback retry timer fires, hub must write "
+         "{\"cmd\":\"get_all\"} to D6.";
+}
+
+TEST_F(HubFixture, LackingProperties_LatchesOnGetAll) {
+  hub_.set_stored_pin("12345");
+  run_to_ready_();
+
+  hub_.parse_should_succeed_ = false;
+  feed_message(hub_, kLackingPropertiesSentinel);
+  ASSERT_EQ(hub_.poll_verb(), esphome::subzero_protocol::PollVerb::kGetAll);
+  scheduler_.advance_by(1100);
+  transport_.clear_writes();
+  hub_.parse_should_succeed_ = true;
+  feed_message(hub_, "{\"status\":0,\"resp\":{\"ref_set_temp\":38}}\n");
+  EXPECT_EQ(hub_.poll_verb(), esphome::subzero_protocol::PollVerb::kGetAll);
+
+  // And the next periodic_poll must use get_all.
+  hub_.do_periodic_poll();
+  EXPECT_TRUE(transport_.wrote_command_to(hub_.d6_handle(), "get_all"));
+  EXPECT_FALSE(transport_.wrote_command_to(hub_.d6_handle(), "get_async"))
+      << "After latching, periodic poll must use get_all exclusively.";
+}
+
+TEST_F(HubFixture, LackingProperties_SecondHitDoesNotPingPongVerb) {
+  hub_.set_stored_pin("12345");
+  run_to_ready_();
+  hub_.parse_should_succeed_ = false;
+
+  feed_message(hub_, kLackingPropertiesSentinel);
+  EXPECT_EQ(hub_.poll_verb(), esphome::subzero_protocol::PollVerb::kGetAll);
+  scheduler_.advance_by(1100);
+
+  // Second hit — get_all also failed.
+  feed_message(hub_, kLackingPropertiesSentinel);
+  EXPECT_EQ(hub_.poll_verb(), esphome::subzero_protocol::PollVerb::kGetAll)
+      << "Verb must stay at kGetAll on repeated sentinel responses — no "
+         "ping-pong back to kGetAsync.";
+}
+
+TEST_F(HubFixture, ResetPairing_RestoresDefaultVerb) {
+  hub_.set_stored_pin("12345");
+  run_to_ready_();
+  hub_.set_poll_verb(esphome::subzero_protocol::PollVerb::kGetAll);
+
+  hub_.press_reset_pairing();
+  EXPECT_EQ(hub_.poll_verb(), esphome::subzero_protocol::PollVerb::kGetAsync);
+}
+
+TEST_F(HubFixture, PeriodicPoll_UsesCurrentVerb) {
+  hub_.set_stored_pin("12345");
+  run_to_ready_();
+  transport_.clear_writes();
+
+  hub_.do_periodic_poll();
+  EXPECT_TRUE(transport_.wrote_command_to(hub_.d6_handle(), "get_async"));
+
+  hub_.set_poll_verb(esphome::subzero_protocol::PollVerb::kGetAll);
+  transport_.clear_writes();
+  hub_.do_periodic_poll();
+  EXPECT_TRUE(transport_.wrote_command_to(hub_.d6_handle(), "get_all"));
+}

--- a/tests/cpp/hub_test.cpp
+++ b/tests/cpp/hub_test.cpp
@@ -6,12 +6,11 @@
 // advanced via FakeScheduler::advance_to().
 
 #include "../../components/subzero_appliance/hub.h"
-
 #include "hub_test_helpers.h"
-
-#include <gtest/gtest.h>
-
+#include "protocol.h"
+#include <algorithm>
 #include <cstring>
+#include <gtest/gtest.h>
 #include <string>
 #include <vector>
 
@@ -590,9 +589,6 @@ TEST_F(HubFixture, PostBondRestart_CancelsPriorPostBond) {
   // the hub must not have rescheduled multiple competing chains.
   EXPECT_LE(scheduler_.pending_count(), pending_before + 1);
 }
-
-#include "protocol.h"
-#include <algorithm>
 
 namespace {
 

--- a/tests/cpp/hub_test.cpp
+++ b/tests/cpp/hub_test.cpp
@@ -771,3 +771,107 @@ TEST_F(HubFixture, PeriodicPoll_UsesCurrentVerb) {
   hub_.do_periodic_poll();
   EXPECT_TRUE(transport_.wrote_command_to(hub_.d6_handle(), "\"get\"}"));
 }
+
+// =============================================================================
+// poll_ok_ semantics — must distinguish poll responses (full state) from
+// push notifications. The fw 8.5 silent-poll case keeps pushing
+// diagnostic_status (msg_types:1) every minute or so; if those reset
+// poll_miss_ the zombie detector never triggers, and we never reconnect
+// to refresh full state. See live log analysis 2026-05-01 (issue #91 thread).
+// =============================================================================
+
+namespace {
+
+// Helper: feed a fully-formed JSON string + trailing newline through the
+// D6 indication path so json_buf_ can detect message completion.
+void feed_complete_d6_(SubzeroHub &hub, const std::string &payload) {
+  std::string with_newline = payload + "\n";
+  hub.handle_d6_notify(
+      reinterpret_cast<const std::uint8_t *>(with_newline.data()),
+      with_newline.size());
+}
+
+} // namespace
+
+TEST_F(HubFixture, PollOk_NotSetByMsgTypes2Push) {
+  hub_.set_stored_pin("12345");
+  run_to_ready_();
+  // After run_to_ready_, subscribe_initial_get_ has set poll_ok_=false
+  // and written get_async. One do_periodic_poll cycle takes miss to 1.
+  hub_.do_periodic_poll();
+  ASSERT_EQ(hub_.poll_miss(), 1);
+
+  // Feed a msg_types:2 push. With the fix, poll_ok_ stays false because
+  // the push has no "status":0.
+  hub_.parse_should_succeed_ = true;
+  feed_complete_d6_(hub_,
+                    R"({"seq":1,"msg_types":2,"props":{"door_ajar":true}})");
+
+  // Next periodic_poll must increment miss (push did NOT reset poll_ok_).
+  hub_.do_periodic_poll();
+  EXPECT_EQ(hub_.poll_miss(), 2)
+      << "poll_miss_ must NOT reset on a msg_types:2 push — only real "
+         "poll responses (status:0) reset the zombie counter. fw 8.5 "
+         "silent-poll detection depends on this.";
+}
+
+TEST_F(HubFixture, PollOk_NotSetByMsgTypes1Push) {
+  hub_.set_stored_pin("12345");
+  run_to_ready_();
+  hub_.do_periodic_poll();
+  ASSERT_EQ(hub_.poll_miss(), 1);
+
+  hub_.parse_should_succeed_ = true;
+  feed_complete_d6_(hub_,
+                    R"({"diagnostic_status":"0x123","msg_types":1,"seq":1})");
+
+  hub_.do_periodic_poll();
+  EXPECT_EQ(hub_.poll_miss(), 2)
+      << "msg_types:1 diagnostic_status pushes must NOT reset the zombie "
+         "counter — fw 8.5 wall ovens emit these continuously while "
+         "get_async goes silent (live log 2026-05-01, issue #91 thread).";
+}
+
+TEST_F(HubFixture, PollOk_SetByActualPollResponse) {
+  hub_.set_stored_pin("12345");
+  run_to_ready_();
+  hub_.do_periodic_poll();
+  ASSERT_EQ(hub_.poll_miss(), 1)
+      << "Test setup: needs poll_miss_ > 0 before feeding the response.";
+
+  hub_.parse_should_succeed_ = true;
+  // Real poll response: status:0 — must reset the zombie counter.
+  feed_complete_d6_(hub_, R"({"status":0,"resp":{"ref_set_temp":38}})");
+
+  hub_.do_periodic_poll();
+  EXPECT_EQ(hub_.poll_miss(), 0)
+      << "poll_miss_ must reset to 0 once a real poll response arrives.";
+}
+
+TEST_F(HubFixture, ZombieDetector_StillFiresWithPushTraffic) {
+  // Direct integration test for the live-log scenario from the issue
+  // #91 thread (Wall Oven SO3050PESP fw 8.5): appliance keeps pushing
+  // msg_types:1 every minute but never answers get_async. The zombie
+  // detector must still trip after 3 silent polls and force a reconnect
+  // — otherwise the appliance state stays frozen on its initial poll
+  // values forever.
+  hub_.set_stored_pin("12345");
+  run_to_ready_();
+  hub_.parse_should_succeed_ = true;
+  std::size_t disc_before = transport_.disconnect_count();
+
+  // Cycle 1: poll fails silently, then push arrives (poll_ok_ stays false)
+  hub_.do_periodic_poll();
+  feed_complete_d6_(hub_,
+                    R"({"diagnostic_status":"0x1","msg_types":1,"seq":1})");
+  // Cycle 2: poll fails silently, push arrives
+  hub_.do_periodic_poll();
+  feed_complete_d6_(hub_,
+                    R"({"diagnostic_status":"0x2","msg_types":1,"seq":2})");
+  // Cycle 3: poll fails silently → miss hits threshold → ZOMBIE FIRES
+  hub_.do_periodic_poll();
+  EXPECT_GT(transport_.disconnect_count(), disc_before)
+      << "Zombie detector must force a reconnect after 3 silent polls "
+         "even when push notifications keep arriving — otherwise the "
+         "fw 8.5 silent-poll case never recovers.";
+}

--- a/tests/cpp/hub_test.cpp
+++ b/tests/cpp/hub_test.cpp
@@ -590,3 +590,87 @@ TEST_F(HubFixture, PostBondRestart_CancelsPriorPostBond) {
   // the hub must not have rescheduled multiple competing chains.
   EXPECT_LE(scheduler_.pending_count(), pending_before + 1);
 }
+
+#include "protocol.h"
+#include <algorithm>
+
+namespace {
+
+class RecordingFridgeLikeHub : public SubzeroHub {
+public:
+  RecordingFridgeLikeHub() = default;
+  bool parse_and_dispatch_(const std::string &msg) override {
+    auto s = esphome::subzero_protocol::parse_fridge(msg);
+    if (!s.valid)
+      return false;
+    log_data_keys_(s.data_keys);
+    return true;
+  }
+
+  void log_data_keys_(const std::vector<std::string> &keys) override {
+    log_calls_.push_back(keys);
+  }
+
+  std::vector<std::vector<std::string>> log_calls_;
+};
+
+class FridgeLikeFixture : public ::testing::Test {
+protected:
+  RecordingFridgeLikeHub hub_;
+};
+
+} // namespace
+
+TEST_F(FridgeLikeFixture, ParseAndDispatch_InvokesLogDataKeysWithParsedKeys) {
+  const std::string msg =
+      R"({"status":0,"resp":{"sabbath_on":false,"ref_set_temp":38,"appliance_model":"DEU2450R"}})";
+
+  bool ok = hub_.parse_and_dispatch_(msg);
+  ASSERT_TRUE(ok);
+
+  ASSERT_EQ(hub_.log_calls_.size(), 1u)
+      << "Subclass parse_and_dispatch_ must call log_data_keys_ exactly "
+         "once per successful parse — if this fires 0 times, the subclass "
+         "dropped the call (regression of the Phase 3 port).";
+
+  const auto &keys = hub_.log_calls_.front();
+  EXPECT_NE(std::find(keys.begin(), keys.end(), "sabbath_on"), keys.end());
+  EXPECT_NE(std::find(keys.begin(), keys.end(), "ref_set_temp"), keys.end());
+  EXPECT_NE(std::find(keys.begin(), keys.end(), "appliance_model"), keys.end());
+  EXPECT_EQ(keys.size(), 3u)
+      << "log_data_keys_ should receive the full data_keys vector from "
+         "the parser, not a subset.";
+}
+
+TEST_F(FridgeLikeFixture, ParseAndDispatch_DoesNotInvokeLogOnParseFailure) {
+  bool ok = hub_.parse_and_dispatch_("not json at all");
+  EXPECT_FALSE(ok);
+  EXPECT_EQ(hub_.log_calls_.size(), 0u);
+}
+
+namespace {
+
+class GuardSpyHub : public SubzeroHub {
+public:
+  bool parse_and_dispatch_(const std::string &) override { return true; }
+  void log_data_keys_(const std::vector<std::string> &keys) override {
+    invocations_++;
+    SubzeroHub::log_data_keys_(keys); // exercises the debug_mode_ guard
+  }
+  int invocations_ = 0;
+};
+
+} // namespace
+
+TEST(SubzeroHubLogDataKeys, NoDebugMode_GuardLetsBaseNoOp) {
+  GuardSpyHub h;
+  h.log_data_keys_({"a", "b", "c"});
+  EXPECT_EQ(h.invocations_, 1);
+}
+
+TEST(SubzeroHubLogDataKeys, DebugModeOn_BaseCompletesWithoutError) {
+  GuardSpyHub h;
+  h.set_debug_mode(true);
+  h.log_data_keys_({"a", "b"});
+  EXPECT_EQ(h.invocations_, 1);
+}

--- a/tests/cpp/lifecycle_guards_test.cpp
+++ b/tests/cpp/lifecycle_guards_test.cpp
@@ -21,7 +21,9 @@ std::string extract_case_body(const std::string &src,
   if (start == std::string::npos)
     return "";
   start += needle.size();
-  auto stop = src.find("break;", start);
+  std::size_t next_case = src.find("\n  case ", start);
+  std::size_t next_default = src.find("\n  default:", start);
+  std::size_t stop = std::min(next_case, next_default);
   if (stop == std::string::npos)
     return src.substr(start);
   return src.substr(start, stop - start);

--- a/tests/cpp/lifecycle_guards_test.cpp
+++ b/tests/cpp/lifecycle_guards_test.cpp
@@ -1,0 +1,76 @@
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace {
+
+std::string read_file(const std::string &path) {
+  std::ifstream in(path);
+  EXPECT_TRUE(in.is_open()) << "Could not open " << path;
+  std::stringstream ss;
+  ss << in.rdbuf();
+  return ss.str();
+}
+
+std::string extract_case_body(const std::string &src,
+                              const std::string &case_label) {
+  std::string needle = "case " + case_label + ":";
+  auto start = src.find(needle);
+  if (start == std::string::npos)
+    return "";
+  start += needle.size();
+  auto stop = src.find("break;", start);
+  if (stop == std::string::npos)
+    return src.substr(start);
+  return src.substr(start, stop - start);
+}
+
+} // namespace
+
+TEST(LifecycleGuards, HubCppGatesLogsOnUseEsp32) {
+  std::string src = read_file(std::string(APPLIANCE_DIR) + "/hub.cpp");
+
+  // Must use USE_ESP32 — the on-device sentinel. ESPHome's build
+  // defines this; the host gtest build does not.
+  EXPECT_NE(src.find("#ifdef USE_ESP32"), std::string::npos)
+      << "hub.cpp must gate the on-device log macros on USE_ESP32 — see "
+         "tests/cpp/lifecycle_guards_test.cpp";
+
+  EXPECT_EQ(src.find("#ifdef ESPHOME_LOG_HAS_INFO"), std::string::npos)
+      << "hub.cpp must NOT gate on ESPHOME_LOG_HAS_INFO — that symbol "
+         "is defined inside esphome/core/log.h and the #ifdef would "
+         "silently turn HUB_LOGI/W/E/D into no-ops on device. Use "
+         "USE_ESP32 instead.";
+}
+
+TEST(LifecycleGuards, ApplianceBaseRoutesConnectFromSearchCmpl) {
+  std::string src =
+      read_file(std::string(APPLIANCE_DIR) + "/appliance_base.cpp");
+
+  std::string search_cmpl_body =
+      extract_case_body(src, "ESP_GATTC_SEARCH_CMPL_EVT");
+  ASSERT_FALSE(search_cmpl_body.empty())
+      << "appliance_base.cpp must have a `case ESP_GATTC_SEARCH_CMPL_EVT:` "
+         "arm in gattc_event_handler";
+  EXPECT_NE(search_cmpl_body.find("handle_connected()"), std::string::npos)
+      << "appliance_base.cpp's ESP_GATTC_SEARCH_CMPL_EVT arm must call "
+         "h->handle_connected() — that's when subscribe is safe to fire.";
+}
+
+TEST(LifecycleGuards, ApplianceBaseDoesNotRouteConnectFromOpenEvt) {
+  std::string src =
+      read_file(std::string(APPLIANCE_DIR) + "/appliance_base.cpp");
+
+  std::string open_body = extract_case_body(src, "ESP_GATTC_OPEN_EVT");
+  ASSERT_FALSE(open_body.empty())
+      << "appliance_base.cpp must have a `case ESP_GATTC_OPEN_EVT:` arm";
+  EXPECT_EQ(open_body.find("handle_connected()"), std::string::npos)
+      << "appliance_base.cpp's ESP_GATTC_OPEN_EVT arm must NOT call "
+         "h->handle_connected(). The GATT cache isn't populated until "
+         "SEARCH_CMPL — calling subscribe earlier silently no-ops the "
+         "register_for_notify / CCCD writes and the appliance never "
+         "sends data back. Hook handle_connected() to "
+         "ESP_GATTC_SEARCH_CMPL_EVT instead.";
+}

--- a/tests/cpp/protocol_test.cpp
+++ b/tests/cpp/protocol_test.cpp
@@ -354,10 +354,6 @@ TEST(ProtocolTest, IsPollAcrossAllThreeParsers) {
   EXPECT_FALSE(parse_range(R"({"seq":1,"props":{},"msg_types":2})").is_poll);
 }
 
-// msg_types:1 — a "diagnostic_status changed" push that arrives with
-// fields at the ROOT level (no resp/props wrapper). Observed on Wolf
-// SO3050PESP fw 8.5; previously dropped as a parse failure (which also
-// spammed the warning log every cycle).
 TEST(ProtocolTest, MsgTypes1PushExtractsDiagnosticStatus) {
   const std::string msg =
       R"({"diagnostic_status":"0x00000301111","msg_types":1,)"
@@ -370,16 +366,25 @@ TEST(ProtocolTest, MsgTypes1PushExtractsDiagnosticStatus) {
 }
 
 TEST(ProtocolTest, MsgTypes1PushAcrossAllParsers) {
-  // The msg_types:1 shape is appliance-agnostic — all three parsers
-  // must extract diagnostic_status.
   const std::string msg =
       R"({"diagnostic_status":"0x12345","msg_types":1,"seq":1})";
-  EXPECT_TRUE(parse_fridge(msg).valid);
-  EXPECT_TRUE(parse_dishwasher(msg).valid);
-  EXPECT_TRUE(parse_range(msg).valid);
-  EXPECT_FALSE(parse_fridge(msg).is_poll);
-  EXPECT_FALSE(parse_dishwasher(msg).is_poll);
-  EXPECT_FALSE(parse_range(msg).is_poll);
+  auto f = parse_fridge(msg);
+  auto d = parse_dishwasher(msg);
+  auto r = parse_range(msg);
+
+  ASSERT_TRUE(f.valid);
+  ASSERT_TRUE(d.valid);
+  ASSERT_TRUE(r.valid);
+  EXPECT_FALSE(f.is_poll);
+  EXPECT_FALSE(d.is_poll);
+  EXPECT_FALSE(r.is_poll);
+
+  ASSERT_TRUE(f.common.diagnostic_status.has_value());
+  ASSERT_TRUE(d.common.diagnostic_status.has_value());
+  ASSERT_TRUE(r.common.diagnostic_status.has_value());
+  EXPECT_EQ(*f.common.diagnostic_status, "0x12345");
+  EXPECT_EQ(*d.common.diagnostic_status, "0x12345");
+  EXPECT_EQ(*r.common.diagnostic_status, "0x12345");
 }
 
 TEST(ProtocolTest, DataKeysCapturedInOrder) {

--- a/tests/cpp/protocol_test.cpp
+++ b/tests/cpp/protocol_test.cpp
@@ -354,6 +354,34 @@ TEST(ProtocolTest, IsPollAcrossAllThreeParsers) {
   EXPECT_FALSE(parse_range(R"({"seq":1,"props":{},"msg_types":2})").is_poll);
 }
 
+// msg_types:1 — a "diagnostic_status changed" push that arrives with
+// fields at the ROOT level (no resp/props wrapper). Observed on Wolf
+// SO3050PESP fw 8.5; previously dropped as a parse failure (which also
+// spammed the warning log every cycle).
+TEST(ProtocolTest, MsgTypes1PushExtractsDiagnosticStatus) {
+  const std::string msg =
+      R"({"diagnostic_status":"0x00000301111","msg_types":1,)"
+      R"("seq":475,"timestamp":"2026-05-01T23:08:02-05:00"})";
+  auto f = parse_fridge(msg);
+  ASSERT_TRUE(f.valid);
+  EXPECT_FALSE(f.is_poll);
+  ASSERT_TRUE(f.common.diagnostic_status.has_value());
+  EXPECT_EQ(*f.common.diagnostic_status, "0x00000301111");
+}
+
+TEST(ProtocolTest, MsgTypes1PushAcrossAllParsers) {
+  // The msg_types:1 shape is appliance-agnostic — all three parsers
+  // must extract diagnostic_status.
+  const std::string msg =
+      R"({"diagnostic_status":"0x12345","msg_types":1,"seq":1})";
+  EXPECT_TRUE(parse_fridge(msg).valid);
+  EXPECT_TRUE(parse_dishwasher(msg).valid);
+  EXPECT_TRUE(parse_range(msg).valid);
+  EXPECT_FALSE(parse_fridge(msg).is_poll);
+  EXPECT_FALSE(parse_dishwasher(msg).is_poll);
+  EXPECT_FALSE(parse_range(msg).is_poll);
+}
+
 TEST(ProtocolTest, DataKeysCapturedInOrder) {
   auto f = parse_fridge(
       R"({"status":0,"resp":{"ref_set_temp":38,"ice_maker_on":true,"appliance_model":"2028"}})");

--- a/tests/fixtures/range_lacking_properties_d6.expected.json
+++ b/tests/fixtures/range_lacking_properties_d6.expected.json
@@ -1,0 +1,3 @@
+{
+  "valid": false
+}

--- a/tests/fixtures/range_lacking_properties_d6.json
+++ b/tests/fixtures/range_lacking_properties_d6.json
@@ -1,1 +1,5 @@
-{"status":1,"resp":{},"status_msg":"An error occurred"}
+{
+  "status": 1,
+  "resp": {},
+  "status_msg": "An error occurred"
+}

--- a/tests/fixtures/range_lacking_properties_d6.json
+++ b/tests/fixtures/range_lacking_properties_d6.json
@@ -1,0 +1,1 @@
+{"status":1,"resp":{},"status_msg":"An error occurred"}

--- a/tests/fixtures/range_push_msg_types_1_diagnostic_status.expected.json
+++ b/tests/fixtures/range_push_msg_types_1_diagnostic_status.expected.json
@@ -1,0 +1,6 @@
+{
+  "valid": true,
+  "common": {
+    "diagnostic_status": "0x00000301111"
+  }
+}

--- a/tests/fixtures/range_push_msg_types_1_diagnostic_status.json
+++ b/tests/fixtures/range_push_msg_types_1_diagnostic_status.json
@@ -1,0 +1,6 @@
+{
+  "diagnostic_status": "0x00000301111",
+  "msg_types": 1,
+  "seq": 475,
+  "timestamp": "2026-05-01T23:08:02.260-05:00"
+}


### PR DESCRIPTION
debug log button regression happened somewhere around the recent massive refactor. fix debug so that when a user presses `log debug output`, it turns on debug before disconnecting the appliance AND also try to log all the keys as well also, fixed a connection logic issue that roughly worked as followed:

`register_for_notify` no-ops against an empty GATT cache. fridge never learns we want indications then, CCCD writes log the `status=10` warning and proceed without enabling indications. the unlock_channel and get_async writes go out but the response notifications are never delivered to us (the appliance sends them, but bluedroid drops them — we're not actually subscribed) Status sensor is inaccurate: it says "Connected and polling." but no data flows except push data..... occasionally? 3 minutes later, kZombiePollMissThreshold trips and we force-reconnect, then that would Repeat forever

also lint+format appliance init python

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Waits for service discovery before confirming BLE connections.
  * Ensures debug-switch state is synchronized to avoid racey publishes after disconnects.
  * Zombie-poll detection ignores push notifications and only resets on true poll responses.
  * Poll fallback retries are canceled on disconnect/reset.

* **New Features**
  * Polling supports two verbs (async vs fallback), latched per-device on sentinel responses with deferred retry.
  * Per-message parsed data-keys logging for debugging.
  * Parsers accept additional push-notification formats (diagnostic_status/msg_types).

* **Documentation**
  * Protocol docs updated with poll-verb semantics, sentinel response, push-notification distinctions, and polling/zombie behavior.

* **Tests**
  * New/expanded tests covering poll-verb behavior, sentinel detection, parsing/logging, and lifecycle/logging guards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->