### PR TITLE
fix: additional flag to hide filter expiry date & remaining gallons

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -184,7 +184,8 @@ subzero_appliance:
 | `hide_ref_drawer` | `true` | Refrigerator Drawer Set Temperature, Refrigerator Drawer Door
 | `hide_crisper` | `true` | Crisper Drawer Set Temperature
 | `hide_air_filter` | `true` | Air Filter, Air Filter Remaining
-| `hide_water_filter` | `true` | Water Filter Remaining
+| `hide_water_filter` | `true` | Water Filter Remaining (%)
+| `hide_water_filter_extra` | `false` | Water Filter Gallons Remaining, Water Filter Expires (set true on models that don't expose these)
 | `hide_softener` | `true` | Water Softener Low (dishwasher only)
 | `hide_oven2` | `true` | All Oven 2 sensors (range only - for dual-oven)
 |===
@@ -329,6 +330,8 @@ NOTE: Sub-Zero fridge firmware only exposes _set points_ over BLE - actual/measu
 | *Air Filter* | Air filter on/off binary sensor _(optional)_
 | *Air Filter Remaining* | Air filter life remaining (%) _(optional)_
 | *Water Filter Remaining* | Water filter life remaining (%) _(optional)_
+| *Water Filter Gallons Remaining* | Water filter life remaining (gallons), supported on some fridges _(optional)_
+| *Water Filter Expires* | Water filter expiration date (timestamp), supported on some fridges _(optional)_
 | *Service Required* | Alerts when the appliance flags a service need
 | *Appliance Model* | Model number (e.g. `DEU2450R`, `313`)
 | *Appliance Uptime* | Time since last power cycle

--- a/README.adoc
+++ b/README.adoc
@@ -185,7 +185,7 @@ subzero_appliance:
 | `hide_crisper` | `true` | Crisper Drawer Set Temperature
 | `hide_air_filter` | `true` | Air Filter, Air Filter Remaining
 | `hide_water_filter` | `true` | Water Filter Remaining (%)
-| `hide_water_filter_extra` | `false` | Water Filter Gallons Remaining, Water Filter Expires (set true on models that don't expose these)
+| `hide_water_filter_extra` | `true` | Water Filter Gallons Remaining, Water Filter Expires (set false on models that expose these)
 | `hide_softener` | `true` | Water Softener Low (dishwasher only)
 | `hide_oven2` | `true` | All Oven 2 sensors (range only - for dual-oven)
 |===

--- a/components/subzero_appliance/__init__.py
+++ b/components/subzero_appliance/__init__.py
@@ -907,7 +907,7 @@ TYPE_SCHEMAS = {
         cv.Optional("hide_crisper", default=True): cv.boolean,
         cv.Optional("hide_air_filter", default=True): cv.boolean,
         cv.Optional("hide_water_filter", default=True): cv.boolean,
-        cv.Optional("hide_water_filter_extra", default=False): cv.boolean,
+        cv.Optional("hide_water_filter_extra", default=True): cv.boolean,
     },
     "dishwasher": {
         cv.Optional("hide_softener", default=True): cv.boolean,

--- a/components/subzero_appliance/__init__.py
+++ b/components/subzero_appliance/__init__.py
@@ -412,7 +412,7 @@ FRIDGE_SENSORS = [
             "accuracy_decimals": 1,
             CONF_ICON: "mdi:water",
         },
-        "hide_water_filter",
+        "hide_water_filter_extra",
     ),
 ]
 
@@ -425,7 +425,7 @@ FRIDGE_TEXT_SENSORS = [
             CONF_DEVICE_CLASS: DEVICE_CLASS_TIMESTAMP,
             CONF_ICON: "mdi:calendar-clock",
         },
-        "hide_water_filter",
+        "hide_water_filter_extra",
     ),
 ]
 
@@ -907,6 +907,7 @@ TYPE_SCHEMAS = {
         cv.Optional("hide_crisper", default=True): cv.boolean,
         cv.Optional("hide_air_filter", default=True): cv.boolean,
         cv.Optional("hide_water_filter", default=True): cv.boolean,
+        cv.Optional("hide_water_filter_extra", default=False): cv.boolean,
     },
     "dishwasher": {
         cv.Optional("hide_softener", default=True): cv.boolean,

--- a/tests/cpp/dispatch_test.cpp
+++ b/tests/cpp/dispatch_test.cpp
@@ -265,6 +265,8 @@ TEST(Dispatch, FridgeFieldsRouted) {
   s.air_filter_on = true;
   s.air_filter_pct_remaining = 80.0f;
   s.water_filter_pct_remaining = 50.0f;
+  s.water_filter_gal_remaining = 220.0f;
+  s.water_filter_end_date = std::string("2027-04-26T00:00:00+00:00");
 
   FridgeRecorder rec;
   dispatch_fridge(s, rec);
@@ -284,6 +286,8 @@ TEST(Dispatch, FridgeFieldsRouted) {
   EXPECT_EQ(rec.bools["air_filter_on"], true);
   EXPECT_FLOAT_EQ(rec.floats["air_filter_pct"], 80.0f);
   EXPECT_FLOAT_EQ(rec.floats["water_filter_pct"], 50.0f);
+  EXPECT_FLOAT_EQ(rec.floats["water_filter_gal"], 220.0f);
+  EXPECT_EQ(rec.strings["water_filter_end_date"], "2027-04-26T00:00:00+00:00");
 }
 
 // Some fridges (e.g. PRO3650G) wire the main door and the refrigerator drawer


### PR DESCRIPTION
code still defaults to show these sensors, but allows users to turn them off if their models do not support them

closes https://github.com/JonGilmore/esphome-subzero-ble/issues/104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to separately control visibility of additional water-filter sensor data (gallons remaining and expiry date).

* **Documentation**
  * Updated to document new water-filter configuration controls and supported sensor types for refrigerators.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JonGilmore/esphome-subzero-ble/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->