### PR TITLE
Add notif_type → event mapping for BLE push notifications

### DIFF
--- a/components/subzero_protocol/protocol.cpp
+++ b/components/subzero_protocol/protocol.cpp
@@ -141,6 +141,21 @@ FridgeState parse_fridge(const std::string &json) {
   state.is_poll = is_poll;
   capture_keys(data, state.data_keys);
   fill_common(data, state.common);
+  auto notif_type = opt_int(data["notif_type"]);
+
+  if (notif_type) {
+    switch (*notif_type) {
+      case 108:
+        state.notif_event = "fridge_door_open";
+        break;
+      case 109:
+        state.notif_event = "freezer_door_open";
+        break;
+      
+      default:
+        break;
+    }
+  }
 
   // Setpoint with freezer-only fallback.
   if (data["ref_set_temp"].is<float>()) {
@@ -187,6 +202,20 @@ DishwasherState parse_dishwasher(const std::string &json) {
   state.is_poll = is_poll;
   capture_keys(data, state.data_keys);
   fill_common(data, state.common);
+  auto notif_type = opt_int(data["notif_type"]);
+
+  if (notif_type) {
+    switch (*notif_type) {
+      case 301:
+        state.notif_event = "dishwasher_cycle_complete";
+        break;
+      case 302:
+        state.notif_event = "dishwasher_event_302";
+        break;
+      default:
+        break;
+    }
+  }  
 
   state.door_ajar = opt_bool(data["door_ajar"]);
   state.wash_cycle_on = opt_bool(data["wash_cycle_on"]);
@@ -233,7 +262,35 @@ RangeState parse_range(const std::string &json) {
   state.is_poll = is_poll;
   capture_keys(data, state.data_keys);
   fill_common(data, state.common);
+  auto notif_type = opt_int(data["notif_type"]);
 
+  if (notif_type) {
+    switch (*notif_type) {
+      case 201:
+        state.notif_event = "oven_preheat_complete";
+        break;
+      case 207:
+        state.notif_event = "timer_ended";
+        break;
+      case 208:
+        state.notif_event = "timer2_ended";
+        break;
+      case 209:
+        state.notif_event = "timer_1min_remaining";
+        break;
+      case 210:
+        state.notif_event = "timer2_1min_remaining";
+        break;
+      case 215:
+        state.notif_event = "oven_event_215";
+        break;
+      case 218:
+        state.notif_event = "oven_event_218";
+        break;
+      default:
+        break;
+    }
+  }
   // Door with generic fallback.
   if (data["cav_door_ajar"].is<bool>()) {
     state.door_ajar = data["cav_door_ajar"].as<bool>();

--- a/components/subzero_protocol/protocol.cpp
+++ b/components/subzero_protocol/protocol.cpp
@@ -207,10 +207,10 @@ DishwasherState parse_dishwasher(const std::string &json) {
   if (notif_type) {
     switch (*notif_type) {
       case 301:
-        state.notif_event = "dishwasher_cycle_complete";
+        state.notif_event = "dishwasher_cycle_started";
         break;
       case 302:
-        state.notif_event = "dishwasher_event_302";
+        state.notif_event = "dishwasher_cycle_complete";
         break;
       default:
         break;


### PR DESCRIPTION
Adds mapping from notif_type integers to human-readable event names
in fridge, dishwasher, and range parsers.

Mappings are based on observed BLE push logs and issue discussion.

This enables higher-level integrations (e.g., Home Assistant events).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Enhanced appliance event notifications with improved recognition for refrigerator door status (open/close)
  - Added dishwasher cycle event notifications (start and completion)
  - Expanded range/oven event detection including timer-related notifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->