### PR TITLE
fix: replace poll-miss zombie reconnect with scheduled 18-min session…

### DIFF
--- a/components/subzero_appliance/hub.cpp
+++ b/components/subzero_appliance/hub.cpp
@@ -51,6 +51,7 @@ constexpr const char *kTimeoutSubscribeGet = "subscribe_get";
 constexpr const char *kTimeoutFastReconnect = "fast_reconnect";
 constexpr const char *kTimeoutSubmitPinPoll = "submit_pin_poll";
 constexpr const char *kTimeoutVerbFallbackRetry = "verb_fallback_retry";
+constexpr const char *kTimeoutSessionRefresh = "session_refresh";
 } // namespace
 
 // =============================================================================
@@ -111,6 +112,7 @@ void SubzeroHub::handle_disconnected() {
   scheduler_->cancel_timeout(kTimeoutFastReconnect);
   scheduler_->cancel_timeout(kTimeoutSubmitPinPoll);
   scheduler_->cancel_timeout(kTimeoutVerbFallbackRetry);
+  scheduler_->cancel_timeout(kTimeoutSessionRefresh);
   post_bond_running_ = false;
   subscribe_running_ = false;
   fast_reconnect_running_ = false;
@@ -157,26 +159,11 @@ std::uint32_t SubzeroHub::handle_passkey_request() {
 void SubzeroHub::handle_d5_notify(const std::uint8_t * /*data*/,
                                   std::size_t /*len*/) {
   // D5 indications are control-channel responses (display_pin /
-  // unlock_channel / set / scan acks) and duplicate copies of D6 push
-  // notifications — never poll responses. Setting poll_ok_=true here
-  // would mask the fw 8.5 silent-D6-poll case the same way D6 push
-  // traffic used to (the appliance keeps acking D5 commands AND
-  // mirroring D6 pushes onto D5 even when get_async on D6 has gone
-  // silent). poll_ok_ flips only in process_message_complete_ on a
-  // successful POLL RESPONSE — see CodeRabbit review on PR f795296.
-  // Body intentionally empty.
+  // unlock_channel / set / scan acks) and mirror copies of D6 pushes.
+  // Body intentionally empty - all useful state lands on D6.
 }
 
 void SubzeroHub::handle_d6_notify(const std::uint8_t *data, std::size_t len) {
-  // Don't set poll_ok_ here — push notifications on D6 (msg_types:1
-  // diagnostic_status, msg_types:2 props) would mask the fw 8.5
-  // silent-poll case where the appliance keeps pushing but never
-  // answers get_async. poll_ok_ is set in process_message_complete_
-  // only when a parsed message is a real POLL RESPONSE (status:0).
-  // The zombie detector then correctly forces a reconnect every ~3 min
-  // on fw 8.5, which is the only way to refresh full state on those
-  // devices (D6 unlock session expires server-side after ~60-80s of
-  // idle).
   if (json_buf_.feed(data, len)) {
     process_message_complete_();
   }
@@ -215,13 +202,6 @@ void SubzeroHub::process_message_complete_() {
     return;
   }
   fast_retries_ = 0;
-  // poll_ok_ tracks specifically successful POLL RESPONSES (full state),
-  // not pushes. Setting it on incidental pushes (msg_types:1
-  // diagnostic_status, msg_types:2 props) would mask the fw 8.5
-  // silent-poll case — appliance keeps pushing but never answers
-  // get_async, so the zombie detector must still trigger a reconnect.
-  // has_status_value is whitespace-tolerant and digit-suffix-safe (won't
-  // false-match `"status":01` or `"status": 0` or `"status":09`).
   if (esphome::subzero_protocol::has_status_value(*msg, '0')) {
     poll_ok_ = true;
   }
@@ -302,22 +282,10 @@ void SubzeroHub::do_periodic_poll() {
     return;
   if (!transport_->connected())
     return;
-
   if (poll_ok_) {
     poll_miss_ = 0;
   } else {
     poll_miss_ += 1;
-    if (poll_miss_ >= kZombiePollMissThreshold) {
-      HUB_LOGW("szg",
-               "[%s] Appliance unresponsive (%d intervals, no data), "
-               "forcing reconnect",
-               name_.c_str(), poll_miss_);
-      poll_miss_ = 0;
-      json_buf_.clear();
-      publish_status_("Connection stale, reconnecting...");
-      transport_->disconnect();
-      return;
-    }
   }
   poll_ok_ = false;
   json_buf_.clear();
@@ -546,6 +514,32 @@ void SubzeroHub::subscribe_initial_get_() {
   poll_ok_ = false;
   write_poll_command_(d6_handle_);
   publish_status_("Connected and polling.");
+
+  // Arm scheduled session refresh: ~18 min from now, proactively
+  // disconnect-and-reconnect to refresh the appliance's BLE unlock
+  // session before the firmware's own ~20-25 min expiry kicks us off
+  // unpredictably. handle_disconnected cancels the timer if the link
+  // drops for any other reason, so we never carry it across sessions.
+  scheduler_->set_timeout(kTimeoutSessionRefresh, kSessionRefreshIntervalMs,
+                          [this]() { disconnect_for_session_refresh_(); });
+}
+
+// =============================================================================
+// Scheduled session refresh
+// =============================================================================
+
+void SubzeroHub::disconnect_for_session_refresh_() {
+  if (transport_ == nullptr)
+    return;
+  if (!transport_->connected())
+    return;
+  HUB_LOGI(
+      "ble",
+      "[%s] Scheduled session refresh (%u min), reconnecting via fast path",
+      name_.c_str(), static_cast<unsigned>(kSessionRefreshIntervalMs / 60000));
+  json_buf_.clear();
+  publish_status_("Refreshing session...");
+  transport_->disconnect();
 }
 
 // =============================================================================
@@ -588,6 +582,7 @@ void SubzeroHub::press_connect() {
     scheduler_->cancel_timeout(kTimeoutFastReconnect);
     scheduler_->cancel_timeout(kTimeoutSubmitPinPoll);
     scheduler_->cancel_timeout(kTimeoutVerbFallbackRetry);
+    scheduler_->cancel_timeout(kTimeoutSessionRefresh);
   }
   post_bond_running_ = false;
   subscribe_running_ = false;
@@ -681,6 +676,7 @@ void SubzeroHub::press_reset_pairing() {
     scheduler_->cancel_timeout(kTimeoutFastReconnect);
     scheduler_->cancel_timeout(kTimeoutSubmitPinPoll);
     scheduler_->cancel_timeout(kTimeoutVerbFallbackRetry);
+    scheduler_->cancel_timeout(kTimeoutSessionRefresh);
   }
   pin_confirmed_ = false;
   clear_handles_();

--- a/components/subzero_appliance/hub.cpp
+++ b/components/subzero_appliance/hub.cpp
@@ -118,18 +118,28 @@ void SubzeroHub::handle_disconnected() {
   fast_reconnect_running_ = false;
 
   if (d5_handle_ > 0 && phase_ >= 1) {
-    fast_retries_ += 1;
-    if (fast_retries_ >= kStaleBondsThreshold) {
-      HUB_LOGW("ble", "[%s] Stale bond (%d failures), clearing for re-pair",
-               name_.c_str(), fast_retries_);
-      transport_->remove_bond();
-      clear_handles_();
-      phase_ = 0;
-      fast_retries_ = 0;
-      publish_status_("Bond cleared, re-pairing on next connect...");
+    if (intentional_disconnect_) {
+      // Scheduled session refresh — we initiated this. Don't let it
+      // contribute to stale-bond detection; the bond is fine, we're
+      // just rotating the unlock session.
+      intentional_disconnect_ = false;
+      HUB_LOGI("ble",
+               "[%s] Disconnected (intentional refresh, handles cached, d5=%d)",
+               name_.c_str(), d5_handle_);
     } else {
-      HUB_LOGI("ble", "[%s] Disconnected (handles cached, d5=%d, retries=%d)",
-               name_.c_str(), d5_handle_, fast_retries_);
+      fast_retries_ += 1;
+      if (fast_retries_ >= kStaleBondsThreshold) {
+        HUB_LOGW("ble", "[%s] Stale bond (%d failures), clearing for re-pair",
+                 name_.c_str(), fast_retries_);
+        transport_->remove_bond();
+        clear_handles_();
+        phase_ = 0;
+        fast_retries_ = 0;
+        publish_status_("Bond cleared, re-pairing on next connect...");
+      } else {
+        HUB_LOGI("ble", "[%s] Disconnected (handles cached, d5=%d, retries=%d)",
+                 name_.c_str(), d5_handle_, fast_retries_);
+      }
     }
   } else {
     phase_ = 0;
@@ -539,6 +549,9 @@ void SubzeroHub::disconnect_for_session_refresh_() {
       name_.c_str(), static_cast<unsigned>(kSessionRefreshIntervalMs / 60000));
   json_buf_.clear();
   publish_status_("Refreshing session...");
+  // Tag the next disconnect callback so handle_disconnected skips
+  // fast_retries_ accounting — see intentional_disconnect_ comment.
+  intentional_disconnect_ = true;
   transport_->disconnect();
 }
 

--- a/components/subzero_appliance/hub.h
+++ b/components/subzero_appliance/hub.h
@@ -112,6 +112,10 @@ public:
   // Per-appliance stagger to avoid concurrent bonding races on shared
   // ESP32. Translated from the `poll_offset` substitution.
   void set_poll_offset_ms(std::uint32_t ms) { poll_offset_ms_ = ms; }
+
+  // Public so tests can advance the fake scheduler to exactly the refresh
+  // deadline
+  static constexpr std::uint32_t kSessionRefreshIntervalMs = 18 * 60 * 1000;
   // Status text callback — connected to ${prefix}_debug.publish_state.
   void set_status_callback(std::function<void(const std::string &)> cb) {
     status_cb_ = std::move(cb);
@@ -190,6 +194,9 @@ private:
   void start_fast_reconnect_();
   void fast_reconnect_subscribe_();
 
+  // Scheduled session refresh - fires once per session ~18 min after unlock
+  void disconnect_for_session_refresh_();
+
   // ---- helpers ----
   void publish_status_(const std::string &text);
   void clear_handles_();
@@ -253,7 +260,6 @@ private:
   static constexpr std::uint32_t kSubmitPinPollDelayMs = 3000;
   static constexpr std::uint32_t kResetPairingDisconnectDelayMs = 1000;
   static constexpr int kStaleBondsThreshold = 3;
-  static constexpr int kZombiePollMissThreshold = 3;
   static constexpr std::uint32_t kVerbFallbackRetryDelayMs = 1000;
 };
 

--- a/components/subzero_appliance/hub.h
+++ b/components/subzero_appliance/hub.h
@@ -240,6 +240,14 @@ private:
   bool subscribe_running_ = false;
   bool fast_reconnect_running_ = false;
 
+  // Set by disconnect_for_session_refresh_() immediately before the
+  // disconnect call, consumed and cleared in handle_disconnected().
+  // Marks the next disconnect as "by us, on purpose" so it doesn't
+  // count toward stale-bond detection (kStaleBondsThreshold). Without
+  // this, two failed reconnects on top of a session refresh would
+  // wrongly wipe the bond.
+  bool intentional_disconnect_ = false;
+
   // D6 message buffer (D5 is heartbeat-only post-PR-#72).
   esphome::subzero_protocol::MessageBuffer json_buf_;
 

--- a/tests/cpp/hub_test.cpp
+++ b/tests/cpp/hub_test.cpp
@@ -350,25 +350,28 @@ TEST_F(HubFixture, PeriodicPoll_WritesUnlockAndGetAsyncOnHappyPath) {
   EXPECT_TRUE(transport_.wrote_command_to(d6, "get_async"));
 }
 
-TEST_F(HubFixture, PeriodicPoll_ZombieDetection_ReconnectsAfterThreeMisses) {
+TEST_F(HubFixture, PeriodicPoll_PollMissIsDiagnosticOnly_NoReconnect) {
   hub_.set_stored_pin("12345");
   transport_.set_gatt_db(full_gatt_db());
   hub_.handle_connected();
   scheduler_.advance_by(3000);
   transport_.clear_writes();
-  // Each poll without a notification arriving counts as a miss.
-  // poll_ok_ enters this block at false (subscribe_initial_get_ explicitly
-  // sets it to false; no notify arrived in the test). After 3 misses the
-  // hub forces a reconnect and resets poll_miss to 0.
+  // poll_miss_ is now diagnostic-only. It still increments on silent
+  // polls (so logs make the silent-poll case visible) but does NOT
+  // trigger a reconnect — that's the job of the scheduled session
+  // refresh (kSessionRefreshIntervalMs in subscribe_initial_get_).
+  std::size_t disconnect_before = transport_.disconnect_count();
   hub_.do_periodic_poll();
   EXPECT_EQ(hub_.poll_miss(), 1);
   hub_.do_periodic_poll();
   EXPECT_EQ(hub_.poll_miss(), 2);
-  std::size_t disconnect_before = transport_.disconnect_count();
   hub_.do_periodic_poll();
-  EXPECT_GT(transport_.disconnect_count(), disconnect_before);
-  EXPECT_EQ(hub_.poll_miss(), 0);
-  EXPECT_TRUE(any_status_contains("Connection stale"));
+  EXPECT_EQ(hub_.poll_miss(), 3);
+  hub_.do_periodic_poll();
+  EXPECT_EQ(hub_.poll_miss(), 4);
+  EXPECT_EQ(transport_.disconnect_count(), disconnect_before)
+      << "poll_miss_ at any value must NOT trigger a reconnect — only "
+         "the scheduled session-refresh timer does.";
 }
 
 // =============================================================================
@@ -838,30 +841,53 @@ TEST_F(HubFixture, PollOk_SetByActualPollResponse) {
       << "poll_miss_ must reset to 0 once a real poll response arrives.";
 }
 
-TEST_F(HubFixture, ZombieDetector_StillFiresWithPushTraffic) {
-  // Direct integration test for the live-log scenario from the issue
-  // #91 thread (Wall Oven SO3050PESP fw 8.5): appliance keeps pushing
-  // msg_types:1 every minute but never answers get_async. The zombie
-  // detector must still trip after 3 silent polls and force a reconnect
-  // — otherwise the appliance state stays frozen on its initial poll
-  // values forever.
+TEST_F(HubFixture, PushTraffic_DoesNotForceReconnectFromPollSilence) {
   hub_.set_stored_pin("12345");
   run_to_ready_();
   hub_.parse_should_succeed_ = true;
   std::size_t disc_before = transport_.disconnect_count();
 
-  // Cycle 1: poll fails silently, then push arrives (poll_ok_ stays false)
-  hub_.do_periodic_poll();
-  feed_complete_d6_(hub_,
-                    R"({"diagnostic_status":"0x1","msg_types":1,"seq":1})");
-  // Cycle 2: poll fails silently, push arrives
-  hub_.do_periodic_poll();
-  feed_complete_d6_(hub_,
-                    R"({"diagnostic_status":"0x2","msg_types":1,"seq":2})");
-  // Cycle 3: poll fails silently → miss hits threshold → ZOMBIE FIRES
-  hub_.do_periodic_poll();
+  for (int i = 0; i < 6; ++i) {
+    hub_.do_periodic_poll();
+    feed_complete_d6_(hub_,
+                      R"({"diagnostic_status":"0x1","msg_types":1,"seq":1})");
+  }
+  EXPECT_EQ(transport_.disconnect_count(), disc_before)
+      << "Silent polls must not kill a healthy push-streaming connection. "
+         "Reconnect is now scheduled (18 min) — not poll-miss-triggered.";
+  EXPECT_GE(hub_.poll_miss(), 6)
+      << "poll_miss_ should still increment as a diagnostic counter "
+         "even though it no longer drives reconnect.";
+}
+
+TEST_F(HubFixture, SessionRefresh_FiresAfterIntervalAndDisconnects) {
+  hub_.set_stored_pin("12345");
+  run_to_ready_();
+  std::size_t disc_before = transport_.disconnect_count();
+
+  // Just before the refresh interval — no disconnect yet.
+  scheduler_.advance_by(SubzeroHub::kSessionRefreshIntervalMs - 1000);
+  EXPECT_EQ(transport_.disconnect_count(), disc_before)
+      << "Session refresh must not fire before the interval elapses.";
+
+  // Cross the interval — refresh fires, transport disconnect requested.
+  scheduler_.advance_by(2000);
   EXPECT_GT(transport_.disconnect_count(), disc_before)
-      << "Zombie detector must force a reconnect after 3 silent polls "
-         "even when push notifications keep arriving — otherwise the "
-         "fw 8.5 silent-poll case never recovers.";
+      << "Session refresh must trigger a disconnect after "
+         "kSessionRefreshIntervalMs.";
+  EXPECT_TRUE(any_status_contains("Refreshing session"));
+}
+
+TEST_F(HubFixture, SessionRefresh_CancelledOnDisconnect) {
+  hub_.set_stored_pin("12345");
+  run_to_ready_();
+  ASSERT_TRUE(scheduler_.has_pending("session_refresh"))
+      << "Session refresh timer should be armed after subscribe_initial_get_.";
+
+  // External disconnect (e.g. RF interruption, appliance reboot) — the
+  // scheduled timer must be cancelled so it doesn't try to disconnect
+  // an already-disconnected transport on the next session.
+  hub_.handle_disconnected();
+  EXPECT_FALSE(scheduler_.has_pending("session_refresh"))
+      << "handle_disconnected must cancel the session-refresh timer.";
 }

--- a/tests/cpp/hub_test.cpp
+++ b/tests/cpp/hub_test.cpp
@@ -891,3 +891,26 @@ TEST_F(HubFixture, SessionRefresh_CancelledOnDisconnect) {
   EXPECT_FALSE(scheduler_.has_pending("session_refresh"))
       << "handle_disconnected must cancel the session-refresh timer.";
 }
+
+TEST_F(HubFixture, SessionRefresh_DoesNotIncrementFastRetries) {
+  hub_.set_stored_pin("12345");
+  run_to_ready_();
+  ASSERT_EQ(hub_.fast_retries(), 0);
+
+  // Trigger the scheduled session refresh. The hub calls
+  // transport_->disconnect(); in production the BLE stack then
+  // delivers the disconnect callback to handle_disconnected().
+  scheduler_.advance_by(SubzeroHub::kSessionRefreshIntervalMs);
+  hub_.handle_disconnected();
+
+  EXPECT_EQ(hub_.fast_retries(), 0)
+      << "Intentional session-refresh disconnect must not contribute "
+         "to stale-bond detection. Otherwise two failed reconnects on "
+         "top of a refresh would wrongly trigger remove_bond().";
+
+  // And the flag must auto-clear: a subsequent unexpected disconnect
+  // (e.g. RF loss) should still increment normally.
+  hub_.handle_disconnected();
+  EXPECT_EQ(hub_.fast_retries(), 1)
+      << "Unexpected disconnects after a refresh must still count.";
+}


### PR DESCRIPTION
… refresh

The previous zombie heuristic killed any connection where 3 consecutive periodic polls went unanswered, which on fw 8.5 fires every 3-4 minutes even when the appliance is actively streaming pushes (live log from esp32-kitchen02 2026-05-09: Wall Oven SO3050PESP and Main Fridge 313 both cycling every ~3 min while continuously emitting kitchen-timer, oven-light, and diagnostic-status push events between disconnects).  Each cycle ate 30-90s of "no data" while the link reconnected.

The signal "no poll response" is a brittle proxy for "connection dead":
- fw 8.5 silently drops periodic get_async post-unlock but pushes work
- An idle fridge can legitimately produce zero pushes for hours
- Either case false-positives the heuristic

Switch to a fixed 18-min schedule that fires once per session from subscribe_initial_get_, comfortably under the firmware-side ~20-25 min unlock-session expiry. handle_disconnected, press_connect, and press_reset_pairing all cancel the timer so it never carries across sessions. poll_miss_ stays as a diagnostic counter in the periodic poll log line but no longer drives reconnect.

Trade-off: fw 2.27 appliances which previously never reconnected now do so every 18 min. Cost is ~5-10s gap per refresh; benefit is one predictable cycle per 18 min instead of ~6 unpredictable cycles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic session refresh mechanism (~18 minutes) to maintain stable BLE unlock sessions.

* **Improvements**
  * Removed forced reconnections triggered by repeated polling failures; reconnection now occurs via scheduled session refresh instead.
  * Session refresh is properly canceled on manual disconnect and pairing reset.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JonGilmore/esphome-subzero-ble/pull/100)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->