### PR TITLE
feat: map BLE notif_type pushes to Notification Event sensor

### DIFF
--- a/components/subzero_appliance/__init__.py
+++ b/components/subzero_appliance/__init__.py
@@ -216,6 +216,12 @@ COMMON_TEXT_SENSORS = [
             CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC,
         },
     ),
+    (
+        "notif_event",
+        "Notification Event",
+        "set_notif_event_sensor",
+        {CONF_ICON: "mdi:bell-ring"},
+    ),
 ]
 
 # Buttons — same across all appliance types.

--- a/components/subzero_appliance/appliance_base.h
+++ b/components/subzero_appliance/appliance_base.h
@@ -97,6 +97,9 @@ public:
   void set_board_version_sensor(esphome::text_sensor::TextSensor *s) {
     common_bus()->board_version = s;
   }
+  void set_notif_event_sensor(esphome::text_sensor::TextSensor *s) {
+    common_bus()->notif_event = s;
+  }
 
   // ---- ESPHome lifecycle ----
 

--- a/components/subzero_protocol/dispatch.h
+++ b/components/subzero_protocol/dispatch.h
@@ -62,6 +62,8 @@ inline void dispatch_common(const CommonFields &c, Bus &bus) {
 template <typename Bus>
 inline void dispatch_fridge(const FridgeState &s, Bus &bus) {
   dispatch_common(s.common, bus);
+  if (s.notif_event)
+    bus.publish_notif_event(*s.notif_event);
   // Fridge / Freezer
   if (s.ref_set_temp)
     bus.publish_set_temp(*s.ref_set_temp);
@@ -107,6 +109,8 @@ inline void dispatch_fridge(const FridgeState &s, Bus &bus) {
 template <typename Bus>
 inline void dispatch_dishwasher(const DishwasherState &s, Bus &bus) {
   dispatch_common(s.common, bus);
+  if (s.notif_event)
+    bus.publish_notif_event(*s.notif_event);
   if (s.door_ajar)
     bus.publish_door_ajar(*s.door_ajar);
   if (s.wash_cycle_on)
@@ -148,6 +152,8 @@ inline void dispatch_dishwasher(const DishwasherState &s, Bus &bus) {
 template <typename Bus>
 inline void dispatch_range(const RangeState &s, Bus &bus) {
   dispatch_common(s.common, bus);
+  if (s.notif_event)
+    bus.publish_notif_event(*s.notif_event);
   if (s.door_ajar)
     bus.publish_door_ajar(*s.door_ajar);
   // Primary cavity

--- a/components/subzero_protocol/dispatch_esphome.h
+++ b/components/subzero_protocol/dispatch_esphome.h
@@ -74,6 +74,10 @@ struct CommonBus {
   esphome::text_sensor::TextSensor *os_version = nullptr;
   esphome::text_sensor::TextSensor *rtapp_version = nullptr;
   esphome::text_sensor::TextSensor *board_version = nullptr;
+  // Latest notif_type → human-readable event name (e.g. "fridge_door_open").
+  // Updated only on push messages that carry a notif_type; HA automations
+  // can trigger on state-changes here.
+  esphome::text_sensor::TextSensor *notif_event = nullptr;
 
   void publish_sabbath_on(bool v) { detail::publish_if(sabbath_on, v); }
   void publish_svc_required(bool v) { detail::publish_if(svc_required, v); }
@@ -106,6 +110,9 @@ struct CommonBus {
   }
   void publish_board_version(const std::string &v) {
     detail::publish_if(board_version, v);
+  }
+  void publish_notif_event(const std::string &v) {
+    detail::publish_if(notif_event, v);
   }
 };
 

--- a/components/subzero_protocol/protocol.cpp
+++ b/components/subzero_protocol/protocol.cpp
@@ -66,6 +66,94 @@ JsonObjectConst extract_data(JsonObjectConst root, bool &is_poll) {
   return JsonObjectConst();
 }
 
+// Format the unknown-code fallback used when notif_type is present but not
+// recognized by the per-appliance mapping. Surfaces the raw integer to HA
+// (as e.g. "fridge_event_142") so users can observe and report new codes
+// without us hard-coding a placeholder name.
+std::string unknown_notif_event(const char *appliance, int notif_type) {
+  char buf[40];
+  std::snprintf(buf, sizeof(buf), "%s_event_%d", appliance, notif_type);
+  return buf;
+}
+
+// notif_type → human-readable event name. Mappings come from issue #69
+// debug captures, cross-referenced against the official Sub-Zero iOS app's
+// push notification text. Codes not in the table fall through to
+// "<appliance>_event_<n>" so unknown codes are still observable.
+std::optional<std::string> fridge_notif_event(JsonObjectConst root) {
+  auto t = opt_int(root["notif_type"]);
+  if (!t)
+    return std::nullopt;
+  switch (*t) {
+  case 101:
+    return std::string("fridge_door_open");
+  case 102:
+    return std::string("freezer_door_open");
+  case 106:
+    return std::string("fridge_setpoint_changed");
+  case 107:
+    return std::string("freezer_setpoint_changed");
+  case 108:
+    return std::string("water_filter_expired");
+  case 109:
+    return std::string("air_filter_expired");
+  default:
+    return unknown_notif_event("fridge", *t);
+  }
+}
+
+std::optional<std::string> dishwasher_notif_event(JsonObjectConst root) {
+  auto t = opt_int(root["notif_type"]);
+  if (!t)
+    return std::nullopt;
+  switch (*t) {
+  case 301:
+    return std::string("wash_cycle_started");
+  case 302:
+    return std::string("wash_cycle_complete");
+  case 304:
+    return std::string("rinse_aid_low");
+  case 306:
+    return std::string("wash_cycle_interrupted");
+  case 307:
+    return std::string("wash_cycle_cancelled");
+  default:
+    return unknown_notif_event("dishwasher", *t);
+  }
+}
+
+std::optional<std::string> range_notif_event(JsonObjectConst root) {
+  auto t = opt_int(root["notif_type"]);
+  if (!t)
+    return std::nullopt;
+  switch (*t) {
+  case 201:
+    return std::string("oven_preheat_complete");
+  case 203:
+    return std::string("oven_probe_in_use");
+  case 205:
+    return std::string("oven_probe_temp_reached");
+  case 207:
+    return std::string("kitchen_timer_ended");
+  case 208:
+    return std::string("kitchen_timer2_ended");
+  case 209:
+    return std::string("kitchen_timer_1min_remaining");
+  case 210:
+    return std::string("kitchen_timer2_1min_remaining");
+  case 211:
+    return std::string("timed_cook_ended");
+  case 213:
+    return std::string("timed_cook_1min_remaining");
+  case 215:
+    return std::string("oven_probe_within_10deg");
+  case 218:
+    return std::string("oven_door_opened");
+  default:
+    return unknown_notif_event("range", *t);
+  }
+}
+
 void fill_version(JsonObjectConst v, Version &out) {
   out.fw = opt_str(v["fw"]);
   out.api = opt_str(v["api"]);
@@ -133,12 +221,26 @@ FridgeState parse_fridge(const std::string &json) {
     return state;
   if (!doc.is<JsonObject>())
     return state;
+  JsonObjectConst root = doc.as<JsonObjectConst>();
+  // Extract notif_event from root first — `notif_type` lives at the root of
+  // push messages, alongside `seq`/`timestamp`, NOT inside `props`.
+  auto notif_event = fridge_notif_event(root);
   bool is_poll = true;
-  JsonObjectConst data = extract_data(doc.as<JsonObjectConst>(), is_poll);
-  if (data.isNull())
+  JsonObjectConst data = extract_data(root, is_poll);
+  if (data.isNull()) {
+    // msg_types:4 notification-only push: no `props`/`resp`, just notif_type
+    // at root. Mark valid so the bus can publish the event; leave data
+    // fields empty.
+    if (notif_event) {
+      state.valid = true;
+      state.is_poll = false;
+      state.notif_event = std::move(notif_event);
+    }
     return state;
+  }
   state.valid = true;
   state.is_poll = is_poll;
+  state.notif_event = std::move(notif_event);
   capture_keys(data, state.data_keys);
   fill_common(data, state.common);
 
@@ -173,13 +275,21 @@ DishwasherState parse_dishwasher(const std::string &json) {
     return state;
   if (!doc.is<JsonObject>())
     return state;
-  bool is_poll = true;
   JsonObjectConst root = doc.as<JsonObjectConst>();
+  auto notif_event = dishwasher_notif_event(root);
+  bool is_poll = true;
   JsonObjectConst data = extract_data(root, is_poll);
-  if (data.isNull())
+  if (data.isNull()) {
+    if (notif_event) {
+      state.valid = true;
+      state.is_poll = false;
+      state.notif_event = std::move(notif_event);
+    }
     return state;
+  }
   state.valid = true;
   state.is_poll = is_poll;
+  state.notif_event = std::move(notif_event);
   capture_keys(data, state.data_keys);
   fill_common(data, state.common);
 
@@ -220,12 +330,21 @@ RangeState parse_range(const std::string &json) {
     return state;
   if (!doc.is<JsonObject>())
     return state;
+  JsonObjectConst root = doc.as<JsonObjectConst>();
+  auto notif_event = range_notif_event(root);
   bool is_poll = true;
-  JsonObjectConst data = extract_data(doc.as<JsonObjectConst>(), is_poll);
-  if (data.isNull())
+  JsonObjectConst data = extract_data(root, is_poll);
+  if (data.isNull()) {
+    if (notif_event) {
+      state.valid = true;
+      state.is_poll = false;
+      state.notif_event = std::move(notif_event);
+    }
     return state;
+  }
   state.valid = true;
   state.is_poll = is_poll;
+  state.notif_event = std::move(notif_event);
   capture_keys(data, state.data_keys);
   fill_common(data, state.common);
 

--- a/components/subzero_protocol/protocol.h
+++ b/components/subzero_protocol/protocol.h
@@ -38,6 +38,7 @@ struct FridgeState {
   // Top-level keys present in the data object (resp or props), in order.
   // Populated on every parse; the lambdas log these when debug mode is on.
   std::vector<std::string> data_keys;
+  std::optional<std::string> notif_event;
   CommonFields common;
   std::optional<float> ref_set_temp;
   std::optional<bool> door_ajar;
@@ -60,6 +61,7 @@ struct DishwasherState {
   bool valid = false;
   bool is_poll = false;
   std::vector<std::string> data_keys;
+  std::optional<std::string> notif_event;
   CommonFields common;
   std::optional<bool> door_ajar;
   std::optional<bool> wash_cycle_on;
@@ -82,6 +84,7 @@ struct RangeState {
   bool valid = false;
   bool is_poll = false;
   std::vector<std::string> data_keys;
+  std::optional<std::string> notif_event;
   CommonFields common;
   std::optional<bool> door_ajar;
 

--- a/tests/cpp/dispatch_test.cpp
+++ b/tests/cpp/dispatch_test.cpp
@@ -51,6 +51,7 @@ struct CommonRecorder {
   void publish_board_version(const std::string &v) {
     strings["board_version"] = v;
   }
+  void publish_notif_event(const std::string &v) { strings["notif_event"] = v; }
 };
 
 struct FridgeRecorder : CommonRecorder {

--- a/tests/cpp/protocol_test.cpp
+++ b/tests/cpp/protocol_test.cpp
@@ -93,6 +93,7 @@ json fridge_to_json(const FridgeState &s) {
   json c = common_to_json(s.common);
   if (!c.empty())
     o["common"] = c;
+  OPT_PUT(o, s, notif_event);
   OPT_PUT(o, s, ref_set_temp);
   OPT_PUT(o, s, door_ajar);
   OPT_PUT(o, s, frz_set_temp);
@@ -119,6 +120,7 @@ json dishwasher_to_json(const DishwasherState &s) {
   json c = common_to_json(s.common);
   if (!c.empty())
     o["common"] = c;
+  OPT_PUT(o, s, notif_event);
   OPT_PUT(o, s, door_ajar);
   OPT_PUT(o, s, wash_cycle_on);
   OPT_PUT(o, s, heated_dry_on);
@@ -145,6 +147,7 @@ json range_to_json(const RangeState &s) {
   json c = common_to_json(s.common);
   if (!c.empty())
     o["common"] = c;
+  OPT_PUT(o, s, notif_event);
   OPT_PUT(o, s, door_ajar);
   OPT_PUT(o, s, cav_unit_on);
   OPT_PUT(o, s, cav_at_set_temp);
@@ -435,6 +438,107 @@ TEST(ProtocolTest, DataKeysPopulatedForPushMessages) {
   ASSERT_EQ(r.data_keys.size(), 2u);
   EXPECT_EQ(r.data_keys[0], "cav_temp");
   EXPECT_EQ(r.data_keys[1], "cav_unit_on");
+}
+
+TEST(ProtocolTest, FridgeNotifTypeMapsToEvent) {
+  // msg_types=6 push: props + notif_type at root.
+  auto f = parse_fridge(R"({
+    "msg_types":6,"seq":1,"notif_seq":1,"notif_type":108,
+    "props":{"water_filter_pct_remaining":0}
+  })");
+  ASSERT_TRUE(f.valid);
+  ASSERT_TRUE(f.notif_event.has_value());
+  EXPECT_EQ(*f.notif_event, "water_filter_expired");
+  // The push's data field was still extracted.
+  ASSERT_TRUE(f.water_filter_pct_remaining.has_value());
+}
+
+TEST(ProtocolTest, FridgeMsgTypes4NotifOnlyPushIsValid) {
+  auto f = parse_fridge(R"({
+    "msg_types":4,"seq":103,"notif_seq":1360,"notif_type":109,
+    "timestamp":"2026-05-04T09:38:51.391-05:00"
+  })");
+  ASSERT_TRUE(f.valid);
+  EXPECT_FALSE(f.is_poll);
+  ASSERT_TRUE(f.notif_event.has_value());
+  EXPECT_EQ(*f.notif_event, "air_filter_expired");
+  // No data fields set since there are no props/resp.
+  EXPECT_FALSE(f.door_ajar.has_value());
+  EXPECT_TRUE(f.data_keys.empty());
+}
+
+TEST(ProtocolTest, FridgeUnknownNotifTypeFallsBack) {
+  auto f =
+      parse_fridge(R"({"msg_types":4,"seq":1,"notif_type":142,"notif_seq":1})");
+  ASSERT_TRUE(f.valid);
+  ASSERT_TRUE(f.notif_event.has_value());
+  EXPECT_EQ(*f.notif_event, "fridge_event_142");
+}
+
+TEST(ProtocolTest, FridgeMsgTypes4WithoutNotifTypeIsInvalid) {
+  auto f = parse_fridge(R"({"msg_types":4,"seq":1})");
+  EXPECT_FALSE(f.valid);
+}
+
+TEST(ProtocolTest, DishwasherWashCycleStartedEvent) {
+  auto d = parse_dishwasher(R"({
+    "seq":711,"timestamp":"2026-05-03T15:09:37.021-05:00",
+    "props":{"wash_cycle_on":true},
+    "notif_seq":31,"notif_type":301,"msg_types":6
+  })");
+  ASSERT_TRUE(d.valid);
+  ASSERT_TRUE(d.notif_event.has_value());
+  EXPECT_EQ(*d.notif_event, "wash_cycle_started");
+  ASSERT_TRUE(d.wash_cycle_on.has_value());
+  EXPECT_TRUE(*d.wash_cycle_on);
+}
+
+TEST(ProtocolTest, DishwasherWashCycleCompleteEvent) {
+  auto d = parse_dishwasher(R"({
+    "msg_types":6,"seq":602,"notif_seq":1,"notif_type":302,
+    "props":{"wash_cycle_on":false}
+  })");
+  ASSERT_TRUE(d.valid);
+  ASSERT_TRUE(d.notif_event.has_value());
+  EXPECT_EQ(*d.notif_event, "wash_cycle_complete");
+}
+
+TEST(ProtocolTest, RangeOvenPreheatCompleteEvent) {
+  auto r = parse_range(R"({
+    "seq":3606,"timestamp":"2026-04-30T21:37:15.519-05:00",
+    "props":{"cav_at_set_temp":true},
+    "notif_seq":14,"notif_type":201,"msg_types":6
+  })");
+  ASSERT_TRUE(r.valid);
+  ASSERT_TRUE(r.notif_event.has_value());
+  EXPECT_EQ(*r.notif_event, "oven_preheat_complete");
+}
+
+TEST(ProtocolTest, RangeKitchenTimerEndedEvents) {
+  auto r1 = parse_range(R"({
+    "msg_types":6,"seq":1,"notif_seq":1,"notif_type":207,
+    "props":{"kitchen_timer_complete":true}
+  })");
+  ASSERT_TRUE(r1.notif_event.has_value());
+  EXPECT_EQ(*r1.notif_event, "kitchen_timer_ended");
+
+  auto r2 = parse_range(R"({
+    "msg_types":6,"seq":1,"notif_seq":1,"notif_type":208,
+    "props":{"kitchen_timer2_complete":true}
+  })");
+  ASSERT_TRUE(r2.notif_event.has_value());
+  EXPECT_EQ(*r2.notif_event, "kitchen_timer2_ended");
+}
+
+TEST(ProtocolTest, NotifTypeInPollResponseIsIgnored) {
+  auto f = parse_fridge(R"({
+    "status":0,"resp":{
+      "notifs":[{"notif_type":109,"notif_seq":1,"timestamp":"2026-05-04T09:38:51"}],
+      "ref_set_temp":38
+    }
+  })");
+  ASSERT_TRUE(f.valid);
+  EXPECT_FALSE(f.notif_event.has_value());
 }
 
 TEST(ProtocolTest, DishwasherNegativeRemainingClampsToZero) {

--- a/tests/fixtures/dishwasher_push_wash_cycle_started.expected.json
+++ b/tests/fixtures/dishwasher_push_wash_cycle_started.expected.json
@@ -1,0 +1,5 @@
+{
+  "valid": true,
+  "notif_event": "wash_cycle_started",
+  "wash_cycle_on": true
+}

--- a/tests/fixtures/dishwasher_push_wash_cycle_started.json
+++ b/tests/fixtures/dishwasher_push_wash_cycle_started.json
@@ -1,0 +1,10 @@
+{
+  "seq": 711,
+  "timestamp": "2026-05-03T15:09:37.021-05:00",
+  "props": {
+    "wash_cycle_on": true
+  },
+  "notif_seq": 31,
+  "notif_type": 301,
+  "msg_types": 6
+}

--- a/tests/fixtures/fridge_push_air_filter_expired_msg4.expected.json
+++ b/tests/fixtures/fridge_push_air_filter_expired_msg4.expected.json
@@ -1,0 +1,4 @@
+{
+  "valid": true,
+  "notif_event": "air_filter_expired"
+}

--- a/tests/fixtures/fridge_push_air_filter_expired_msg4.json
+++ b/tests/fixtures/fridge_push_air_filter_expired_msg4.json
@@ -1,0 +1,7 @@
+{
+  "msg_types": 4,
+  "notif_type": 109,
+  "notif_seq": 1360,
+  "seq": 103,
+  "timestamp": "2026-05-04T09:38:51.391-05:00"
+}

--- a/tests/fixtures/range_push_oven_preheat_complete.expected.json
+++ b/tests/fixtures/range_push_oven_preheat_complete.expected.json
@@ -1,0 +1,5 @@
+{
+  "valid": true,
+  "notif_event": "oven_preheat_complete",
+  "cav_at_set_temp": true
+}

--- a/tests/fixtures/range_push_oven_preheat_complete.json
+++ b/tests/fixtures/range_push_oven_preheat_complete.json
@@ -1,0 +1,10 @@
+{
+  "seq": 3606,
+  "timestamp": "2026-04-30T21:37:15.519-05:00",
+  "props": {
+    "cav_at_set_temp": true
+  },
+  "notif_seq": 14,
+  "notif_type": 201,
+  "msg_types": 6
+}


### PR DESCRIPTION
## Summary

Adds a `Notification Event` text sensor on every appliance that surfaces BLE push notifications (washer cycle complete, fridge door left open, oven preheat reached, filter expired, etc.) as human-readable event names HA automations can trigger on.

Closes #69. Supersedes #96 (thanks to @ManjunathByadagi for the initial PR and @mwbourgeois for the exhaustive debug capture work that made the mapping table possible).

## Mappings (debug-confirmed in #69)

| Appliance | Codes |
|---|---|
| **Fridge** | `101` fridge_door_open, `102` freezer_door_open, `106` fridge_setpoint_changed, `107` freezer_setpoint_changed, `108` water_filter_expired, `109` air_filter_expired |
| **Range** | `201` oven_preheat_complete, `203` oven_probe_in_use, `205` oven_probe_temp_reached, `207`/`208` kitchen_timer{,2}_ended, `209`/`210` kitchen_timer{,2}_1min_remaining, `211` timed_cook_ended, `213` timed_cook_1min_remaining, `215` oven_probe_within_10deg, `218` oven_door_opened |
| **Dishwasher** | `301` wash_cycle_started, `302` wash_cycle_complete, `304` rinse_aid_low, `306` wash_cycle_interrupted, `307` wash_cycle_cancelled |

Unknown codes fall back to `<appliance>_event_<n>` so they remain observable in HA without us hardcoding placeholder names — users can report them and we add a real mapping later.

## Notable parser fix

`msg_types:4` notification-only pushes (no `props`/`resp`, just `notif_type` at root) were previously rejected by `extract_data` and showed up as `[W] Parse failed or status!=0, skipping` in logs. Sub-Zero fw 2.27 sends these for filter/door/setpoint events. Now treated as a valid push so the event reaches HA.

`notif_type` is also now read from the **root** of the JSON, not from `props` — that's where it actually lives in push messages.

## Test plan

- [x] All 203 C++ tests pass (12 new: 9 unit + 3 fixture pairs sourced from real captures in #69)
- [x] `esphome compile --only-generate` produces a `set_notif_event_sensor(${prefix}_notif_event)` call with a "Main Fridge Notification Event" entity
- [x] Wash cycle completes on a real DW2450 → `Notification Event` flips to `wash_cycle_complete`
- [ ] Fridge door left open → `notif_event` = `fridge_door_open`, no longer "Parse failed"
- [ ] Oven preheat reached → `notif_event` = `oven_preheat_complete`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notification event sensor for Sub-Zero appliances (refrigerators, dishwashers, and ranges) that captures real-time event notifications including filter status alerts, cycle completion events, and temperature milestone notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->